### PR TITLE
Correct Reporting of Multi-Threaded Test Outcomes

### DIFF
--- a/src/H5public.h
+++ b/src/H5public.h
@@ -419,6 +419,7 @@ extern "C" {
 
 #define H5_ATOMIC_STORE(dst, value) atomic_store(&dst, value)
 #define H5_ATOMIC_LOAD(src) atomic_load(&src)
+#define H5_ATOMIC_ADD(dst, value) atomic_fetch_add(&dst, value)
 
 #else
 #define H5_ATOMIC(type) type
@@ -427,6 +428,7 @@ extern "C" {
 
 #define H5_ATOMIC_STORE(dst, value) (dst = value)
 #define H5_ATOMIC_LOAD(src) (src)
+#define H5_ATOMIC_ADD(dst, value) (dst += value)
 #endif
 
 

--- a/test/API/H5_api_dataset_test.c
+++ b/test/API/H5_api_dataset_test.c
@@ -8344,7 +8344,6 @@ test_dataset_string_encodings(void H5_ATTR_UNUSED *params)
         }
         PART_END(UTF8_cset);
 
-        PASSED();
     }
     END_MULTIPART;
 

--- a/test/API/H5_api_dataset_test.c
+++ b/test/API/H5_api_dataset_test.c
@@ -3129,9 +3129,11 @@ test_create_many_dataset(void H5_ATTR_UNUSED *params)
         goto error;
     }
 
-    printf("\n");
+    if (IS_MAIN_TEST_THREAD)
+        printf("\n");
     for (i = 0; i < DATASET_NUMB; i++) {
-        printf("\r %u/%u", i + 1, DATASET_NUMB);
+        if (IS_MAIN_TEST_THREAD)
+            printf("\r %u/%u", i + 1, DATASET_NUMB);
         snprintf(dset_name, sizeof(dset_name), "dset_%02u", i);
         data = i % 256;
 
@@ -5258,7 +5260,7 @@ test_dataset_io_point_selections(void H5_ATTR_UNUSED *params)
     /* Perform with and without chunking */
     for (do_chunk = false;; do_chunk = true) {
         if (do_chunk) {
-            TESTING("point selection I/O with all selection in memory and points in file with chunking");
+            TESTING_2("point selection I/O with all selection in memory and points in file with chunking");
 
             /* Create chunked dataset */
             if ((dset_id = H5Dcreate2(group_id, DATASET_IO_POINT_DSET_NAME_CHUNK, H5T_NATIVE_INT, fspace_id,
@@ -5339,9 +5341,9 @@ test_dataset_io_point_selections(void H5_ATTR_UNUSED *params)
         PASSED();
 
         if (do_chunk)
-            TESTING("point selection I/O with points in memory and file (same shape) with chunking");
+            TESTING_2("point selection I/O with points in memory and file (same shape) with chunking");
         else
-            TESTING("point selection I/O with points in memory and file (same shape)");
+            TESTING_2("point selection I/O with points in memory and file (same shape)");
 
         /* Generate points to read */
         DATASET_IO_POINT_GEN_POINTS(points, i, j);
@@ -5405,9 +5407,9 @@ test_dataset_io_point_selections(void H5_ATTR_UNUSED *params)
         PASSED();
 
         if (do_chunk)
-            TESTING("point selection I/O with points in memory and file (different shape) with chunking");
+            TESTING_2("point selection I/O with points in memory and file (different shape) with chunking");
         else
-            TESTING("point selection I/O with points in memory and file (different shape)");
+            TESTING_2("point selection I/O with points in memory and file (different shape)");
 
         /* Generate points to read */
         DATASET_IO_POINT_GEN_POINTS(points, i, j);
@@ -5478,9 +5480,9 @@ test_dataset_io_point_selections(void H5_ATTR_UNUSED *params)
         PASSED();
 
         if (do_chunk)
-            TESTING("point selection I/O with hyperslab in memory and points in file with chunking");
+            TESTING_2("point selection I/O with hyperslab in memory and points in file with chunking");
         else
-            TESTING("point selection I/O with hyperslab in memory and points in file");
+            TESTING_2("point selection I/O with hyperslab in memory and points in file");
 
         /* Generate points to read */
         DATASET_IO_POINT_GEN_POINTS(points, i, j);
@@ -5551,9 +5553,9 @@ test_dataset_io_point_selections(void H5_ATTR_UNUSED *params)
         PASSED();
 
         if (do_chunk)
-            TESTING("point selection I/O with points in memory and hyperslab in file with chunking");
+            TESTING_2("point selection I/O with points in memory and hyperslab in file with chunking");
         else
-            TESTING("point selection I/O with points in memory and hyperslab in file");
+            TESTING_2("point selection I/O with points in memory and hyperslab in file");
 
         /* Generate points to read */
         DATASET_IO_POINT_GEN_POINTS(points, i, j);
@@ -12855,11 +12857,13 @@ test_write_multi_chunk_dataset_diff_shape_read(void H5_ATTR_UNUSED *params)
     /*
      * Read every chunk in the dataset, checking the data for each one.
      */
-    printf("\n");
+    if (IS_MAIN_TEST_THREAD)
+        printf("\n");
     for (i = 0; i < data_size / chunk_size; i++) {
         size_t j;
 
-        printf("\r Reading chunk %zu", i);
+        if (IS_MAIN_TEST_THREAD)
+            printf("\r Reading chunk %zu", i);
 
         for (j = 0; j < DATASET_MULTI_CHUNK_WRITE_DIFF_SPACE_READ_TEST_DSET_SPACE_RANK; j++) {
             if (dims[j] == chunk_dims[j])
@@ -13081,7 +13085,8 @@ test_overwrite_multi_chunk_dataset_same_shape_read(void H5_ATTR_UNUSED *params)
         count[i] = chunk_dims[i];
     }
 
-    printf("\n");
+    if (IS_MAIN_TEST_THREAD)
+        printf("\n");
     for (niter = 0; niter < DATASET_MULTI_CHUNK_OVERWRITE_SAME_SPACE_READ_TEST_NITERS; niter++) {
         memset(write_buf, 0, data_size);
 
@@ -13190,7 +13195,8 @@ test_overwrite_multi_chunk_dataset_same_shape_read(void H5_ATTR_UNUSED *params)
         for (i = 0; i < data_size / chunk_size; i++) {
             size_t j, k;
 
-            printf("\r Reading chunk %zu", i);
+            if (IS_MAIN_TEST_THREAD)
+                printf("\r Reading chunk %zu", i);
 
             for (j = 0; j < DATASET_MULTI_CHUNK_OVERWRITE_SAME_SPACE_READ_TEST_DSET_SPACE_RANK; j++) {
                 if (dims[j] == chunk_dims[j])
@@ -13425,7 +13431,8 @@ test_overwrite_multi_chunk_dataset_diff_shape_read(void H5_ATTR_UNUSED *params)
         count[i] = chunk_dims[i];
     }
 
-    printf("\n");
+    if (IS_MAIN_TEST_THREAD)
+        printf("\n");
     for (niter = 0; niter < DATASET_MULTI_CHUNK_OVERWRITE_DIFF_SPACE_READ_TEST_NITERS; niter++) {
         memset(write_buf, 0, data_size);
 
@@ -13534,7 +13541,8 @@ test_overwrite_multi_chunk_dataset_diff_shape_read(void H5_ATTR_UNUSED *params)
         for (i = 0; i < data_size / chunk_size; i++) {
             size_t j;
 
-            printf("\r Reading chunk %zu", i);
+            if (IS_MAIN_TEST_THREAD)
+                printf("\r Reading chunk %zu", i);
 
             for (j = 0; j < DATASET_MULTI_CHUNK_OVERWRITE_DIFF_SPACE_READ_TEST_DSET_SPACE_RANK; j++) {
                 if (dims[j] == chunk_dims[j])
@@ -13945,7 +13953,8 @@ test_read_partial_chunk_hyperslab_selection(void H5_ATTR_UNUSED *params)
     /*
      * Write and read each chunk in the dataset.
      */
-    printf("\n");
+    if (IS_MAIN_TEST_THREAD)
+        printf("\n");
     for (i = 0; i < FIXED_NCHUNKS; i++) {
         hsize_t start[DATASET_PARTIAL_CHUNK_READ_HYPER_SEL_TEST_DSET_SPACE_RANK];
         hsize_t count[DATASET_PARTIAL_CHUNK_READ_HYPER_SEL_TEST_DSET_SPACE_RANK];
@@ -14009,7 +14018,8 @@ test_read_partial_chunk_hyperslab_selection(void H5_ATTR_UNUSED *params)
             goto error;
         }
 
-        printf("\r Writing chunk %zu", i);
+        if (IS_MAIN_TEST_THREAD)
+            printf("\r Writing chunk %zu", i);
 
         if (H5Dwrite(dset_id, DATASET_PARTIAL_CHUNK_READ_HYPER_SEL_TEST_DSET_DTYPE, mspace_id, fspace_id,
                      H5P_DEFAULT, write_buf) < 0) {
@@ -14044,7 +14054,8 @@ test_read_partial_chunk_hyperslab_selection(void H5_ATTR_UNUSED *params)
             goto error;
         }
 
-        printf("\r Reading chunk %zu", i);
+        if (IS_MAIN_TEST_THREAD)
+            printf("\r Reading chunk %zu", i);
 
         if (H5Dread(dset_id, DATASET_PARTIAL_CHUNK_READ_HYPER_SEL_TEST_DSET_DTYPE, mspace_id, fspace_id,
                     H5P_DEFAULT, read_buf) < 0) {

--- a/test/API/H5_api_datatype_test.c
+++ b/test/API/H5_api_datatype_test.c
@@ -755,12 +755,18 @@ test_create_committed_datatype_empty_types(void H5_ATTR_UNUSED *params)
     }
     END_MULTIPART;
 
+    TESTING_2("test cleanup");
+
     if (H5Gclose(group_id) < 0)
         TEST_ERROR;
     if (H5Gclose(container_group) < 0)
         TEST_ERROR;
     if (H5Fclose(file_id) < 0)
         TEST_ERROR;
+
+    PASSED();
+
+    return;
 
 error:
     H5E_BEGIN_TRY

--- a/test/API/H5_api_file_test.c
+++ b/test/API/H5_api_file_test.c
@@ -1720,7 +1720,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 2) < 0) {
                 H5_FAILED();
                 printf("    number of open files (%ld) did not match %s expected number (2)\n", obj_count,
-                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
+                       TEST_EXECUTION_CONCURRENT ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_files);
             }
 
@@ -1764,7 +1764,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 1) < 0) {
                 H5_FAILED();
                 printf("    number of open groups (%ld) did not match %s expected number (1)\n", obj_count,
-                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
+                       TEST_EXECUTION_CONCURRENT ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_types);
             }
 
@@ -1786,7 +1786,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 1) < 0) {
                 H5_FAILED();
                 printf("    number of open named datatypes (%ld) did not match %s expected number (1)\n", obj_count,
-                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
+                       TEST_EXECUTION_CONCURRENT ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_types);
             }
 
@@ -1808,7 +1808,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 1) < 0) {
                 H5_FAILED();
                 printf("    number of open attributes (%ld) did not match %s expected number (1)\n", obj_count,
-                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
+                       TEST_EXECUTION_CONCURRENT ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_attrs);
             }
 
@@ -1830,7 +1830,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 1) < 0) {
                 H5_FAILED();
                 printf("    number of open datasets (%ld) did not match %s expected number (1)\n", obj_count,
-                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
+                       TEST_EXECUTION_CONCURRENT ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_dsets);
             }
 
@@ -1874,7 +1874,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 6) < 0) {
                 H5_FAILED();
                 printf("    number of open objects (%ld) did not match %s expected number (6)\n", obj_count,
-                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
+                       TEST_EXECUTION_CONCURRENT ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_all);
             }
 
