### PR TITLE
Fix spurious test failures when building with multi-threading

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,8 +35,6 @@ jobs:
       # Check out repository under $GITHUB_WORKSPACE
       - name: Get Sources
         uses: actions/checkout@v4.1.7
-        with:
-          ref: 1_14_2_multithread
 
       - name: CMake Configure
         run: |

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 12 * * *"
-#  push:
-#  pull_request:
-#    branches: [ 1_14_2_multithread ]
-#    paths-ignore:
-#      - '**.md'
+  push:
+  pull_request:
+    branches: [ 1_14_2_multithread ]
+    paths-ignore:
+      - '**.md'
 
 permissions:
   contents: read

--- a/src/H5FLprivate.h
+++ b/src/H5FLprivate.h
@@ -27,7 +27,7 @@
 
 /* Macros for turning off free lists in the library */
 /*#define H5_NO_FREE_LISTS*/
-#if defined H5_NO_FREE_LISTS || defined H5_USING_MEMCHECKER
+#if defined H5_NO_FREE_LISTS || defined H5_USING_MEMCHECKER || defined H5_HAVE_MULTITHREAD
 #define H5_NO_REG_FREE_LISTS
 #define H5_NO_ARR_FREE_LISTS
 #define H5_NO_SEQ_FREE_LISTS

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -101,7 +101,7 @@ typedef struct thread_info_t {
 #ifdef H5_HAVE_MULTITHREAD
 extern pthread_key_t test_thread_info_key_g;
 
-#define IS_MAIN_TEST_THREAD ((GetTestMaxNumThreads() == 1) ||\
+#define IS_MAIN_TEST_THREAD ((GetTestMaxNumThreads() <= 1) ||\
     ((pthread_getspecific(test_thread_info_key_g)) && (((thread_info_t*)pthread_getspecific(test_thread_info_key_g))->thread_idx == 0)))
 
 #else


### PR DESCRIPTION
- Disable free lists when building with multi-threading

This will fix the CI failure in test_misc35 regarding the free list length.

- Fix test output being suppressed when building with multi-threading and running tests in a single thread

Due to the links_env test being evaluated in terms of expected test output compared vs. a reference file, this showed up as a failure

- Run CMake CI on PRs to the multithread branch


- Run CMake CI against PR commits, instead of always running against the remote branch