### PR TITLE
Remove static VOL connector property

### DIFF
--- a/src/H5VLcallback.c
+++ b/src/H5VLcallback.c
@@ -3935,7 +3935,7 @@ H5VL_file_open(H5VL_connector_prop_t *connector_prop, const char *name, unsigned
          * to attempt to open the file with. This only occurs if the default
          * VOL connector was used for the initial file open attempt.
          */
-        H5VL__is_default_conn(fapl_id, connector_prop->connector_id, &is_default_conn);
+        H5VL__is_default_conn(connector_prop->connector_id, &is_default_conn);
 
         if (is_default_conn) {
             H5VL_file_open_find_connector_t find_connector_ud;

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -147,9 +147,6 @@ H5FL_DEFINE_MT(H5VL_object_t);
 /* Declare a free list to manage the H5VL_wrap_ctx_t struct */
 H5FL_DEFINE_STATIC_MT(H5VL_wrap_ctx_t);
 
-/* Default VOL connector */
-static H5VL_connector_prop_t H5VL_def_conn_s = {-1, NULL};
-
 /*-------------------------------------------------------------------------
  * Function:    H5VL_init_phase1
  *
@@ -228,10 +225,6 @@ H5VL_init_phase2(void)
 
     /* clang-format on */
 
-    /* Sanity check default VOL connector */
-    assert(H5VL_def_conn_s.connector_id == (-1));
-    assert(H5VL_def_conn_s.connector_info == NULL);
-
     /* Set up the default VOL connector in the default FAPL */
     if (H5VL__set_def_conn() < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "unable to set default VOL connector");
@@ -258,17 +251,15 @@ H5VL_term_package(void)
 
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
-    if (H5VL_def_conn_s.connector_id > 0) {
-        /* Release the default VOL connector */
-        (void)H5VL_conn_free(&H5VL_def_conn_s);
-        H5VL_def_conn_s.connector_id   = -1;
-        H5VL_def_conn_s.connector_info = NULL;
+    if (H5I_nmembers(H5I_VOL) > 0) {
+        /* Unregister all VOL connectors */
+        (void)H5I_clear_type(H5I_VOL, TRUE, FALSE);
         n++;
     } /* end if */
     else {
-        if (H5I_nmembers(H5I_VOL) > 0) {
-            /* Unregister all VOL connectors */
-            (void)H5I_clear_type(H5I_VOL, TRUE, FALSE);
+        if (H5VL__num_opt_operation() > 0) {
+            /* Unregister all dynamically registered optional operations */
+            (void)H5VL__term_opt_operation();
             n++;
         } /* end if */
         else {
@@ -341,6 +332,7 @@ done:
 herr_t
 H5VL__set_def_conn(void)
 {
+    H5VL_connector_prop_t vol_prop = {H5_DEFAULT_VOL, NULL}; /* VOL connector property */
     H5P_genplist_t *def_fapl;               /* Default file access property list */
     H5P_genclass_t *def_fapclass;           /* Default file access property class */
     const char     *env_var;                /* Environment variable for default VOL connector */
@@ -351,15 +343,6 @@ H5VL__set_def_conn(void)
     int dec_ref_ret = 0;                     /* Return value from H5I_dec_ref() */
 
     FUNC_ENTER_PACKAGE
-
-    /* Reset default VOL connector, if it's set already */
-    /* (Can happen during testing -QAK) */
-    if (H5VL_def_conn_s.connector_id > 0) {
-        /* Release the default VOL connector */
-        (void)H5VL_conn_free(&H5VL_def_conn_s);
-        H5VL_def_conn_s.connector_id   = -1;
-        H5VL_def_conn_s.connector_info = NULL;
-    } /* end if */
 
     /* Check for environment variable set */
     env_var = HDgetenv(HDF5_VOL_CONNECTOR);
@@ -415,27 +398,18 @@ H5VL__set_def_conn(void)
             if (H5VL__connector_str_to_info(tok, connector_id, &vol_info) < 0)
                 HGOTO_ERROR(H5E_VOL, H5E_CANTDECODE, FAIL, "can't deserialize connector info");
 
-        /* Set the default VOL connector */
-        H5VL_def_conn_s.connector_id   = connector_id;
-        H5VL_def_conn_s.connector_info = vol_info;
+        /* Store information */
+        /* Temporary local copy, do not increase ref count */
+        vol_prop.connector_id   = connector_id;
+        vol_prop.connector_info = vol_info;
     } /* end if */
-    else {
-        /* Increment the ref count on the default connector */
-        if (H5I_inc_ref(H5_DEFAULT_VOL, FALSE) < 0)
-            HGOTO_ERROR(H5E_VOL, H5E_CANTINC, FAIL, "can't increment VOL connector refcount");
-
-        /* Set the default VOL connector */
-        H5VL_def_conn_s.connector_id   = H5_DEFAULT_VOL;
-        H5VL_def_conn_s.connector_info = NULL;
-
-    } /* end else */
 
     /* Get default file access pclass */
     if (NULL == (def_fapclass = (H5P_genclass_t *)H5I_object(H5P_FILE_ACCESS)))
         HGOTO_ERROR(H5E_VOL, H5E_BADID, FAIL, "can't find object for default file access property class ID");
 
     /* Change the default VOL for the default file access pclass */
-    if (H5P_reset_vol_class(def_fapclass, &H5VL_def_conn_s) < 0)
+    if (H5P_reset_vol_class(def_fapclass, &vol_prop) < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL,
                     "can't set default VOL connector for default file access property class");
 
@@ -444,7 +418,7 @@ H5VL__set_def_conn(void)
         HGOTO_ERROR(H5E_VOL, H5E_BADID, FAIL, "can't find object for default fapl ID");
 
     /* Change the default VOL for the default FAPL */
-    if (H5P_set_vol(def_fapl, H5VL_def_conn_s.connector_id, H5VL_def_conn_s.connector_info) < 0)
+    if (H5P_set_vol(def_fapl, vol_prop.connector_id, vol_prop.connector_info) < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "can't set default VOL connector for default FAPL");
 
 done:
@@ -3021,19 +2995,14 @@ H5VL_check_plugin_load(const H5VL_class_t *cls, const H5PL_key_t *key, hbool_t *
  *-------------------------------------------------------------------------
  */
 void
-H5VL__is_default_conn(hid_t fapl_id, hid_t connector_id, hbool_t *is_default)
+H5VL__is_default_conn(hid_t connector_id, hbool_t *is_default)
 {
     FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
     assert(is_default);
 
-    /* Determine if the default VOL connector will be used, based on non-default
-     * values in the FAPL, connector ID, or the HDF5_VOL_CONNECTOR environment
-     * variable being set.
-     */
-    *is_default = (H5VL_def_conn_s.connector_id == H5_DEFAULT_VOL) &&
-                  ((H5P_FILE_ACCESS_DEFAULT == fapl_id) || connector_id == H5_DEFAULT_VOL);
+    *is_default = (connector_id == H5_DEFAULT_VOL);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5VL__is_default_conn() */

--- a/src/H5VLpkg.h
+++ b/src/H5VLpkg.h
@@ -61,7 +61,7 @@ H5_DLL hid_t   H5VL__peek_connector_id_by_name(const char *name);
 H5_DLL hid_t   H5VL__peek_connector_id_by_value(H5VL_class_value_t value);
 H5_DLL herr_t  H5VL__connector_str_to_info(const char *str, hid_t connector_id, void **info);
 H5_DLL ssize_t H5VL__get_connector_name(hid_t id, char *name /*out*/, size_t size);
-H5_DLL void    H5VL__is_default_conn(hid_t fapl_id, hid_t connector_id, hbool_t *is_default);
+H5_DLL void    H5VL__is_default_conn(hid_t connector_id, hbool_t *is_default);
 H5_DLL herr_t  H5VL__register_opt_operation(H5VL_subclass_t subcls, const char *op_name, int *op_val);
 H5_DLL size_t  H5VL__num_opt_operation(void);
 H5_DLL herr_t  H5VL__find_opt_operation(H5VL_subclass_t subcls, const char *op_name, int *op_val);


### PR DESCRIPTION
- Remove global VOL connector property `H5VL_def_conn_s`

The only actual use of this global field was in H5VL__is_default_conn(), where it was redundant. 

- Rework `H5VL__is_default_conn()`

This used to check the environment variables (via the static connector property), and a provided FAPL, and a provided connector property. It's not clear to me why, since the provided property entirely controls the connector that is used.  

It now returns 'true' based solely on the connector property.