### PR TITLE
Re-enable free list in misc test

### DIFF
--- a/test/tmisc.c
+++ b/test/tmisc.c
@@ -6062,7 +6062,7 @@ test_misc35(void)
     ret = H5get_free_list_sizes(&reg_size_start, &arr_size_start, &blk_size_start, &fac_size_start);
     CHECK(ret, FAIL, "H5get_free_list_sizes");
 
-#if !defined H5_NO_FREE_LISTS && !defined H5_USING_MEMCHECKER && !defined H5_HAVE_MULTITHREAD
+#if !defined H5_NO_FREE_LISTS && !defined H5_USING_MEMCHECKER
     /* All the free list values should be >0 */
     CHECK(reg_size_start, 0, "H5get_free_list_sizes");
     CHECK(arr_size_start, 0, "H5get_free_list_sizes");


### PR DESCRIPTION
The initial plan was to disable the free list on any multi-thread build, which is why the free list check was disabled here. But the check that expected the free lists to be active was never removed, causing this test to fail.

The current plan is to specifically disable free list usage in MT modules only, leaving it enabled in general. As such, this test should be allowed to use it even when building with multi-threading.