### PR TITLE
Sync autotools API test headers with CMake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4280,6 +4280,7 @@ AC_CONFIG_FILES([Makefile
                  test/test_vds_env.sh
                  test/test_vds_swmr.sh
                  test/API/Makefile
+                 test/API/H5_api_test_config.h:test/API/H5_api_test_config_at.h.in
                  testpar/Makefile
                  testpar/testpflush.sh
                  utils/Makefile

--- a/test/API/H5_api_test_config_at.h.in
+++ b/test/API/H5_api_test_config_at.h.in
@@ -1,0 +1,1 @@
+/* Boilerplate to match CMake build process */


### PR DESCRIPTION
The autotools build of the API tests will fail
if this header isn't generated, so keep it around
for now even though it's empty.