@@ -2559,9 +2559,9 @@ herr_t
 check_open_obj_count(ssize_t obj_count, int expected) {
     herr_t ret_value = SUCCEED;
     /* If multiple threads are concurrently executing tests, then more objects than expected may be open in the library */
-    if (TEST_EXECUTION_MULTITHREADED && obj_count < expected) {
+    if (TEST_EXECUTION_CONCURRENT && obj_count < expected) {
         ret_value = FAIL;
-    } else if (!TEST_EXECUTION_MULTITHREADED && obj_count != expected) { /* Single thread, expect exact count */
+    } else if (!TEST_EXECUTION_CONCURRENT && obj_count != expected) { /* Single thread, expect exact count */
         ret_value = FAIL;
     }
 

--- a/test/API/H5_api_file_test.c
+++ b/test/API/H5_api_file_test.c
@@ -1627,11 +1627,6 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
         return;
     }
 
-    if (GetTestMaxNumThreads() == 0) {
-        printf("    Active thread count is invalid\n");
-        TEST_ERROR;
-    }
-
     TESTING_2("test setup");
 
     if (prefix_filename(test_path_prefix, GET_OBJ_COUNT_TEST_FILENAME1, &prefixed_filename1) < 0) {

--- a/test/API/H5_api_file_test.c
+++ b/test/API/H5_api_file_test.c
@@ -230,8 +230,12 @@ test_create_file_invalid_params(void H5_ATTR_UNUSED *params)
     }
     END_MULTIPART;
 
+    TESTING_2("test cleanup");
+
     free(prefixed_filename);
     prefixed_filename = NULL;
+
+    PASSED();
 
     return;
 
@@ -404,7 +408,7 @@ test_open_file(void H5_ATTR_UNUSED *params)
          * XXX: SWMR open flags
          */
     }
-    END_MULTIPART;
+    END_MULTIPART_NO_CLEANUP;
 
     return;
 
@@ -506,7 +510,7 @@ test_open_file_invalid_params(void H5_ATTR_UNUSED *params)
         }
         PART_END(H5Fopen_invalid_flags);
     }
-    END_MULTIPART;
+    END_MULTIPART_NO_CLEANUP;
 
     return;
 
@@ -1107,8 +1111,12 @@ test_file_is_accessible(void H5_ATTR_UNUSED *params)
     }
     END_MULTIPART;
 
+    TESTING_2("test cleanup");
+
     free(prefixed_filename);
     prefixed_filename = NULL;
+
+    PASSED();
 
     return;
 
@@ -1572,11 +1580,15 @@ test_get_file_intent(void H5_ATTR_UNUSED *params)
     }
     END_MULTIPART;
 
+    TESTING_2("test cleanup");
+
     if (GetTestCleanup() && H5Fdelete(prefixed_filename, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
     free(prefixed_filename);
     prefixed_filename = NULL;
+
+    PASSED();
 
     return;
 

--- a/test/API/H5_api_file_test.c
+++ b/test/API/H5_api_file_test.c
@@ -1720,7 +1720,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 2) < 0) {
                 H5_FAILED();
                 printf("    number of open files (%ld) did not match %s expected number (2)\n", obj_count,
-                       GetTestMaxNumThreads() > 1 ? "or exceed" : "");
+                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_files);
             }
 
@@ -1764,7 +1764,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 1) < 0) {
                 H5_FAILED();
                 printf("    number of open groups (%ld) did not match %s expected number (1)\n", obj_count,
-                       GetTestMaxNumThreads() > 1 ? "or exceed" : "");
+                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_types);
             }
 
@@ -1786,7 +1786,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 1) < 0) {
                 H5_FAILED();
                 printf("    number of open named datatypes (%ld) did not match %s expected number (1)\n", obj_count,
-                       GetTestMaxNumThreads() > 1 ? "or exceed" : "");
+                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_types);
             }
 
@@ -1808,7 +1808,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 1) < 0) {
                 H5_FAILED();
                 printf("    number of open attributes (%ld) did not match %s expected number (1)\n", obj_count,
-                       GetTestMaxNumThreads() > 1 ? "or exceed" : "");
+                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_attrs);
             }
 
@@ -1830,7 +1830,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 1) < 0) {
                 H5_FAILED();
                 printf("    number of open datasets (%ld) did not match %s expected number (1)\n", obj_count,
-                       GetTestMaxNumThreads() > 1 ? "or exceed" : "");
+                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_dsets);
             }
 
@@ -1874,7 +1874,7 @@ test_get_file_obj_count(void H5_ATTR_UNUSED *params)
             if (check_open_obj_count(obj_count, 6) < 0) {
                 H5_FAILED();
                 printf("    number of open objects (%ld) did not match %s expected number (6)\n", obj_count,
-                       GetTestMaxNumThreads() > 1 ? "or exceed" : "");
+                       TEST_EXECUTION_MULTITHREADED ? "or exceed" : "");
                 PART_ERROR(H5Fget_obj_count_all);
             }
 
@@ -2559,9 +2559,9 @@ herr_t
 check_open_obj_count(ssize_t obj_count, int expected) {
     herr_t ret_value = SUCCEED;
     /* If multiple threads are concurrently executing tests, then more objects than expected may be open in the library */
-    if (GetTestMaxNumThreads() > 1 && obj_count < expected) {
+    if (TEST_EXECUTION_MULTITHREADED && obj_count < expected) {
         ret_value = FAIL;
-    } else if (GetTestMaxNumThreads() == 1 && obj_count != expected) { /* Single thread, expect exact count */
+    } else if (!TEST_EXECUTION_MULTITHREADED && obj_count != expected) { /* Single thread, expect exact count */
         ret_value = FAIL;
     }
 

--- a/test/API/H5_api_group_test.c
+++ b/test/API/H5_api_group_test.c
@@ -214,10 +214,13 @@ test_create_many_groups(void H5_ATTR_UNUSED *params)
     }
 
     /* Create multiple groups under the parent group */
-    printf("\n");
+    if (IS_MAIN_TEST_THREAD)
+        printf("\n");
     for (i = 0; i < GROUP_NUMB_MANY; i++) {
-        printf("\r %u/%u", i + 1, GROUP_NUMB_MANY);
+        if (IS_MAIN_TEST_THREAD)
+            printf("\r %u/%u", i + 1, GROUP_NUMB_MANY);
         snprintf(group_name, sizeof(group_name), "group %02u", i);
+
         if ((child_group_id =
                  H5Gcreate2(parent_group_id, group_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
             H5_FAILED();
@@ -292,7 +295,8 @@ test_create_deep_groups(void H5_ATTR_UNUSED *params)
         goto error;
     }
 
-    printf("\n");
+    if (IS_MAIN_TEST_THREAD)
+        printf("\n");
     if (create_group_recursive(group_id, 1) < 0)
         TEST_ERROR;
 
@@ -328,7 +332,8 @@ create_group_recursive(hid_t parent_gid, unsigned counter)
     hid_t child_gid = H5I_INVALID_HID;
     char  gname[NAME_BUF_SIZE];
 
-    printf("\r %u/%u", counter, GROUP_DEPTH);
+    if (IS_MAIN_TEST_THREAD)
+        printf("\r %u/%u", counter, GROUP_DEPTH);
     if (counter == 1)
         snprintf(gname, sizeof(gname), "2nd_child_group");
     else if (counter == 2)

--- a/test/API/H5_api_link_test.c
+++ b/test/API/H5_api_link_test.c
@@ -461,9 +461,9 @@ test_create_hard_link_many(void H5_ATTR_UNUSED *params)
     }
 
     for (size_t i = 1; (i < HARD_LINK_TEST_GROUP_MANY_NUM_HARD_LINKS + 1 && !valid_name_matched); i++) {
-        char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
+        char name_possibility[H5_TEST_FILENAME_MAX_LENGTH];
 
-        snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu",
+        snprintf(name_possibility, H5_TEST_FILENAME_MAX_LENGTH, "%s%zu",
                  "/" LINK_TEST_GROUP_NAME "/" HARD_LINK_TEST_GROUP_MANY_NAME "/hard", i);
 
         valid_name_matched |= !strcmp(objname, name_possibility);
@@ -1678,9 +1678,9 @@ test_create_soft_link_many(void H5_ATTR_UNUSED *params)
     }
 
     for (size_t i = 1; (i < SOFT_LINK_TEST_GROUP_MANY_NAME_SOFT_LINK_COUNT + 1 && !valid_name_matched); i++) {
-        char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
+        char name_possibility[H5_TEST_FILENAME_MAX_LENGTH];
 
-        snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu",
+        snprintf(name_possibility, H5_TEST_FILENAME_MAX_LENGTH, "%s%zu",
                  "/" LINK_TEST_GROUP_NAME "/" SOFT_LINK_TEST_GROUP_MANY_NAME "/soft", i);
 
         valid_name_matched |= !strcmp(objname, name_possibility);
@@ -2777,9 +2777,9 @@ test_create_external_link_ping_pong(void H5_ATTR_UNUSED *params)
             }
 
             for (size_t i = 1; i < EXTERNAL_LINK_TEST_PING_PONG_NUM_LINKS + 1 && !valid_name_matched; i++) {
-                char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
+                char name_possibility[H5_TEST_FILENAME_MAX_LENGTH];
 
-                snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu", "/link", i);
+                snprintf(name_possibility, H5_TEST_FILENAME_MAX_LENGTH, "%s%zu", "/link", i);
 
                 valid_name_matched |= !strcmp(name_possibility, objname);
             }
@@ -2847,9 +2847,9 @@ test_create_external_link_ping_pong(void H5_ATTR_UNUSED *params)
             }
 
             for (size_t i = 1; i < EXTERNAL_LINK_TEST_PING_PONG_NUM_LINKS + 1 && !valid_name_matched; i++) {
-                char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
+                char name_possibility[H5_TEST_FILENAME_MAX_LENGTH];
 
-                snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu%s", "/link", i,
+                snprintf(name_possibility, H5_TEST_FILENAME_MAX_LENGTH, "%s%zu%s", "/link", i,
                          "/new_group");
 
                 valid_name_matched |= !strcmp(objname, name_possibility);

--- a/test/API/H5_api_link_test.c
+++ b/test/API/H5_api_link_test.c
@@ -2570,6 +2570,8 @@ test_create_external_link_multi(void H5_ATTR_UNUSED *params)
     }
     END_MULTIPART;
 
+    TESTING_2("test cleanup");
+
     if (remove_test_file(NULL, ext_link_filename1) < 0)
         TEST_ERROR;
     if (remove_test_file(NULL, ext_link_filename2) < 0)
@@ -2580,6 +2582,8 @@ test_create_external_link_multi(void H5_ATTR_UNUSED *params)
     free(ext_link_filename1);
     free(ext_link_filename2);
     free(ext_link_filename3);
+
+    PASSED();
 
     return;
 
@@ -2882,6 +2886,8 @@ test_create_external_link_ping_pong(void H5_ATTR_UNUSED *params)
     }
     END_MULTIPART;
 
+    TESTING_2("test cleanup");
+
     if (remove_test_file(NULL, ext_link_filename1) < 0)
         TEST_ERROR;
     if (remove_test_file(NULL, ext_link_filename2) < 0)
@@ -2889,6 +2895,8 @@ test_create_external_link_ping_pong(void H5_ATTR_UNUSED *params)
 
     free(ext_link_filename1);
     free(ext_link_filename2);
+
+    PASSED();
 
     return;
 

--- a/test/API/H5_api_object_test.c
+++ b/test/API/H5_api_object_test.c
@@ -1933,7 +1933,7 @@ test_incr_decr_object_refcount_invalid_params(void H5_ATTR_UNUSED *params)
         }
         PART_END(H5Odecr_refcount_invalid_param);
     }
-    END_MULTIPART;
+    END_MULTIPART_NO_CLEANUP;
 
     return;
 

--- a/test/API/H5_api_test.c
+++ b/test/API/H5_api_test.c
@@ -44,7 +44,7 @@
 #include <pthread.h>
 #endif
 
-char H5_api_test_filename_g[H5_API_TEST_FILENAME_MAX_LENGTH];
+char H5_api_test_filename_g[H5_TEST_FILENAME_MAX_LENGTH];
 
 static int H5_api_test_create_containers(const char *filename, uint64_t vol_cap_flags);
 static int H5_api_test_create_single_container(const char *filename, uint64_t vol_cap_flags);
@@ -227,14 +227,14 @@ main(int argc, char **argv)
 
     if (GetTestMaxNumThreads() == 1) {
         /* Populate global test filename */
-        if ((chars_written = HDsnprintf(H5_api_test_filename_g, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s",test_path_prefix,
+        if ((chars_written = HDsnprintf(H5_api_test_filename_g, H5_TEST_FILENAME_MAX_LENGTH, "%s%s",test_path_prefix,
                 TEST_FILE_NAME)) < 0) {
             fprintf(stderr, "Error while creating test file name\n");
             err_occurred = TRUE;
             goto done;
         }
 
-        if ((size_t)chars_written >= H5_API_TEST_FILENAME_MAX_LENGTH) {
+        if ((size_t)chars_written >= H5_TEST_FILENAME_MAX_LENGTH) {
             fprintf(stderr, "Test file name exceeded expected size\n");
             err_occurred = TRUE;
             goto done;

--- a/test/API/H5_api_test.c
+++ b/test/API/H5_api_test.c
@@ -214,7 +214,7 @@ main(int argc, char **argv)
         test_path_prefix = "";
 
 #ifndef H5_HAVE_MULTITHREAD
-    if (TEST_EXECUTION_MULTITHREADED) {
+    if (TEST_EXECUTION_THREADED) {
         fprintf(stderr, "HDF5 must be built with multi-thread support to run multi-threaded API tests\n");
         err_occurred = TRUE;
         goto done;
@@ -225,7 +225,7 @@ main(int argc, char **argv)
         SetTestMaxNumThreads(API_TESTS_DEFAULT_NUM_THREADS);
     }
 
-    if (!TEST_EXECUTION_MULTITHREADED) {
+    if (!TEST_EXECUTION_THREADED) {
         /* Populate global test filename */
         if ((chars_written = HDsnprintf(H5_api_test_filename_g, H5_TEST_FILENAME_MAX_LENGTH, "%s%s",test_path_prefix,
                 TEST_FILE_NAME)) < 0) {

--- a/test/API/H5_api_test.c
+++ b/test/API/H5_api_test.c
@@ -214,7 +214,7 @@ main(int argc, char **argv)
         test_path_prefix = "";
 
 #ifndef H5_HAVE_MULTITHREAD
-    if (GetTestMaxNumThreads() > 1) {
+    if (TEST_EXECUTION_MULTITHREADED) {
         fprintf(stderr, "HDF5 must be built with multi-thread support to run multi-threaded API tests\n");
         err_occurred = TRUE;
         goto done;
@@ -225,7 +225,7 @@ main(int argc, char **argv)
         SetTestMaxNumThreads(API_TESTS_DEFAULT_NUM_THREADS);
     }
 
-    if (GetTestMaxNumThreads() == 1) {
+    if (!TEST_EXECUTION_MULTITHREADED) {
         /* Populate global test filename */
         if ((chars_written = HDsnprintf(H5_api_test_filename_g, H5_TEST_FILENAME_MAX_LENGTH, "%s%s",test_path_prefix,
                 TEST_FILE_NAME)) < 0) {

--- a/test/API/H5_api_test.c
+++ b/test/API/H5_api_test.c
@@ -215,15 +215,11 @@ main(int argc, char **argv)
 
 #ifndef H5_HAVE_MULTITHREAD
     if (TEST_EXECUTION_THREADED) {
-        fprintf(stderr, "HDF5 must be built with multi-thread support to run multi-threaded API tests\n");
+        fprintf(stderr, "HDF5 must be built with multi-thread support to run threaded API tests\n");
         err_occurred = TRUE;
         goto done;
     }
 #endif
-
-    if (GetTestMaxNumThreads() <= 0) {
-        SetTestMaxNumThreads(API_TESTS_DEFAULT_NUM_THREADS);
-    }
 
     if (!TEST_EXECUTION_THREADED) {
         /* Populate global test filename */
@@ -414,7 +410,6 @@ done:
 static int
 H5_api_test_create_containers(const char *filename, uint64_t vol_cap_flags)
 {
-    int max_threads = GetTestMaxNumThreads();
     char *tl_filename = NULL;
 
     if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
@@ -422,9 +417,9 @@ H5_api_test_create_containers(const char *filename, uint64_t vol_cap_flags)
         goto error;
     }
 
-    if (max_threads > 1) {
+    if (TEST_EXECUTION_THREADED) {
 #ifdef H5_HAVE_MULTITHREAD
-        for (int i = 0; i < max_threads; i++) {
+        for (int i = 0; i < GetTestMaxNumThreads(); i++) {
             if ((tl_filename = generate_threadlocal_filename(test_path_prefix, i, filename)) == NULL) {
                 printf("    failed to generate thread-local API test filename\n");
                 goto error;
@@ -534,7 +529,6 @@ error:
 static int
 H5_api_test_destroy_container_files(void) {
 
-    int max_threads = GetTestMaxNumThreads();
     char *filename = NULL;
 
     if (!(vol_cap_flags_g & H5VL_CAP_FLAG_FILE_BASIC)) {
@@ -542,13 +536,13 @@ H5_api_test_destroy_container_files(void) {
         goto error;
     }
 
-    if (max_threads > 1) {
+    if (TEST_EXECUTION_THREADED) {
 #ifndef H5_HAVE_MULTITHREAD
         printf("    thread-specific cleanup requested, but multithread support not enabled\n");
         goto error;
 #endif
         
-        for (int i = 0; i < max_threads; i++) {
+        for (int i = 0; i < GetTestMaxNumThreads(); i++) {
             if ((filename = generate_threadlocal_filename(test_path_prefix, i, TEST_FILE_NAME)) == NULL) {
                 printf("    failed to generate thread-local API test filename\n");
                 goto error;

--- a/test/API/H5_api_test.h
+++ b/test/API/H5_api_test.h
@@ -38,7 +38,7 @@
 
 /* Final name of the API test container file (for this thread) */
 #ifdef H5_HAVE_MULTITHREAD
-#define H5_API_TEST_FILENAME (GetTestMaxNumThreads() > 1 ? ((thread_info_t*) pthread_getspecific(test_thread_info_key_g))->test_thread_filename : H5_api_test_filename_g)
+#define H5_API_TEST_FILENAME (TEST_EXECUTION_MULTITHREADED ? ((thread_info_t*) pthread_getspecific(test_thread_info_key_g))->test_thread_filename : H5_api_test_filename_g)
 #else
 #define H5_API_TEST_FILENAME H5_api_test_filename_g
 #endif

--- a/test/API/H5_api_test.h
+++ b/test/API/H5_api_test.h
@@ -38,7 +38,7 @@
 
 /* Final name of the API test container file (for this thread) */
 #ifdef H5_HAVE_MULTITHREAD
-#define H5_API_TEST_FILENAME (TEST_EXECUTION_MULTITHREADED ? ((thread_info_t*) pthread_getspecific(test_thread_info_key_g))->test_thread_filename : H5_api_test_filename_g)
+#define H5_API_TEST_FILENAME (TEST_EXECUTION_THREADED ? ((thread_info_t*) pthread_getspecific(test_thread_info_key_g))->test_thread_filename : H5_api_test_filename_g)
 #else
 #define H5_API_TEST_FILENAME H5_api_test_filename_g
 #endif

--- a/test/API/H5_api_test_util.c
+++ b/test/API/H5_api_test_util.c
@@ -649,7 +649,7 @@ error:
  * is responsible for freeing the returned filename
  * pointer with free().
  * 
- * If the API tests are being run multi-threaded,
+ * If the API tests are being run in separate thread(s)
  * then the framework-assigned thread index will be inserted as well.
  */
 herr_t

--- a/test/API/H5_api_test_util.c
+++ b/test/API/H5_api_test_util.c
@@ -678,7 +678,7 @@ prefix_filename(const char *prefix, const char *filename, char **filename_out)
         goto done;
     }
 
-    if (TEST_EXECUTION_MULTITHREADED) {
+    if (TEST_EXECUTION_THREADED) {
 #ifdef H5_HAVE_MULTITHREAD
 
         if ((tinfo = (thread_info_t *)pthread_getspecific(test_thread_info_key_g)) == NULL) {

--- a/test/API/H5_api_test_util.c
+++ b/test/API/H5_api_test_util.c
@@ -678,7 +678,7 @@ prefix_filename(const char *prefix, const char *filename, char **filename_out)
         goto done;
     }
 
-    if (GetTestMaxNumThreads() > 1) {
+    if (TEST_EXECUTION_MULTITHREADED) {
 #ifdef H5_HAVE_MULTITHREAD
 
         if ((tinfo = (thread_info_t *)pthread_getspecific(test_thread_info_key_g)) == NULL) {

--- a/test/API/H5_api_test_util.c
+++ b/test/API/H5_api_test_util.c
@@ -699,13 +699,13 @@ prefix_filename(const char *prefix, const char *filename, char **filename_out)
         goto done;
 #endif
     } else {
-        if (NULL == (out_buf = malloc(H5_API_TEST_FILENAME_MAX_LENGTH))) {
+        if (NULL == (out_buf = malloc(H5_TEST_FILENAME_MAX_LENGTH))) {
             printf("    couldn't allocated filename buffer\n");
             ret_value = FAIL;
             goto done;
         }
 
-        if ((chars_written = HDsnprintf(out_buf, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", prefix, filename)) <
+        if ((chars_written = HDsnprintf(out_buf, H5_TEST_FILENAME_MAX_LENGTH, "%s%s", prefix, filename)) <
             0) {
             printf("    couldn't prefix filename\n");
             ret_value = FAIL;
@@ -713,7 +713,7 @@ prefix_filename(const char *prefix, const char *filename, char **filename_out)
         }
     }
 
-    if ((size_t)chars_written >= H5_API_TEST_FILENAME_MAX_LENGTH) {
+    if ((size_t)chars_written >= H5_TEST_FILENAME_MAX_LENGTH) {
         printf("    filename buffer too small\n");
         ret_value = FAIL;
         goto done;

--- a/test/API/H5_api_test_util.h
+++ b/test/API/H5_api_test_util.h
@@ -13,8 +13,6 @@
 #ifndef H5_API_TEST_UTIL_H_
 #define H5_API_TEST_UTIL_H_
 
-#define API_TESTS_DEFAULT_NUM_THREADS 1
-
 #include "hdf5.h"
 
 hid_t  generate_random_datatype(H5T_class_t parent_class, bool is_compact);

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -2194,19 +2194,19 @@ char *generate_threadlocal_filename(const char *prefix, int thread_idx, const ch
         goto error;
     }
 
-    if (MAX_THREAD_IDX_LEN + strlen(filename) >= H5_API_TEST_FILENAME_MAX_LENGTH) {
+    if (MAX_THREAD_IDX_LEN + strlen(filename) >= H5_TEST_FILENAME_MAX_LENGTH) {
         fprintf(stderr, "    test file name exceeded expected size\n");
         goto error;
     }
 
-    if (NULL == (test_filename = (char *)calloc(1, H5_API_TEST_FILENAME_MAX_LENGTH))) {
+    if (NULL == (test_filename = (char *)calloc(1, H5_TEST_FILENAME_MAX_LENGTH))) {
         fprintf(stderr, "    couldn't allocate memory for test file name\n");
         goto error;
     }
 
     /* Write prefix, thread index, and filename into buffer */
     if ((chars_written = snprintf(test_filename,
-                                  H5_API_TEST_FILENAME_MAX_LENGTH, "%s%d%s",
+                                  H5_TEST_FILENAME_MAX_LENGTH, "%s%d%s",
                                   prefix, thread_idx, filename)) < 0) {
         fprintf(stderr, "    couldn't create test file name\n");
         goto error;

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -67,7 +67,7 @@ typedef struct thread_info_t {
     char* test_thread_filename; /* The name of the test container file */
 } thread_info_t;
 
-/* Whether or not the tests are configured to execute using multi-threaded infrastructure.
+/* Whether or not the tests are configured to execute using threaded infrastructure.
  * Note that if GetTestMaxNumThreads() == 1, then the tests are still only run in a single thread,
  * but that thread is a new thread spawned by the main thread. */
 #define TEST_EXECUTION_THREADED (GetTestMaxNumThreads() >= 1)
@@ -86,7 +86,7 @@ extern pthread_key_t test_thread_info_key_g;
 #endif /* H5_HAVE_MULTITHREAD */
 
 /* Flag values for TestFrameworkFlags */
-#define ALLOW_MULTITHREAD 0x00000001 /* Run the test in a multi-threaded environment */
+#define ALLOW_MULTITHREAD 0x00000001 /* Allow test to be run in spawned thread(s) based on runtime configuration */
 
 /*
  * Print the current location on the standard output stream.

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -182,6 +182,7 @@ extern pthread_key_t test_thread_info_key_g;
         } else {                                                                                             \
             /* Store test desc for display after test completion */ \
             thread_info_t *_tinfo = (thread_info_t*)pthread_getspecific(test_thread_info_key_g);                \
+            assert(_tinfo);                                                                                 \
             /* TBD - Only need to store this for 1 thread */\
             _tinfo->test_descriptions[_tinfo->num_tests - 1] = WHAT; \
         }                                                                                                   \

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -136,10 +136,10 @@ extern pthread_key_t test_thread_info_key_g;
 
 #else
 
-#define INCR_RUN_COUNT     n_tests_run_g++;
-#define INCR_FAILED_COUNT  n_tests_failed_g++;
-#define INCR_PASSED_COUNT  n_tests_passed_g++;
-#define INCR_SKIPPED_COUNT n_tests_skipped_g++;
+#define INCR_RUN_COUNT     H5_ATOMIC_ADD(n_tests_run_g, 1);
+#define INCR_FAILED_COUNT  H5_ATOMIC_ADD(n_tests_failed_g, 1);
+#define INCR_PASSED_COUNT  H5_ATOMIC_ADD(n_tests_passed_g, 1);
+#define INCR_SKIPPED_COUNT H5_ATOMIC_ADD(n_tests_skipped_g, 1);
 #endif
 
 /*
@@ -164,6 +164,8 @@ extern pthread_key_t test_thread_info_key_g;
         printf("  Testing %-60s", WHAT);                                                                     \
         fflush(stdout);                                                                                      \
     } while (0)
+
+#ifdef H5_HAVE_MULTITHREAD
 #define TESTING_2(WHAT)                                                                                      \
     do {                                                                                                     \
         INCR_RUN_COUNT;                                                                                     \
@@ -176,6 +178,18 @@ extern pthread_key_t test_thread_info_key_g;
             _tinfo->test_descriptions[_tinfo->num_tests - 1] = WHAT; \
         }                                                                                                   \
     } while (0)
+#else 
+#define TESTING_2(WHAT)                                                                                      \
+    do {                                                                                                     \
+        INCR_RUN_COUNT;                                                                                     \
+        if (GetTestMaxNumThreads() > 1) {                                                                          \
+            printf("  Test run with multiple threads, but library not built with multi-thread support!\n");\
+            goto error;                                                                                     \
+        }                                                                                                   \
+        TESTING_2_DISPLAY(WHAT);                                                                             \
+    } while (0)
+#endif /* H5_HAVE_MULTITHREAD */
+
 #define PASSED_DISPLAY()                                                                                     \
     do {                                                                                                     \
         HDputs(" PASSED");                                                                                   \

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -44,10 +44,26 @@ H5TEST_DLLVAR MPI_Info h5_io_info_g; /* MPI INFO object for IO */
 #endif
 
 #define H5_TEST_FILENAME_MAX_LENGTH 1024
+#define H5_MAX_NUM_SUBTESTS 64
+
+/* The results are defined like this to make it simple for
+ * a fail in one thread to supersede passes/skips in other threads
+ * by using greater-than comparisons
+ */
+typedef uint8_t test_outcome_t;
+
+#define TEST_UNINIT  ((uint8_t) 0x00)
+#define TEST_PASS    ((uint8_t) 0x01)
+#define TEST_SKIP    ((uint8_t) 0x02)
+#define TEST_FAIL    ((uint8_t) 0x03)
+#define TEST_INVALID ((uint8_t) 0x04)
 
 /* Information for an individual thread running the API tests */
 typedef struct thread_info_t {
-    int thread_idx; /* The test-assign index of the thread */
+    int thread_idx; /* The test-framework-assigned index of the thread */
+    size_t num_tests; /* Number of individual tests contained within a top-level test */
+    test_outcome_t *test_outcomes;
+    const char **test_descriptions;
     char* test_thread_filename; /* The name of the test container file */
 } thread_info_t;
 
@@ -77,12 +93,53 @@ extern pthread_key_t test_thread_info_key_g;
  */
 #ifdef H5_HAVE_MULTITHREAD
 
-/* Increment global atomic testing variable. Used for MT testing by
- * tests that don't define threadlocal test information */
-#define INCR_TEST_STAT(field_name)  atomic_fetch_add(&field_name, 1);
+#define INCR_RUN_COUNT                                                                                 \
+    if (GetTestMaxNumThreads() > 1 && pthread_getspecific(test_thread_info_key_g)) {                        \
+        ((thread_info_t*)pthread_getspecific(test_thread_info_key_g))->num_tests++;                      \
+        assert(((thread_info_t*)pthread_getspecific(test_thread_info_key_g))->num_tests <= H5_MAX_NUM_SUBTESTS); \
+    } else {                                                                                                 \
+        H5_ATOMIC_ADD(n_tests_run_g, 1);                                                                                  \
+    }
+
+/* If running multi-threaded tests, store outcomes on threadlocal variable for later aggregation. */
+/* The global variables are atomic based on build configuration, not runtime thread count,
+ * and so the ATOMIC_ADD macros must be used even in the single-thread runtime. */
+#define INCR_FAILED_COUNT                                                                                  \
+    if (GetTestMaxNumThreads() > 1 && pthread_getspecific(test_thread_info_key_g)) {                        \
+        thread_info_t *_tinfo = (thread_info_t*)pthread_getspecific(test_thread_info_key_g);                \
+        assert(_tinfo->num_tests > 0);                                                                   \
+        assert(_tinfo->test_outcomes[_tinfo->num_tests - 1] == TEST_UNINIT);                                \
+        _tinfo->test_outcomes[_tinfo->num_tests - 1] = TEST_FAIL;                                          \
+    } else {                                                                                                 \
+        H5_ATOMIC_ADD(n_tests_failed_g, 1);                                                                                  \
+    }
+
+#define INCR_PASSED_COUNT                                                                                 \
+    if (GetTestMaxNumThreads() > 1 && pthread_getspecific(test_thread_info_key_g)) {                        \
+        thread_info_t *_tinfo = (thread_info_t*)pthread_getspecific(test_thread_info_key_g);                \
+        assert(_tinfo->num_tests > 0);                                                                   \
+        assert(_tinfo->test_outcomes[_tinfo->num_tests - 1] == TEST_UNINIT);                                \
+        _tinfo->test_outcomes[_tinfo->num_tests - 1] = TEST_PASS;                                          \
+    } else {                                                                                                 \
+        H5_ATOMIC_ADD(n_tests_passed_g, 1);                                                                                  \
+    }
+
+#define INCR_SKIPPED_COUNT                                                                               \
+    if (GetTestMaxNumThreads() > 1 && pthread_getspecific(test_thread_info_key_g)) {                        \
+        thread_info_t *_tinfo = (thread_info_t*)pthread_getspecific(test_thread_info_key_g);                \
+        assert(_tinfo->num_tests > 0);                                                                   \
+        assert(_tinfo->test_outcomes[_tinfo->num_tests - 1] == TEST_UNINIT);                                \
+        _tinfo->test_outcomes[_tinfo->num_tests - 1] = TEST_SKIP;                                          \
+    } else {                                                                                                 \
+        H5_ATOMIC_ADD(n_tests_skipped_g, 1);                                                                                 \
+    }
 
 #else
-#define INCR_TEST_STAT(field_name) field_name++
+
+#define INCR_RUN_COUNT     n_tests_run_g++;
+#define INCR_FAILED_COUNT  n_tests_failed_g++;
+#define INCR_PASSED_COUNT  n_tests_passed_g++;
+#define INCR_SKIPPED_COUNT n_tests_skipped_g++;
 #endif
 
 /*
@@ -96,35 +153,52 @@ extern pthread_key_t test_thread_info_key_g;
  */
 #define TESTING(WHAT)                                                                                        \
     do {                                                                                                     \
+        INCR_RUN_COUNT;                                                                                       \
         if (IS_MAIN_TEST_THREAD) {                                                                           \
-            printf("Testing %-62s", WHAT);                                                                   \
-            fflush(stdout);                                                                                  \
-        }                                                                                                    \
-        INCR_TEST_STAT(n_tests_run_g);                                                                       \
+            printf("Testing %-62s", WHAT);                                                                       \
+            fflush(stdout);                                                                                      \
+        }                                                                                                   \
+    } while (0)
+#define TESTING_2_DISPLAY(WHAT)                                                                             \
+    do {                                                                                                     \
+        printf("  Testing %-60s", WHAT);                                                                     \
+        fflush(stdout);                                                                                      \
     } while (0)
 #define TESTING_2(WHAT)                                                                                      \
     do {                                                                                                     \
-        if (IS_MAIN_TEST_THREAD) {                                                                           \
-            printf("  Testing %-60s", WHAT);                                                                 \
-            fflush(stdout);                                                                                  \
-        }                                                                                                    \
-        INCR_TEST_STAT(n_tests_run_g);                                                                       \
+        INCR_RUN_COUNT;                                                                                     \
+        if (GetTestMaxNumThreads() == 1) {                                                                           \
+            TESTING_2_DISPLAY(WHAT);                                                                             \
+        } else {                                                                                             \
+            /* Store test desc for display after test completion */ \
+            thread_info_t *_tinfo = (thread_info_t*)pthread_getspecific(test_thread_info_key_g);                \
+            /* TBD - Only need to store this for 1 thread */\
+            _tinfo->test_descriptions[_tinfo->num_tests - 1] = WHAT; \
+        }                                                                                                   \
+    } while (0)
+#define PASSED_DISPLAY()                                                                                     \
+    do {                                                                                                     \
+        HDputs(" PASSED");                                                                                   \
+        fflush(stdout);                                                                                      \
     } while (0)
 #define PASSED()                                                                                             \
     do {                                                                                                     \
-        if (IS_MAIN_TEST_THREAD) {                                                                           \
-            HDputs(" PASSED");                                                                               \
-            fflush(stdout);                                                                                  \
-        }                                                                                                    \
-        INCR_TEST_STAT(n_tests_passed_g);                                                                    \
+        if (GetTestMaxNumThreads() == 1) {                                                                           \
+            PASSED_DISPLAY();                                                                                   \
+        }                                                                                                  \
+        INCR_PASSED_COUNT;                                                                                  \
+    } while (0)
+#define H5_FAILED_DISPLAY()                                                                                  \
+    do {                                                                                                     \
+        HDputs("*FAILED*");                                                                                  \
+        fflush(stdout);                                                                                      \
     } while (0)
 #define H5_FAILED()                                                                                          \
     do {                                                                                                     \
-        if (IS_MAIN_TEST_THREAD) {                                                                           \
-            HDputs("*FAILED*");                                                                              \
-            fflush(stdout);                                                                                  \
-        }                                                                                                    \
-        INCR_TEST_STAT(n_tests_failed_g);                                                                    \
+        if (GetTestMaxNumThreads() == 1) {                                                                           \
+            H5_FAILED_DISPLAY();                                                                                 \
+        }                                                                                                  \
+        INCR_FAILED_COUNT;                                                                                   \
     } while (0)
 #define H5_WARNING()                                                                                         \
     do {                                                                                                     \
@@ -133,13 +207,22 @@ extern pthread_key_t test_thread_info_key_g;
             fflush(stdout);                                                                                  \
         }                                                                                                    \
     } while (0)
+#define SKIPPED_DISPLAY()                                                                                    \
+    do {                                                                                                     \
+        HDputs(" -SKIP-");                                                                                   \
+        fflush(stdout);                                                                                      \
+    } while (0)
 #define SKIPPED()                                                                                            \
     do {                                                                                                     \
-        if (IS_MAIN_TEST_THREAD) {                                                                           \
-            HDputs(" -SKIP-");                                                                               \
-            fflush(stdout);                                                                                  \
-        }                                                                                                    \
-        INCR_TEST_STAT(n_tests_skipped_g);                                                                   \
+        if (GetTestMaxNumThreads() == 1) {                                                                           \
+            SKIPPED_DISPLAY();                                                                                   \
+        }                                                                                                 \
+        INCR_SKIPPED_COUNT;                                                                                  \
+    } while (0)
+#define ERROR_DISPLAY()                                                                                     \
+    do {                                                                                                     \
+        HDputs(" *ERROR*");                                                                                 \
+        fflush(stdout);                                                                                      \
     } while (0)
 #define PUTS_ERROR(s)                                                                                        \
     do {                                                                                                     \
@@ -221,7 +304,7 @@ extern pthread_key_t test_thread_info_key_g;
     part_##part_name##_end:
 #define PART_ERROR(part_name)                                                                                \
     do {                                                                                                     \
-        INCR_TEST_STAT(n_tests_failed_g);                                                                    \
+        INCR_FAILED_COUNT;                                                                                  \
         part_nerrors++;                                                                                      \
         goto part_##part_name##_end;                                                                         \
     } while (0)

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -336,7 +336,6 @@ extern pthread_key_t test_thread_info_key_g;
     part_##part_name##_end:
 #define PART_ERROR(part_name)                                                                                \
     do {                                                                                                     \
-        INCR_FAILED_COUNT;                                                                                  \
         part_nerrors++;                                                                                      \
         goto part_##part_name##_end;                                                                         \
     } while (0)

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -43,7 +43,7 @@ H5TEST_DLLVAR char *paraprefix;
 H5TEST_DLLVAR MPI_Info h5_io_info_g; /* MPI INFO object for IO */
 #endif
 
-#define H5_API_TEST_FILENAME_MAX_LENGTH 1024
+#define H5_TEST_FILENAME_MAX_LENGTH 1024
 
 /* Information for an individual thread running the API tests */
 typedef struct thread_info_t {

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -309,8 +309,17 @@ extern pthread_key_t test_thread_info_key_g;
         int part_nerrors = 0;
 
 #define END_MULTIPART                                                                                        \
-    if (part_nerrors > 0)                                                                                    \
-        goto error;                                                                                          \
+        if (part_nerrors > 0) {                                                                              \
+            TESTING_2("test cleanup");                                                                       \
+            SKIPPED();                                                                                       \
+            goto error;                                                                                      \
+        }                                                                                                    \
+    }
+
+#define END_MULTIPART_NO_CLEANUP                                                                             \
+        if (part_nerrors) {                                                                                  \
+            goto error;                                                                                      \
+        }                                                                                                    \
     }
 
 /*

--- a/test/testframe.c
+++ b/test/testframe.c
@@ -449,11 +449,8 @@ done:
 herr_t
 PerformTests(void)
 {
-    unsigned Loop;
-    bool mt_initialized = false;
     int test_num_errs = 0;
     int max_num_threads = GetTestMaxNumThreads();
-    bool is_test_threaded = false;
 
     for (unsigned Loop = 0; Loop < TestCount; Loop++) {
         bool is_test_mt = (TestArray[Loop].TestFrameworkFlags & ALLOW_MULTITHREAD) && (max_num_threads > 1);

--- a/test/testframe.c
+++ b/test/testframe.c
@@ -461,7 +461,7 @@ PerformTests(void)
         }
 
         MESSAGE(2, ("Testing %s -- %s (%s) \n", (is_test_mt ? "(Multi-threaded)" : ""),
-            TestArray[Loop].Description, TestArray[Loop].Name));
+            TestAqrray[Loop].Description, TestArray[Loop].Name));
         MESSAGE(5, ("===============================================\n"));
 
         test_num_errs = H5_ATOMIC_LOAD(TestArray[Loop].TestNumErrors);
@@ -990,7 +990,7 @@ TestErrPrintf(const char *format, ...)
     int     ret_value;
 
     /* Increment the error count */
-    H5_ATOMIC_ADD(TestNumErrs_g, 1);
+    IncTestNumErrs();
 
     /* Print the requested information */
     va_start(arglist, format);

--- a/test/testframe.c
+++ b/test/testframe.c
@@ -453,7 +453,7 @@ PerformTests(void)
     int max_num_threads = GetTestMaxNumThreads();
 
     for (unsigned Loop = 0; Loop < TestCount; Loop++) {
-        bool is_test_mt = (TestArray[Loop].TestFrameworkFlags & ALLOW_MULTITHREAD) && (max_num_threads > 1);
+        bool is_test_mt = (TestArray[Loop].TestFrameworkFlags & ALLOW_MULTITHREAD) && TEST_EXECUTION_THREADED;
         
         if (TestArray[Loop].TestSkipFlag) {
             MESSAGE(2, ("Skipping -- %s (%s) \n", TestArray[Loop].Description, TestArray[Loop].Name));

--- a/testpar/API/H5_api_test_parallel.c
+++ b/testpar/API/H5_api_test_parallel.c
@@ -25,7 +25,7 @@
 #include "H5_api_async_test_parallel.h"
 #endif
 
-char H5_api_test_parallel_filename[H5_API_TEST_FILENAME_MAX_LENGTH];
+char H5_api_test_parallel_filename[H5_TEST_FILENAME_MAX_LENGTH];
 
 const char *test_path_prefix;
 
@@ -383,8 +383,8 @@ main(int argc, char **argv)
     if (NULL == (test_path_prefix = getenv(HDF5_API_TEST_PATH_PREFIX)))
         test_path_prefix = "";
 
-    snprintf(H5_api_test_parallel_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
-             PARALLEL_TEST_FILE_NAME);
+    snprintf(H5_api_test_parallel_filename, H5_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+               PARALLEL_TEST_FILE_NAME);
 
     if (NULL == (vol_connector_string = getenv(HDF5_VOL_CONNECTOR))) {
         if (MAINPROCESS)


### PR DESCRIPTION
- Rework test framework to aggregate and display multi-threaded results properly

This consists of the following major aspects:

1. Consider a failure of a test/subtest in any thread to be an overall failure of that test/subtest
2. Consider the number of tests to be constant regardless of the number of threads used to execute tests

Since subtests aren't exposed directly to testframe, several changes had to be made to support including them in the results while also avoid duplication during multithreading:

- Number of subtests and test outcomes are now stored in the threadlocal info. 

(Sub-)Test count and outcomes are recorded incrementally during runtime by TESTING/TESTING_2/H5_FAILED/SKIPPED/PASSED, and not displayed until after the subtest has finished in each thread. This is to prevent erroneous reporting of success in the case that it passes in the main thread and fails in another thread.

To pass information between testframe and the MT tests, some of these fields have been duplicated in the TestThreadArgs struct.

- Subtest descriptions are stored on the threadlocal info and printed after the test is executed

All subtests are run in a row during test execution, so correct reporting requires waiting until after the subtests are complete to display the test information, which in turn requires storing the test description until it is to be displayed.

- Change several TESTING calls in the I/O point selection test to TESTING_2 for compatibility with the new display code. 

These probably should have been subtests in the first place, but it's now necessary to handle this right since the behavior between the top-level tests and subtest output is different.

- Rework test cleanup declaration for multi-part tests

Previously, multi-part tests would declare 'test cleanup' as a subtest only if no errors occurred during the multi-part test itself. If any errors did occur, it would omit that declaration and silently do the error-cleanup at the end.

Because each thread must now always report the same number of sub-tests, this had to be reworked so that test cleanup is declared consistently.

The actual logic for skipping to error-cleanup is the same. However, the END_MULTIPART macro will now declare and skip the "test cleanup" sub-test if errors did occur. This way, every thread will always report "test cleanup" as a subtest, regardless of outcome.

Multi-part tests without any cleanup must now use the END_MULTIPART_NO_CLEANUP variant.

- Rework INCR_TEST_STAT into INCR_*_COUNT macros that manage the new threadlocal test/subtest information

- Factor out the display portions of several test macros to use from testframe

- Add "test cleanup" sub-test declaration to several multi-part tests

- Rename `H5_API_TEST_FILENAME_MAX_LENGTH` -> `H5_TEST_FILENAME_MAX_LENGTH` since it's no longer exclusive to the API tests

-  Suppress some special output in group/dataset tests on non-main threads

- Replace non-atomic handling of potentially atomic num_errs_g

- Known issue: If a subtest has any mid-test output, the output will be displayed before the subtest's description

This is a dependency for the following PRs:

MT VL Testing - mattjala#10
Make H5VL Multi-Thread Safe - mattjala#9
Implement virtual locks on IDs - mattjala#7