### PR TITLE
H5I assert and seg fault bug fixes

### DIFF
--- a/src/H5Iint.c
+++ b/src/H5Iint.c
@@ -270,7 +270,8 @@ H5I_init(void)
     atomic_init(&(H5I_mt_g.id_info_fl_stail), init_id_sptr);
     atomic_init(&(H5I_mt_g.id_info_fl_len), 0ULL);
     atomic_init(&(H5I_mt_g.max_desired_id_info_fl_len), H5I__MAX_DESIRED_ID_INFO_FL_LEN);
-    atomic_init(&(H5I_mt_g.num_id_info_fl_entries_reallocable), 0ULL);
+    atomic_init(&(H5I_mt_g.id_next_sn), 1ULL);
+    atomic_init(&(H5I_mt_g.id_max_realloc_sn), 0ULL);
 
     /* allocate the initial entry in the id info free list and initialize the id info free list */
     id_info_ptr = H5I__new_mt_id_info(0, 0, 0, NULL, FALSE, NULL, NULL);
@@ -278,6 +279,7 @@ H5I_init(void)
         HGOTO_ERROR(H5E_ID, H5E_CANTINIT, FAIL, "Can't initialize id info free list");
 
     atomic_store(&(id_info_ptr->on_fl), TRUE);
+    atomic_store(&(id_info_ptr->serial_num), 1ULL);
 
     id_sptr.ptr = id_info_ptr;
     id_sptr.sn = 1ULL;
@@ -285,7 +287,7 @@ H5I_init(void)
     atomic_store(&(H5I_mt_g.id_info_fl_shead), id_sptr);
     atomic_store(&(H5I_mt_g.id_info_fl_stail), id_sptr);
     atomic_store(&(H5I_mt_g.id_info_fl_len), 1ULL);
-
+    atomic_store(&(H5I_mt_g.id_next_sn), 2ULL);
 
     /* allocate the initial entry in the type info free list and initialize the type info free list */
 
@@ -293,12 +295,8 @@ H5I_init(void)
     atomic_init(&(H5I_mt_g.type_info_fl_stail), init_type_sptr);
     atomic_init(&(H5I_mt_g.type_info_fl_len), 0ULL);
     atomic_init(&(H5I_mt_g.max_desired_type_info_fl_len), H5I__MAX_DESIRED_TYPE_INFO_FL_LEN);
-#if 1
-    atomic_init(&(H5I_mt_g.num_type_info_fl_entries_reallocable), 0ULL);
-#else
-    H5I_suint64_t init_suint64 = {0ULL, 0ULL};
-    atomic_init(&(H5I_mt_g.snum_type_info_fl_entries_reallocable), init_suint64);
-#endif
+    atomic_init(&(H5I_mt_g.type_next_sn), 1ULL);
+    atomic_init(&(H5I_mt_g.type_max_realloc_sn), 0ULL);
 
     /* allocate the initial entry in the id info free list and initialize the id info free list */
     type_info_ptr = H5I__new_mt_type_info(NULL, 0);
@@ -313,6 +311,7 @@ H5I_init(void)
     atomic_store(&(type_info_ptr->lfht_cleared), TRUE);
 
     atomic_store(&(type_info_ptr->on_fl), TRUE);
+    atomic_store(&(type_info_ptr->serial_num), 1ULL);
 
     type_sptr.ptr = type_info_ptr;
     type_sptr.sn = 1ULL;
@@ -320,6 +319,7 @@ H5I_init(void)
     atomic_store(&(H5I_mt_g.type_info_fl_shead), type_sptr);
     atomic_store(&(H5I_mt_g.type_info_fl_stail), type_sptr);
     atomic_store(&(H5I_mt_g.type_info_fl_len), 1ULL);
+    atomic_store(&(H5I_mt_g.type_next_sn), 2ULL);
 
 
     /* initialize stats */
@@ -338,20 +338,24 @@ H5I_init(void)
     atomic_init(&(H5I_mt_g.num_id_info_fl_head_update_cols), 0ULL);
     atomic_init(&(H5I_mt_g.num_id_info_fl_tail_update_cols), 0ULL);
     atomic_init(&(H5I_mt_g.num_id_info_fl_append_cols), 0ULL);
-    atomic_init(&(H5I_mt_g.num_id_info_structs_marked_reallocatable), 0ULL);
     atomic_init(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty), 0ULL);
     atomic_init(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_no_reallocable_entries), 0ULL);
     atomic_init(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_empty), 0ULL);
     atomic_init(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_fl_too_small), 0ULL);
     atomic_init(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_no_reallocable_entries), 0ULL);
-    atomic_init(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_aborts), 0ULL);
-    atomic_init(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_noops), 0ULL);
-    atomic_init(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_collisions), 0ULL);
-    atomic_init(&(H5I_mt_g.num_id_info_fl_num_reallocable_updates), 0ULL);
-    atomic_init(&(H5I_mt_g.num_id_info_fl_num_reallocable_total), 0ULL);
     atomic_init(&(H5I_mt_g.H5I__discard_mt_id_info__num_calls), 0ULL);
     atomic_init(&(H5I_mt_g.H5I__new_mt_id_info__num_calls), 0ULL);
     atomic_init(&(H5I_mt_g.H5I__clear_mt_id_info_free_list__num_calls), 0ULL);
+
+    atomic_init(&(H5I_mt_g.num_id_next_sn_assigned), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_serial_num_resets), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_head_sn_is_zero), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_max_sn_update_noops), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_max_sn_update_aborts), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_max_sn_updates), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_max_sn_update_cols), 0ULL);
+    atomic_init(&(H5I_mt_g.max_id_info_fl_max_sn_update_col_delta), 0ULL);
+    atomic_init(&(H5I_mt_g.min_id_info_fl_max_sn_update_col_delta), 0ULL);
 
 
     atomic_init(&(H5I_mt_g.max_type_info_fl_len), 1ULL);
@@ -362,20 +366,24 @@ H5I_init(void)
     atomic_init(&(H5I_mt_g.num_type_info_fl_head_update_cols), 0ULL);
     atomic_init(&(H5I_mt_g.num_type_info_fl_tail_update_cols), 0ULL);
     atomic_init(&(H5I_mt_g.num_type_info_fl_append_cols), 0ULL);
-    atomic_init(&(H5I_mt_g.num_type_info_structs_marked_reallocatable), 0ULL);
     atomic_init(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty), 0ULL);
     atomic_init(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_no_reallocable_entries), 0ULL);
     atomic_init(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_empty), 0ULL);
     atomic_init(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_fl_too_small), 0ULL);
     atomic_init(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_no_reallocable_entries), 0ULL);
-    atomic_init(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_aborts), 0ULL);
-    atomic_init(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_noops), 0ULL);
-    atomic_init(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions), 0ULL);
-    atomic_init(&(H5I_mt_g.num_type_info_fl_num_reallocable_updates), 0ULL);
-    atomic_init(&(H5I_mt_g.num_type_info_fl_num_reallocable_total), 0ULL);
     atomic_init(&(H5I_mt_g.H5I__discard_mt_type_info__num_calls), 0ULL);
     atomic_init(&(H5I_mt_g.H5I__new_mt_type_info__num_calls), 0ULL);
     atomic_init(&(H5I_mt_g.H5I__clear_mt_type_info_free_list__num_calls), 0ULL);
+
+    atomic_init(&(H5I_mt_g.num_type_next_sn_assigned), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_serial_num_resets), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_head_sn_is_zero), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_max_sn_update_noops), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_max_sn_update_aborts), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_max_sn_updates), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_max_sn_update_cols), 0ULL);
+    atomic_init(&(H5I_mt_g.max_type_info_fl_max_sn_update_col_delta), 0ULL);
+    atomic_init(&(H5I_mt_g.min_type_info_fl_max_sn_update_col_delta), 0ULL);
 
 
     atomic_init(&(H5I_mt_g.H5I__mark_node__num_calls), 0ULL);
@@ -537,12 +545,14 @@ H5I_term_package(void)
 #endif /* H5I_MT_DEBUG */
 
     H5I_mt_type_info_t *type_info_ptr = NULL; /* Pointer to ID type */
-    int              i;
+    int                 i;
 
     /* Count the number of types still in use */
 
     for (i = 0; i < atomic_load(&(H5I_mt_g.next_type)); i++) {
-        if ((type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[i]))) && ! atomic_load(&(type_info_ptr->lfht_cleared))) {
+
+        if ( ( type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[i])) ) && 
+             ( ! atomic_load(&(type_info_ptr->lfht_cleared)) ) ) {
 
             in_use++;
         }
@@ -550,18 +560,17 @@ H5I_term_package(void)
 
     /* If no types are still being used then clean up */
     if (0 == in_use) {
+
         for (i = 0; i <  atomic_load(&(H5I_mt_g.next_type)); i++) {
+
             type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[i]));
+
             if (type_info_ptr) {
-                assert(atomic_load(&(type_info_ptr->lfht_cleared)));
-#if 1 /* JRM */
+
                 H5I__discard_mt_type_info(type_info_ptr);
                 type_info_ptr = NULL;
-#else /* JRM */
-                type_info_ptr                = H5MM_xfree(type_info_ptr);
-#endif /* JRM */
+
                 atomic_store(&(H5I_mt_g.type_info_array[i]), NULL);
-                in_use++;
             }
         }
 
@@ -581,6 +590,7 @@ H5I_term_package(void)
     }
 
     FUNC_LEAVE_NOAPI(in_use)
+
 } /* end H5I_term_package() */
 
 #else /* H5_HAVE_MULTITHREAD */
@@ -665,20 +675,25 @@ H5I_clear_stats(void)
     atomic_store(&(H5I_mt_g.num_id_info_fl_head_update_cols), 0ULL);
     atomic_store(&(H5I_mt_g.num_id_info_fl_tail_update_cols), 0ULL);
     atomic_store(&(H5I_mt_g.num_id_info_fl_append_cols), 0ULL);
-    atomic_store(&(H5I_mt_g.num_id_info_structs_marked_reallocatable), 0ULL);
     atomic_store(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty), 0ULL);
     atomic_store(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_no_reallocable_entries), 0ULL);
     atomic_store(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_empty), 0ULL);
     atomic_store(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_fl_too_small), 0ULL);
     atomic_store(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_no_reallocable_entries), 0ULL);
-    atomic_store(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_aborts), 0ULL);
-    atomic_store(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_noops), 0ULL);
-    atomic_store(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_collisions), 0ULL);
-    atomic_store(&(H5I_mt_g.num_id_info_fl_num_reallocable_updates), 0ULL);
-    atomic_store(&(H5I_mt_g.num_id_info_fl_num_reallocable_total), 0ULL);
     atomic_store(&(H5I_mt_g.H5I__discard_mt_id_info__num_calls), 0ULL);
     atomic_store(&(H5I_mt_g.H5I__new_mt_id_info__num_calls), 0ULL);
     atomic_store(&(H5I_mt_g.H5I__clear_mt_id_info_free_list__num_calls), 0ULL);
+
+    atomic_store(&(H5I_mt_g.num_id_next_sn_assigned), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_serial_num_resets), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_head_sn_is_zero), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_max_sn_update_noops), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_max_sn_update_aborts), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_max_sn_updates), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_max_sn_update_cols), 0ULL);
+    atomic_store(&(H5I_mt_g.max_id_info_fl_max_sn_update_col_delta), 0ULL);
+    atomic_store(&(H5I_mt_g.min_id_info_fl_max_sn_update_col_delta), 0ULL);
+
 
     atomic_store(&(H5I_mt_g.max_type_info_fl_len), 0ULL);
     atomic_store(&(H5I_mt_g.num_type_info_structs_alloced_from_heap), 0ULL);
@@ -688,20 +703,25 @@ H5I_clear_stats(void)
     atomic_store(&(H5I_mt_g.num_type_info_fl_head_update_cols), 0ULL);
     atomic_store(&(H5I_mt_g.num_type_info_fl_tail_update_cols), 0ULL);
     atomic_store(&(H5I_mt_g.num_type_info_fl_append_cols), 0ULL);
-    atomic_store(&(H5I_mt_g.num_type_info_structs_marked_reallocatable), 0ULL);
     atomic_store(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty), 0ULL);
     atomic_store(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_no_reallocable_entries), 0ULL);
     atomic_store(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_empty), 0ULL);
     atomic_store(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_fl_too_small), 0ULL);
     atomic_store(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_no_reallocable_entries), 0ULL);
-    atomic_store(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_aborts), 0ULL);
-    atomic_store(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_noops), 0ULL);
-    atomic_store(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions), 0ULL);
-    atomic_store(&(H5I_mt_g.num_type_info_fl_num_reallocable_updates), 0ULL);
-    atomic_store(&(H5I_mt_g.num_type_info_fl_num_reallocable_total), 0ULL);
     atomic_store(&(H5I_mt_g.H5I__discard_mt_type_info__num_calls), 0ULL);
     atomic_store(&(H5I_mt_g.H5I__new_mt_type_info__num_calls), 0ULL);
     atomic_store(&(H5I_mt_g.H5I__clear_mt_type_info_free_list__num_calls), 0ULL);
+
+    atomic_store(&(H5I_mt_g.num_type_next_sn_assigned), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_serial_num_resets), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_head_sn_is_zero), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_max_sn_update_noops), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_max_sn_update_aborts), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_max_sn_updates), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_max_sn_update_cols), 0ULL);
+    atomic_store(&(H5I_mt_g.max_type_info_fl_max_sn_update_col_delta), 0ULL);
+    atomic_store(&(H5I_mt_g.min_type_info_fl_max_sn_update_col_delta), 0ULL);
+
 
     atomic_store(&(H5I_mt_g.H5I__mark_node__num_calls), 0ULL);
     atomic_store(&(H5I_mt_g.H5I__mark_node__num_calls_with_global_mutex), 0ULL);
@@ -856,8 +876,6 @@ H5I_dump_stats(FILE * file_ptr)
 
     fprintf(file_ptr, "H5I_mt_g.id_info_fl_len                                                = %lld\n", 
             (unsigned long long)(atomic_load(&(H5I_mt_g.id_info_fl_len))));
-    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_entries_reallocable                            = %lld\n", 
-            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_entries_reallocable))));
     fprintf(file_ptr, "H5I_mt_g.max_id_info_fl_len                                            = %lld\n", 
             (unsigned long long)(atomic_load(&(H5I_mt_g.max_id_info_fl_len))));
     fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_alloced_from_heap                         = %lld\n", 
@@ -874,8 +892,6 @@ H5I_dump_stats(FILE * file_ptr)
             (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_tail_update_cols))));
     fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_append_cols                                    = %lld\n", 
             (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_append_cols))));
-    fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_marked_reallocatable                      = %lld\n", 
-            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_marked_reallocatable))));
     fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty                  = %lld\n", 
             (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty))));
     fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_no_reallocable_entries = %lld\n", 
@@ -888,16 +904,6 @@ H5I_dump_stats(FILE * file_ptr)
     fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_frees_skipped_due_to_no_reallocable_entries    = %lld\n", 
             (unsigned long long) 
             (atomic_load(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_no_reallocable_entries))));
-    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_num_reallocable_update_aborts                  = %lld\n", 
-            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_aborts))));
-    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_num_reallocable_update_noops                   = %lld\n", 
-            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_noops))));
-    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_num_reallocable_update_collisions              = %lld\n", 
-            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_collisions))));
-    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_num_reallocable_updates                        = %lld\n", 
-            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_updates))));
-    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_num_reallocable_total                          = %lld\n", 
-            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_total))));
     fprintf(file_ptr, "H5I_mt_g.H5I__discard_mt_id_info__num_calls                            = %lld\n", 
             (unsigned long long) (atomic_load(&(H5I_mt_g.H5I__discard_mt_id_info__num_calls))));
     fprintf(file_ptr, "H5I_mt_g.H5I__new_mt_id_info__num_calls                                = %lld\n", 
@@ -905,18 +911,28 @@ H5I_dump_stats(FILE * file_ptr)
     fprintf(file_ptr, "H5I_mt_g.H5I__clear_mt_id_info_free_list__num_calls                    = %lld\n\n", 
             (unsigned long long) (atomic_load(&(H5I_mt_g.H5I__clear_mt_id_info_free_list__num_calls))));
 
+    fprintf(file_ptr, "H5I_mt_g.num_id_next_sn_assigned                                       = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_next_sn_assigned))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_serial_num_resets                                      = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_serial_num_resets))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_head_sn_is_zero                                = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_head_sn_is_zero))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_max_sn_update_noops                            = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_update_noops))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_max_sn_update_aborts                           = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_update_aborts))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_max_sn_updates                                 = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_updates))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_max_sn_update_cols                             = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_update_cols))));
+    fprintf(file_ptr, "H5I_mt_g.max_id_info_fl_max_sn_update_col_delta                        = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.max_id_info_fl_max_sn_update_col_delta))));
+    fprintf(file_ptr, "H5I_mt_g.min_id_info_fl_max_sn_update_col_delta                        = %lld\n\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.min_id_info_fl_max_sn_update_col_delta))));
+
+
     fprintf(file_ptr, "H5I_mt_g.type_info_fl_len                                              = %lld\n", 
             (unsigned long long)(atomic_load(&(H5I_mt_g.type_info_fl_len))));
-#if 1
-    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_entries_reallocable                          = %lld\n", 
-            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_entries_reallocable))));
-#else
-    H5I_suint64_t snum_type_info_fl_entries_reallocable;
-    snum_type_info_fl_entries_reallocable = atomic_load(&(H5I_mt_g.snum_type_info_fl_entries_reallocable));
-    fprintf(file_ptr, "H5I_mt_g.snum_type_info_fl_entries_reallocable                         = (%lld, %lld)\n", 
-            (unsigned long long)snum_type_info_fl_entries_reallocable.val,
-            (unsigned long long)snum_type_info_fl_entries_reallocable.sn);
-#endif
     fprintf(file_ptr, "H5I_mt_g.max_type_info_fl_len                                          = %lld\n", 
             (unsigned long long)(atomic_load(&(H5I_mt_g.max_type_info_fl_len))));
     fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_alloced_from_heap                       = %lld\n", 
@@ -933,8 +949,6 @@ H5I_dump_stats(FILE * file_ptr)
             (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_tail_update_cols))));
     fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_append_cols                                  = %lld\n", 
             (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_append_cols))));
-    fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_marked_reallocatable                    = %lld\n", 
-            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_marked_reallocatable))));
     fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty                = %lld\n", 
             (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty))));
     fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_no_reallocable_entries = %lld\n", 
@@ -947,22 +961,33 @@ H5I_dump_stats(FILE * file_ptr)
     fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_frees_skipped_due_to_no_reallocable_entries  = %lld\n", 
             (unsigned long long)
             (atomic_load(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_no_reallocable_entries))));
-    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_num_reallocable_update_aborts                = %lld\n", 
-            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_aborts))));
-    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_num_reallocable_update_noops                 = %lld\n", 
-            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_noops))));
-    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions            = %lld\n", 
-            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions))));
-    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_num_reallocable_updates                      = %lld\n", 
-            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_updates))));
-    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_num_reallocable_total                        = %lld\n", 
-            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_total))));
     fprintf(file_ptr, "H5I_mt_g.H5I__discard_type_id_info__num_calls                          = %lld\n", 
             (unsigned long long) (atomic_load(&(H5I_mt_g.H5I__discard_mt_type_info__num_calls))));
     fprintf(file_ptr, "H5I_mt_g.H5I__new_mt_type_info__num_calls                              = %lld\n", 
             (unsigned long long) (atomic_load(&(H5I_mt_g.H5I__new_mt_type_info__num_calls))));
     fprintf(file_ptr, "H5I_mt_g.H5I__clear_mt_type_info_free_list__num_calls                  = %lld\n\n", 
             (unsigned long long) (atomic_load(&(H5I_mt_g.H5I__clear_mt_type_info_free_list__num_calls))));
+
+    fprintf(file_ptr, "H5I_mt_g.num_type_next_sn_assigned                                     = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_next_sn_assigned))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_serial_num_resets                                    = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_serial_num_resets))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_head_sn_is_zero                              = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_head_sn_is_zero))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_max_sn_update_noops                          = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_update_noops))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_max_sn_update_aborts                         = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_update_aborts))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_max_sn_updates                               = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_updates))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_max_sn_update_cols                           = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_update_cols))));
+    fprintf(file_ptr, "H5I_mt_g.max_type_info_fl_max_sn_update_col_delta                      = %lld\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.max_type_info_fl_max_sn_update_col_delta))));
+    fprintf(file_ptr, "H5I_mt_g.min_type_info_fl_max_sn_update_col_delta                      = %lld\n\n", 
+            (unsigned long long) (atomic_load(&(H5I_mt_g.min_type_info_fl_max_sn_update_col_delta))));
+
+
 
     fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__num_calls                                     = %lld\n", 
             (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__num_calls))));
@@ -1279,10 +1304,6 @@ H5I_dump_nz_stats(FILE * file_ptr, const char * tag)
         fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_append_cols                                    = %lld\n", 
                 (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_append_cols))));
 
-    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_marked_reallocatable))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_marked_reallocatable                      = %lld\n", 
-                (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_marked_reallocatable))));
-
     if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty))) > 0ULL )
         fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty                  = %lld\n", 
                 (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty))));
@@ -1307,31 +1328,6 @@ H5I_dump_nz_stats(FILE * file_ptr, const char * tag)
                 (unsigned long long)
                 (atomic_load(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_no_reallocable_entries))));
 
-    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_aborts))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_num_reallocable_update_aborts                  = %lld\n", 
-                (unsigned long long)
-                (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_aborts))));
-
-    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_noops))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_num_reallocable_update_noops                   = %lld\n", 
-                (unsigned long long)
-                (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_noops))));
-
-    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_collisions))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_num_reallocable_update_collisions              = %lld\n", 
-                (unsigned long long)
-                (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_collisions))));
-
-    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_updates))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_num_reallocable_updates                        = %lld\n", 
-                (unsigned long long)
-                (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_updates))));
-
-    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_total))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_num_reallocable_total                          = %lld\n", 
-                (unsigned long long)
-                (atomic_load(&(H5I_mt_g.num_id_info_fl_num_reallocable_total))));
-
     if ( (unsigned long long) (atomic_load(&(H5I_mt_g.H5I__discard_mt_id_info__num_calls))) > 0ULL )
         fprintf(file_ptr, "H5I_mt_g.H5I__discard_mt_id_info__num_calls                            = %lld\n", 
                 (unsigned long long)
@@ -1346,6 +1342,51 @@ H5I_dump_nz_stats(FILE * file_ptr, const char * tag)
         fprintf(file_ptr, "H5I_mt_g.H5I__clear_mt_id_info_free_list__num_calls                    = %lld\n", 
                 (unsigned long long)
                 (atomic_load(&(H5I_mt_g.H5I__clear_mt_id_info_free_list__num_calls))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_next_sn_assigned))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_next_sn_assigned                                       = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_id_next_sn_assigned))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_serial_num_resets))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_serial_num_resets                                      = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_id_serial_num_resets))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_head_sn_is_zero))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_head_sn_is_zero                                = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_id_info_fl_head_sn_is_zero))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_update_noops))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_max_sn_update_noops                            = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_update_noops))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_update_aborts))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_max_sn_update_aborts                           = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_update_aborts))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_updates))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_max_sn_updates                                 = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_updates))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_update_cols))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_max_sn_update_cols                             = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_id_info_fl_max_sn_update_cols))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.max_id_info_fl_max_sn_update_col_delta))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.max_id_info_fl_max_sn_update_col_delta                        = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.max_id_info_fl_max_sn_update_col_delta))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.min_id_info_fl_max_sn_update_col_delta))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.min_id_info_fl_max_sn_update_col_delta                        = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.min_id_info_fl_max_sn_update_col_delta))));
 
 
     /* type info free list stats */
@@ -1382,10 +1423,6 @@ H5I_dump_nz_stats(FILE * file_ptr, const char * tag)
         fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_append_cols                                  = %lld\n", 
                 (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_append_cols))));
 
-    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_marked_reallocatable))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_marked_reallocatable                    = %lld\n", 
-                (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_marked_reallocatable))));
-
     if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty))) > 0ULL )
         fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty                = %lld\n", 
                 (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty))));
@@ -1410,31 +1447,6 @@ H5I_dump_nz_stats(FILE * file_ptr, const char * tag)
                 (unsigned long long)
                 (atomic_load(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_no_reallocable_entries))));
 
-    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_aborts))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_num_reallocable_update_aborts                = %lld\n", 
-                (unsigned long long)
-                (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_aborts))));
-
-    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_noops))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_num_reallocable_update_noops                 = %lld\n", 
-                (unsigned long long)
-                (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_noops))));
-
-    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions            = %lld\n", 
-                (unsigned long long)
-                (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions))));
-
-    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_updates))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_num_reallocable_updates                      = %lld\n", 
-                (unsigned long long)
-                (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_updates))));
-
-    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_total))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_num_reallocable_total                        = %lld\n", 
-                (unsigned long long)
-                (atomic_load(&(H5I_mt_g.num_type_info_fl_num_reallocable_total))));
-
     if ( (unsigned long long) (atomic_load(&(H5I_mt_g.H5I__discard_mt_type_info__num_calls))) > 0ULL )
         fprintf(file_ptr, "H5I_mt_g.H5I__discard_mt_type_info__num_calls                          = %lld\n", 
                 (unsigned long long)
@@ -1449,6 +1461,52 @@ H5I_dump_nz_stats(FILE * file_ptr, const char * tag)
         fprintf(file_ptr, "H5I_mt_g.H5I__clear_mt_type_info_free_list__num_calls                  = %lld\n", 
                 (unsigned long long)
                 (atomic_load(&(H5I_mt_g.H5I__clear_mt_type_info_free_list__num_calls))));
+
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_next_sn_assigned))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_next_sn_assigned                                       = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_type_next_sn_assigned))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_serial_num_resets))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_serial_num_resets                                      = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_type_serial_num_resets))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_head_sn_is_zero))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_head_sn_is_zero                                = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_type_info_fl_head_sn_is_zero))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_update_noops))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_max_sn_update_noops                            = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_update_noops))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_update_aborts))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_max_sn_update_aborts                           = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_update_aborts))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_updates))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_max_sn_updates                                 = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_updates))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_update_cols))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_max_sn_update_cols                             = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_type_info_fl_max_sn_update_cols))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.max_type_info_fl_max_sn_update_col_delta))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.max_type_info_fl_max_sn_update_col_delta                        = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.max_type_info_fl_max_sn_update_col_delta))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.min_type_info_fl_max_sn_update_col_delta))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.min_type_info_fl_max_sn_update_col_delta                        = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.min_type_info_fl_max_sn_update_col_delta))));
 
 
 
@@ -2036,14 +2094,14 @@ H5I_register_type_internal(const H5I_class_t *cls)
 
             atomic_fetch_sub(&(type_info_ptr->init_count), 1);
 
+            /* since the type info was never installed in H5I_mt_g.type_info_array[], it can't 
+             * have any IDs -- which makes it safe to discard the lock free hash table now.
+             */
             lfht_clear(&(type_info_ptr->lfht));
             atomic_store(&(type_info_ptr->lfht_cleared), TRUE);
-#if 1
+
             result = H5I__discard_mt_type_info(type_info_ptr);
             assert(result >= 0);
-#else 
-            H5MM_free(type_info_ptr);
-#endif
 
             /* If I read the specs on atomic_compare_exchange_strong() correctly, expected_ptr should 
              * equal H5I_mt_g.type_info_array[cls->type] at this point.  Verify this.
@@ -3303,15 +3361,19 @@ H5I__destroy_type(H5I_type_t type)
     }
     H5E_END_TRY /* don't care about errors */
 
-    /* Check if we should release the ID class */
-    if (type_info_ptr->cls->flags & H5I_CLASS_IS_APPLICATION)
-        type_info_ptr->cls = H5MM_xfree_const(type_info_ptr->cls);
+    /* set type_info_ptr->init_count to zero, remove if from H5I_mt_g.type_info_array,
+     * mark the appropriate entry in H5I_mt_g.type_info_allocation_table as available,
+     * and discard the instance of H5I_mt_type_info_t to the free list.
+     *
+     * Note that we do not take down the lock free hash table or (possibly) discard 
+     * type_info->cls until we know that the instance of H5I_mt_type_info_t is 
+     * available for re-allocation or return to the heap.  Must do this since it is 
+     * possible that another thread is acting on an id in the type.  While this 
+     * operation will fail, if we fully take down the type info, this may result 
+     * in a seg fault instead of a graceful failure.
+     */
 
     atomic_store(&(type_info_ptr->init_count), 0);
-
-    lfht_clear(&(type_info_ptr->lfht));
-
-    atomic_store(&(type_info_ptr->lfht_cleared), TRUE);
 
     result = atomic_compare_exchange_strong(&(H5I_mt_g.type_info_array[type]), &type_info_ptr, NULL);
     assert(result);
@@ -5132,10 +5194,6 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
 #if H5I_MT_DEBUG
     fprintf(stdout, "   H5I__dec_ref(0x%llx, reguest, app) called. \n", (unsigned long long)id);
 #endif /* H5I_MT_DEBUG */
-#if 0 /* JRM */
-    if (id == 0x1300000000000000 )
-        fprintf(stderr, "   H5I__dec_ref(0x%llx, reguest, app) entering. \n", (unsigned long long)id);
-#endif /* JRM */
 
     atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__num_calls), 1ULL);
 
@@ -5264,7 +5322,7 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
                 assert( NULL == type_info_ptr->cls->free_func );
 
                 /* id_info_ptr->k.count is about to drop to zero, and as a result, the 
-                 * the ID and *id_info_ptr are about to be removed from the idex at least
+                 * the ID and *id_info_ptr are about to be removed from the index at least
                  * logically, and probably physically as well.  Since the free function 
                  * is undefined, all we need to do is setup mod_info_k accordingly and 
                  * try to replace id_info_ptr->k with mod_info_k.
@@ -5373,7 +5431,7 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
              * Since we can't roll this action back, we need exclusive access to the 
              * kernel of the instance of H5I_mt_id_info_t associated with the ID.
              *
-             * To get this, try to set the do_not_disturb flag in the kernl.   If 
+             * To get this, try to set the do_not_disturb flag in the kernel.  If 
              * successful, this will prevent any other threads from modifying
              * id_info_ptr->k until after it is set back to FALSE.
              */
@@ -8384,7 +8442,7 @@ H5I__find_id_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
     if ( ! info_k.marked ) {
 
         /* Get a pointer to the VOL connector's data */
-#if 0 
+#if 0  /* delete this eventually */
         H5_GCC_CLANG_DIAG_OFF("cast-qual")
         object = H5I__unwrap((void *)info_k.object, type); /* will hit global mutex */
         H5_GCC_CLANG_DIAG_ON("cast-qual")
@@ -8605,7 +8663,7 @@ done:
  *
  *     Note that this function assumes that no other threads are active 
  *     in H5I, and that it is therefore safe to ignore 
- *     H5I_mt_g.num_id_info_fl_entries_reallocable. 
+ *     H5I_mt_g.id_max_realloc_sn and H5I_mt_g.type_max_realloc_sn. 
  *
  *                                          JRM -- 10/24/23
  *
@@ -8654,6 +8712,7 @@ H5I__clear_mt_id_info_free_list(void)
         test_val = atomic_fetch_sub(&(H5I_mt_g.id_info_fl_len), 1ULL);
         assert( test_val > 0ULL);
     }
+
     atomic_store(&(H5I_mt_g.id_info_fl_shead), null_snext);
     atomic_store(&(H5I_mt_g.id_info_fl_stail), null_snext);
 
@@ -8663,7 +8722,6 @@ done:
 
 } /* H5I__clear_mt_id_info_free_list() */
 
-#if 0 /* old version */
 
 /************************************************************************
  *
@@ -8676,161 +8734,6 @@ done:
  *     H5I_mt_t.max_desired_id_info_fl_len, attempt the remove the node 
  *     at the head of the id info free list from the free list, and 
  *     discard it and decrement lfht_ptr->fl_len if successful.
- *     ---- skip for now ---
- *
- *                                          JRM -- 9/1/23
- *
- ************************************************************************/
-
-static herr_t 
-H5I__discard_mt_id_info(H5I_mt_id_info_t * id_info_ptr)
-{
-    hbool_t done = FALSE;
-    hbool_t on_fl = FALSE;
-    hbool_t result;
-    uint64_t fl_len;
-    uint64_t max_fl_len;
-    H5I_mt_id_info_sptr_t snext = {NULL, 0ULL};
-    H5I_mt_id_info_sptr_t new_snext;
-    H5I_mt_id_info_sptr_t fl_stail;
-    H5I_mt_id_info_sptr_t fl_snext;
-    H5I_mt_id_info_sptr_t new_fl_snext;
-    H5I_mt_id_info_sptr_t new_fl_stail;
-    H5I_mt_id_info_sptr_t test_fl_stail;
-    H5I_mt_id_info_kernel_t info_k;
-    herr_t ret_value = SUCCEED; /* Return value */
-
-    FUNC_ENTER_NOAPI_NOERR
-
-    assert(id_info_ptr);
-    assert(H5I__ID_INFO == id_info_ptr->tag);
-
-    info_k = atomic_load(&(id_info_ptr->k));
-
-    assert(0 == info_k.count);
-    assert(0 == info_k.app_count);
-    assert(NULL == info_k.object);
-    assert(TRUE == info_k.marked);
-    assert(FALSE == info_k.do_not_disturb);
-    assert(FALSE == info_k.is_future);
-    assert(FALSE == info_k.have_global_mutex);
-
-    assert(!atomic_load(&(id_info_ptr->on_fl)));
-    assert(!atomic_load(&(id_info_ptr->re_allocable)));
-
-    snext = atomic_load(&(id_info_ptr->fl_snext));
-    new_snext.ptr = NULL;
-    new_snext.sn = snext.sn + 1;
-
-    atomic_store(&(id_info_ptr->fl_snext), new_snext);
-
-    result = atomic_compare_exchange_strong(&(id_info_ptr->on_fl), &on_fl, TRUE);
-    assert( result );
-
-#if 1 /* JRM */
-    result = atomic_compare_exchange_strong(&(id_info_ptr->re_allocable), &on_fl, TRUE);
-    assert( result );
-#endif /* JRM */
-
-    while ( ! done ) {
-
-        fl_stail = atomic_load(&(H5I_mt_g.id_info_fl_stail));
-
-        assert(fl_stail.ptr);
-
-        /* it is possible that *fl_tail.ptr has passed through the free list
-         * and been re-allocated between the time we loaded it, and now.
-         * If so, fl_stail_ptr->on_fl will no longer be TRUE.
-         * This isn't a problem, but if so, the following if statement will fail.
-         */
-        // assert(atomic_load(&(fl_stail.ptr->on_fl)));
-
-        fl_snext = atomic_load(&(fl_stail.ptr->fl_snext));
-
-        test_fl_stail = atomic_load(&(H5I_mt_g.id_info_fl_stail));
-
-        if ( ( test_fl_stail.ptr == fl_stail.ptr ) && ( test_fl_stail.sn == fl_stail.sn ) ) {
-
-            if ( NULL == fl_snext.ptr ) {
-
-                /* attempt to append id_info_ptr by setting fl_tail->fl_snext.ptr to id_info_ptr.
-                 * If this succeeds, update stats and attempt to set H5I_mt_g.id_info_fl_stail.ptr
-                 * to id_info_ptr as well.  This may or may not succeed, but in either
-                 * case we are done.
-                 */
-                new_fl_snext.ptr = id_info_ptr;
-                new_fl_snext.sn  = fl_snext.sn + 1;
-                if ( atomic_compare_exchange_strong(&(fl_stail.ptr->fl_snext), &fl_snext, new_fl_snext) ) {
-
-                    atomic_fetch_add(&(H5I_mt_g.id_info_fl_len), 1);
-                    atomic_fetch_add(&(H5I_mt_g.num_id_info_structs_added_to_fl), 1);
-
-                    new_fl_stail.ptr = id_info_ptr;
-                    new_fl_stail.sn  = fl_stail.sn + 1;
-                    if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_stail), 
-                                                          &fl_stail, new_fl_stail) ) {
-
-                        atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_head_update_cols), 1);
-                    }
-
-                    /* if appropriate, attempt to update H5I_mt_g.max_id_info_fl_len.  In the
-                     * event of a collision, just ignore it and go on, as I don't see any
-                     * reasonable way to recover.
-                     */
-                    if ( (fl_len = atomic_load(&(H5I_mt_g.id_info_fl_len))) >
-                         (max_fl_len = atomic_load(&(H5I_mt_g.max_id_info_fl_len))) ) {
-
-                        atomic_compare_exchange_strong(&(H5I_mt_g.max_id_info_fl_len), &max_fl_len, fl_len);
-                    }
-
-                    done = true;
-
-                } else {
-
-                    /* append failed -- update stats and try again */
-                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_append_cols), 1);
-
-                }
-            } else {
-
-                // assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_next->tag)));
-
-                /* attempt to set lfht_ptr->fl_stail to fl_next.  It doesn't
-                 * matter whether we succeed or fail, as if we fail, it
-                 * just means that some other thread beat us to it.
-                 *
-                 * that said, it doesn't hurt to collect stats
-                 */
-                new_fl_stail.ptr = fl_snext.ptr;
-                new_fl_stail.sn  = fl_stail.sn + 1;
-                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_stail), &fl_stail, new_fl_stail) ) {
-
-                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_tail_update_cols), 1);
-                }
-            }
-        }
-    }
-
-    /* don't implement frees for now -- may deal with this in H5I_mt_enter/exit() */
-
-    FUNC_LEAVE_NOAPI(ret_value)
-
-} /* H5I__discard_mt_id_info() */
-
-#else /* new version */
-
-/************************************************************************
- *
- * H5I__discard_mt_id_info
- *
- *     Append the supplied instance of H5I_mt_id_info_t on the id info
- *     free list and increment H5I_mt_t.id_info_fl_len.
- *
- *     If the free list length exceeds 
- *     H5I_mt_t.max_desired_id_info_fl_len, attempt the remove the node 
- *     at the head of the id info free list from the free list, and 
- *     discard it and decrement lfht_ptr->fl_len if successful.
- *     ---- skip for now ---
  *
  *                                          JRM -- 9/1/23
  *
@@ -8842,7 +8745,6 @@ H5I__discard_mt_id_info(H5I_mt_id_info_t * id_info_ptr)
     hbool_t done = FALSE;
     hbool_t on_fl = FALSE;
     hbool_t try_to_free_an_entry = FALSE;
-    hbool_t reallocable_entry_available = FALSE;
     hbool_t result;
     uint64_t fl_len;
     uint64_t max_fl_len;
@@ -8878,6 +8780,7 @@ H5I__discard_mt_id_info(H5I_mt_id_info_t * id_info_ptr)
     assert(FALSE == info_k.have_global_mutex);
 
     assert(!atomic_load(&(id_info_ptr->on_fl)));
+    assert(0 == atomic_load(&(id_info_ptr->serial_num)));
 
     snext = atomic_load(&(id_info_ptr->fl_snext));
     new_snext.ptr = NULL;
@@ -8888,19 +8791,16 @@ H5I__discard_mt_id_info(H5I_mt_id_info_t * id_info_ptr)
     result = atomic_compare_exchange_strong(&(id_info_ptr->on_fl), &on_fl, TRUE);
     assert( result );
 
+    atomic_store(&(id_info_ptr->serial_num), atomic_fetch_add(&(H5I_mt_g.id_next_sn), 1ULL));
+
+    /* update stats */
+    atomic_fetch_add(&(H5I_mt_g.num_id_next_sn_assigned), 1ULL);
 
     while ( ! done ) {
 
         fl_stail = atomic_load(&(H5I_mt_g.id_info_fl_stail));
 
         assert(fl_stail.ptr);
-
-        /* it is possible that *fl_tail.ptr has passed through the free list
-         * and been re-allocated between the time we loaded it, and now.
-         * If so, fl_stail_ptr->on_fl will no longer be TRUE.
-         * This isn't a problem, but if so, the following if statement will fail.
-         */
-        // assert(atomic_load(&(fl_stail.ptr->on_fl)));
 
         fl_snext = atomic_load(&(fl_stail.ptr->fl_snext));
 
@@ -8950,8 +8850,6 @@ H5I__discard_mt_id_info(H5I_mt_id_info_t * id_info_ptr)
                 }
             } else {
 
-                // assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_next->tag)));
-
                 /* attempt to set lfht_ptr->fl_stail to fl_next.  It doesn't
                  * matter whether we succeed or fail, as if we fail, it
                  * just means that some other thread beat us to it.
@@ -8968,17 +8866,16 @@ H5I__discard_mt_id_info(H5I_mt_id_info_t * id_info_ptr)
         }
     }
 
-    /* test to see if both H5I_mt_g.id_info_fl_len and H5I_mt_g.num_id_info_fl_entries_reallocable 
-     * are greater than H5I_mt_g.max_desired_id_info_fl_len.  Check both, as while we want to 
-     * keep the free list length around H5I_mt_g.max_desired_id_info_fl_len, we also want to 
-     * have an ample supply of reallocable free list entries on hand.
+    /* Test to see if H5I_mt_g.id_info_fl_len is greater than H5I_mt_g.max_desired_id_info_fl_len.
+     *
+     * Note that this doesn't mean that there is a entry available for discard -- we will check this 
+     * later.
      */
-    assert(atomic_load(&(H5I_mt_g.num_id_info_fl_entries_reallocable)) <= 
-           atomic_load(&(H5I_mt_g.id_info_fl_len)));
 
-    if ( ( atomic_load(&(H5I_mt_g.id_info_fl_len)) > atomic_load(&(H5I_mt_g.max_desired_id_info_fl_len)) ) &&
-         ( atomic_load(&(H5I_mt_g.num_id_info_fl_entries_reallocable)) > 
-           atomic_load(&(H5I_mt_g.max_desired_id_info_fl_len)) ) ) {
+    /* must rework this assert for the possibility that these fields will wrap around */
+    assert(atomic_load(&(H5I_mt_g.id_max_realloc_sn)) <= atomic_load(&(H5I_mt_g.id_next_sn)));
+
+    if ( atomic_load(&(H5I_mt_g.id_info_fl_len)) > atomic_load(&(H5I_mt_g.max_desired_id_info_fl_len)) ) {
 
         try_to_free_an_entry = TRUE;
 
@@ -8989,139 +8886,142 @@ H5I__discard_mt_id_info(H5I_mt_id_info_t * id_info_ptr)
 
     if ( try_to_free_an_entry ) {
 
-        uint64_t num_fl_entries_reallocable;
+        uint64_t serial_num;
 
-        /* While a reallocable entry is almost certainly available, there
-         * is the possibility that other threads have snapped up all 
-         * the reallocable entries in the time since we determined that 
-         * we should try to free an entry.  Hence the following:
-         */
-        while ( ( ! reallocable_entry_available ) &&
-                ( 0 < (num_fl_entries_reallocable = atomic_load(&(H5I_mt_g.num_id_info_fl_entries_reallocable))) ) ) {
+        done = FALSE;
 
-            assert( 0 < num_fl_entries_reallocable );
+        while ( ! done ) {
 
-            if ( atomic_compare_exchange_strong(&(H5I_mt_g.num_id_info_fl_entries_reallocable),
-                                                &num_fl_entries_reallocable, (num_fl_entries_reallocable - 1)) ) {
+            fl_shead = atomic_load(&(H5I_mt_g.id_info_fl_shead));
+            fl_stail = atomic_load(&(H5I_mt_g.id_info_fl_stail));
 
-                reallocable_entry_available = TRUE;
+            assert(fl_shead.ptr);
+            assert(fl_stail.ptr);
 
-            } else {
+            fl_snext = atomic_load(&(fl_shead.ptr->fl_snext));
 
-                /* update stats */
-                atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_collisions), 1ULL);
-            }
-        } /* end while */
+            test_fl_shead = atomic_load(&(H5I_mt_g.id_info_fl_shead));
 
-        if ( ! reallocable_entry_available ) {
+            if ( ( test_fl_shead.ptr == fl_shead.ptr ) && ( test_fl_shead.sn == fl_shead.sn ) ) {
 
-            /* No reallocable entries available -- just update stats and quit */
+                if ( fl_shead.ptr == fl_stail.ptr ) {
 
-            atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_no_reallocable_entries), 1ULL);
+                    if ( NULL == fl_snext.ptr ) {
 
-        } else {
+                        /* the free list is empty */
+                        atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_empty), 1);
+                        done = TRUE;
+                        break;
+                    }
 
-            done = FALSE;
+                    /* attempt to set H5I_mt_g.id_info_fl_stail to fl_snext.  It doesn't
+                     * matter whether we succeed or fail, as if we fail, it
+                     * just means that some other thread beat us to it.
+                     *
+                     * that said, it doesn't hurt to collect stats
+                     */
+                    assert(fl_snext.ptr);
+                    new_fl_stail.ptr = fl_snext.ptr;
+                    new_fl_stail.sn  = fl_stail.sn + 1;
+                    if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_stail), &fl_stail, 
+                                                          new_fl_stail) ) {
 
-            while ( ! done ) {
+                        atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_tail_update_cols), 1ULL);
+                    }
+                } else if ( ( 0 < (serial_num = atomic_load(&(fl_shead.ptr->serial_num))) ) &&
+                            ( serial_num >= atomic_load(&(H5I_mt_g.id_max_realloc_sn)) ) ) {
 
-                fl_shead = atomic_load(&(H5I_mt_g.id_info_fl_shead));
-                fl_stail = atomic_load(&(H5I_mt_g.id_info_fl_stail));
+                    /* if serial_num is zero, it should have already been removed from the free
+                     * list by another thread -- if so, the following attempt to remove if from
+                     * the free list will fail.  If this is not the case, we will catch the error
+                     * after we successfully remove the entry.
+                     */
 
-                assert(fl_shead.ptr);
-                assert(fl_stail.ptr);
+                    /* No reallocable entries available -- just update stats and quit */
+                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_no_reallocable_entries), 1ULL);
+                    done = TRUE; 
 
-                fl_snext = atomic_load(&(fl_shead.ptr->fl_snext));
+                } else {
 
-                test_fl_shead = atomic_load(&(H5I_mt_g.id_info_fl_shead));
+                    /* set up new_fl_shead */
+                    assert(fl_snext.ptr);
+                    new_fl_shead.ptr = fl_snext.ptr;
+                    new_fl_shead.sn  = fl_shead.sn + 1;
 
-                if ( ( test_fl_shead.ptr == fl_shead.ptr ) && ( test_fl_shead.sn == fl_shead.sn ) ) {
+                    if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_shead), 
+                                                          &fl_shead, new_fl_shead) ) {
 
-                    if ( fl_shead.ptr == fl_stail.ptr ) {
-
-                        if ( NULL == fl_snext.ptr ) {
-
-                            /* the free list is empty */
-                            atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_empty), 1);
-                            done = TRUE;
-                            break;
-                        }
-
-                        /* attempt to set H5I_mt_g.id_info_fl_stail to fl_snext.  It doesn't
-                         * matter whether we succeed or fail, as if we fail, it
-                         * just means that some other thread beat us to it.
-                         *
-                         * that said, it doesn't hurt to collect stats
+                        /* the attempt to remove the first item from the free list
+                         * failed.  Update stats and try again.
                          */
-                        new_fl_stail.ptr = fl_snext.ptr;
-                        new_fl_stail.sn  = fl_stail.sn + 1;
-                        if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_stail), &fl_stail, 
-                                                              new_fl_stail) ) {
+                        atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_head_update_cols), 1ULL);
 
-                            atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_tail_update_cols), 1ULL);
-                        }
                     } else {
 
-                        /* set up new_fl_shead */
-                        assert(fl_snext.ptr);
-                        new_fl_shead.ptr = fl_snext.ptr;
-                        new_fl_shead.sn  = fl_shead.sn + 1;
+                        H5I_mt_id_info_sptr_t null_snext = {NULL, 0ULL};
 
-                        if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_shead), 
-                                                              &fl_shead, new_fl_shead) ) {
+                        /* first has been removed from the free list.  Set id_info_ptr to fl_shead.ptr,
+                         * discard *id_info_ptr, update stats, and exit the loop by setting done to true.
+                         */
+                        id_info_ptr = fl_shead.ptr;
 
-                            /* the attempt to remove the first item from the free list
-                             * failed.  Update stats and try again.
-                             */
-                            atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_head_update_cols), 1ULL);
+                        assert(H5I__ID_INFO == id_info_ptr->tag);
+                        assert(atomic_load(&(id_info_ptr->on_fl)));
+                        assert(0 < atomic_load(&(id_info_ptr->serial_num)));
 
-                        } else {
+                        /* the above assert only exists in production builds.  If id_info_ptr->serial_num
+                         * is zero and we get this far, increment H5I_mt_g.num_id_info_fl_head_sn_is_zero.
+                         */
+                        if ( 0 == atomic_load(&(id_info_ptr->serial_num)) ) {
 
-                            H5I_mt_id_info_sptr_t null_snext = {NULL, 0ULL};
+                            atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_head_sn_is_zero), 1ULL);
 
-                            /* first has been removed from the free list.  Set id_info_ptr to fl_shead.ptr,
-                             * discard *id_info_ptr, update stats, and exit the loop by setting done to true.
-                             */
-                            id_info_ptr = fl_shead.ptr;
-
-                            assert(H5I__ID_INFO == id_info_ptr->tag);
-                            assert(id_info_ptr->on_fl);
-
-                            info_k = atomic_load(&(id_info_ptr->k));
-
-                            assert(0 == info_k.count);
-                            assert(0 == info_k.app_count);
-                            assert(NULL == info_k.object);
-
-                            /* prepare *if_info_ptr for discard */
-                            id_info_ptr->tag = H5I__ID_INFO_INVALID;
-                            id_info_ptr->id  = (hid_t)0;
-                            atomic_store(&(id_info_ptr->fl_snext), null_snext);
-                            id_info_ptr->realize_cb = NULL;
-                            id_info_ptr->discard_cb = NULL;
-
-                            free(id_info_ptr);
-
-                            /* update stats */
-                            atomic_fetch_add(&(H5I_mt_g.num_id_info_structs_freed), 1ULL);
-                            test_val = atomic_fetch_sub(&(H5I_mt_g.id_info_fl_len), 1ULL);
-                            assert( test_val > 0ULL);
-
-                            done = true;
+                            /* should we throw an error here? */
                         }
+
+                        /* Note that we don't check to see if id_info_ptr->serial_num < 
+                         * H5I_mt_g.id_max_realloc_sn.  This was already checked above.  
+                         * Further, the algorithm for maintaining H5I_mt_g.id_max_realloc_sn
+                         * allows its value to bounce around a bit -- making it possible that 
+                         * we would get a false assertion failure.
+                         */
+
+                        atomic_store(&(id_info_ptr->serial_num), 0ULL);
+
+                        info_k = atomic_load(&(id_info_ptr->k));
+
+                        assert(0 == info_k.count);
+                        assert(0 == info_k.app_count);
+                        assert(NULL == info_k.object);
+
+                        /* prepare *if_info_ptr for discard */
+                        id_info_ptr->tag = H5I__ID_INFO_INVALID;
+                        id_info_ptr->id  = (hid_t)0;
+                        atomic_store(&(id_info_ptr->fl_snext), null_snext);
+                        id_info_ptr->realize_cb = NULL;
+                        id_info_ptr->discard_cb = NULL;
+
+                        free(id_info_ptr);
+
+                        /* update stats */
+                        atomic_fetch_add(&(H5I_mt_g.num_id_info_structs_freed), 1ULL);
+
+                        test_val = atomic_fetch_sub(&(H5I_mt_g.id_info_fl_len), 1ULL);
+                        assert( test_val > 0ULL);
+
+                        atomic_fetch_add(&(H5I_mt_g.num_id_serial_num_resets), 1ULL);
+
+                        done = true;
                     }
                 }
-            } /* while ( ! done ) */
-        }
+            }
+        } /* while ( ! done ) */
     } /* if ( try_to_free_entry ) */
 
     FUNC_LEAVE_NOAPI(ret_value)
 
 } /* H5I__discard_mt_id_info() */
 
-#endif /* new version */
-
-#if 0 /* old version */
 
 /************************************************************************
  *
@@ -9149,201 +9049,11 @@ H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * o
     hbool_t fl_search_done = FALSE;;
     hbool_t result;
     H5I_mt_id_info_t * id_info_ptr = NULL;
-    H5I_mt_id_info_sptr_t sfirst;
-    H5I_mt_id_info_sptr_t new_sfirst;
-    H5I_mt_id_info_sptr_t test_sfirst;
-    H5I_mt_id_info_sptr_t slast;
-    H5I_mt_id_info_sptr_t new_slast;
-    H5I_mt_id_info_sptr_t snext;
-    H5I_mt_id_info_sptr_t new_snext;
-    H5I_mt_id_info_kernel_t new_k = {count, app_count, object, FALSE, FALSE, is_future, FALSE};
-    H5I_mt_id_info_kernel_t old_k;
-    H5I_mt_id_info_t * ret_value = NULL; /* Return value */
-
-    FUNC_ENTER_NOAPI(NULL)
-
-    sfirst = atomic_load(&(H5I_mt_g.id_info_fl_shead));
-
-    if ( NULL == sfirst.ptr ) {
-
-        /* free list is not yet initialized */
-        fl_search_done = TRUE;
-    }
-
-    while ( ! fl_search_done ) {
-
-        sfirst = atomic_load(&(H5I_mt_g.id_info_fl_shead));
-        slast = atomic_load(&(H5I_mt_g.id_info_fl_stail));
-
-        assert(sfirst.ptr);
-        assert(slast.ptr);
-
-        snext = atomic_load(&(sfirst.ptr->fl_snext));
-
-        test_sfirst = atomic_load(&(H5I_mt_g.id_info_fl_shead));
-
-        if ( ( test_sfirst.ptr == sfirst.ptr ) && ( test_sfirst.sn == sfirst.sn ) ) {
-
-            if ( sfirst.ptr == slast.ptr ) {
-
-                if ( NULL == snext.ptr ) {
-
-                    /* the free list is empty */
-                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty), 1);
-                    fl_search_done = TRUE;
-                    break;
-                }
-
-                /* attempt to set H5I_mt_g.id_info_fl_stail to snext.  It doesn't
-                 * matter whether we succeed or fail, as if we fail, it
-                 * just means that some other thread beat us to it.
-                 *
-                 * that said, it doesn't hurt to collect stats
-                 */
-                new_slast.ptr = snext.ptr;
-                new_slast.sn  = slast.sn + 1;
-                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_stail), &slast, new_slast) ) {
-
-                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_tail_update_cols), 1ULL);
-                }
-            } else {
-
-                /* set up new_sfirst now in case we need it later.  */
-                assert(snext.ptr);
-                new_sfirst.ptr = snext.ptr;
-                new_sfirst.sn  = sfirst.sn + 1;
-
-                if ( ! atomic_load(&(sfirst.ptr->re_allocable)) ) {
-
-                    /* The entry at the head of the free list is not re allocable,
-                     * which means that there may be a pointer to it somewhere.  
-                     * Rather than take the risk, let it sit on the free list until 
-                     * is is marked as re allocable.
-                     */
-                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_head_not_reallocable), 1ULL);
-                    fl_search_done = true;
-
-                } else if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_shead), &sfirst, new_sfirst) ) {
-
-                    /* the attempt to remove the first item from the free list
-                     * failed.  Update stats and try again.
-                     */
-                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_head_update_cols), 1ULL);
-
-                } else {
-
-                    /* first has been removed from the free list.  Set fl_node_ptr to first,
-                     * update stats, and exit the loop by setting fl_search_done to true.
-                     */
-                    id_info_ptr = sfirst.ptr;
-
-                    assert(H5I__ID_INFO == id_info_ptr->tag);
-
-                    id_info_ptr->id = id;
-
-                    assert(atomic_load(&(id_info_ptr->on_fl)));
-                    atomic_store(&(id_info_ptr->on_fl), FALSE);
-
-                    assert(atomic_load(&(id_info_ptr->re_allocable)));
-                    atomic_store(&(id_info_ptr->re_allocable), FALSE);
-
-                    new_snext.ptr = NULL;
-                    new_snext.sn  = snext.sn + 1;
-
-                    result = atomic_compare_exchange_strong(&(id_info_ptr->fl_snext), &snext, new_snext);
-                    assert(result);
-
-                    old_k = atomic_load(&(id_info_ptr->k));
-
-                    assert(0 == old_k.count);
-                    assert(0 == old_k.app_count);
-                    assert(NULL == old_k.object);
-
-                    atomic_store(&(id_info_ptr->k), new_k);
-
-                    id_info_ptr->realize_cb = realize_cb;
-                    id_info_ptr->discard_cb = discard_cb;
-
-                    atomic_fetch_sub(&(H5I_mt_g.id_info_fl_len), 1ULL);
-                    atomic_fetch_add(&(H5I_mt_g.num_id_info_structs_alloced_from_fl), 1ULL);
-
-                    fl_search_done = true;
-
-                    assert(id_info_ptr);
-                }
-            }
-        }
-    } /* while ( ! fl_search_done ) */
-
-    if ( NULL == id_info_ptr ) {
-
-        id_info_ptr = (H5I_mt_id_info_t *)malloc(sizeof(H5I_mt_id_info_t));
-
-        if ( NULL == id_info_ptr )
-            HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, NULL, "ID info allocation failed");
-
-        atomic_fetch_add(&(H5I_mt_g.num_id_info_structs_alloced_from_heap), 1ULL);
-
-        id_info_ptr->tag = H5I__ID_INFO;
-        id_info_ptr->id = id;
-        atomic_init(&(id_info_ptr->k), new_k);
-        id_info_ptr->realize_cb = realize_cb;
-        id_info_ptr->discard_cb = discard_cb;
-        atomic_init(&(id_info_ptr->on_fl), FALSE);
-        atomic_init(&(id_info_ptr->re_allocable), FALSE);
-        snext.ptr = NULL;
-        snext.sn = 0ULL;
-        atomic_init(&(id_info_ptr->fl_snext), snext);
-    }
-
-    assert(id_info_ptr);
-
-    /* Set return value */
-    ret_value = id_info_ptr;
-
-    if ( ( atomic_load(
-
-done:
-
-    FUNC_LEAVE_NOAPI(ret_value)
-
-} /* H5I__new_mt_id_info() */
-
-#else /* new version */
-
-/************************************************************************
- *
- * H5I__new_mt_id_info
- *
- *     Test to see if an instance of H5I_mt_id_info_t is available on the
- *     id info free list.  If there is, remove it from the free list, 
- *     re-initialize it, and return a pointer to it.
- *
- *     Otherwise, allocate and initialize an instance of struct
- *     lfht_fl_node_t and return a pointer to the included instance of
- *     lfht_node_t to the caller.
- *
- *     Return a pointer to the new instance on success, and NULL on
- *     failure.
- *
- *                                          JRM -- 8/30/23
- *
- ************************************************************************/
-
-static H5I_mt_id_info_t * 
-H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * object, hbool_t is_future, 
-                    H5I_future_realize_func_t realize_cb, H5I_future_discard_func_t discard_cb)
-{
-    hbool_t fl_search_done = FALSE;;
-    hbool_t result;
-    hbool_t reallocable_entry_available = FALSE;
-    uint64_t num_fl_entries_reallocable;
-    H5I_mt_id_info_t * id_info_ptr = NULL;
-    H5I_mt_id_info_sptr_t sfirst;
-    H5I_mt_id_info_sptr_t new_sfirst;
-    H5I_mt_id_info_sptr_t test_sfirst;
-    H5I_mt_id_info_sptr_t slast;
-    H5I_mt_id_info_sptr_t new_slast;
+    H5I_mt_id_info_sptr_t fl_shead;
+    H5I_mt_id_info_sptr_t new_fl_shead;;
+    H5I_mt_id_info_sptr_t test_fl_shead;
+    H5I_mt_id_info_sptr_t fl_stail;
+    H5I_mt_id_info_sptr_t new_fl_stail;
     H5I_mt_id_info_sptr_t snext;
     H5I_mt_id_info_sptr_t new_snext;
     H5I_mt_id_info_kernel_t new_k;
@@ -9362,73 +9072,36 @@ H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * o
     new_k.have_global_mutex = FALSE;
 
 
-
     atomic_fetch_add(&(H5I_mt_g.H5I__new_mt_id_info__num_calls), 1ULL);
 
-    sfirst = atomic_load(&(H5I_mt_g.id_info_fl_shead));
+    fl_shead = atomic_load(&(H5I_mt_g.id_info_fl_shead));
 
     /* test to see if the free list has been initialized */
 
-    if ( NULL == sfirst.ptr ) {
+    if ( NULL == fl_shead.ptr ) {
 
         /* free list is not yet initialized */
         fl_search_done = TRUE;
     }
 
-    /* Test to see if there is a re-allocable entry on the free list.  Conceptually, we test to see
-     * if H5I_mt_g.num_id_info_fl_entries_reallocable  is positive, we decrement it and set entry_reallocable
-     * to TRUE.  Practically, it is a bit more complicated, as it is possible that 
-     * H5I_mt_g.num_id_info_fl_entries_reallocable between the time that we read it to see if it is 
-     * positive, and we decrement it.  To deal with this, we use an atomic compare exchange to set 
-     * the new value, and retry if there is a collision.
-     */
-    if ( ! fl_search_done ) {
-
-        while ( ( ! reallocable_entry_available ) && 
-                ( 0 < (num_fl_entries_reallocable = atomic_load(&(H5I_mt_g.num_id_info_fl_entries_reallocable))) ) ) {
-
-            assert( 0 < num_fl_entries_reallocable );
-
-            if ( atomic_compare_exchange_strong(&(H5I_mt_g.num_id_info_fl_entries_reallocable),
-                                                &num_fl_entries_reallocable, (num_fl_entries_reallocable - 1)) ) {
-
-                reallocable_entry_available = TRUE;
-            
-            } else { 
-
-                /* update stats */
-                atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_collisions), 1ULL);
-            }
-        } /* end while */
-
-        if ( ! reallocable_entry_available ) {
-
-            /* No reallocable entries available, so set fl_search_done = TRUE */
-
-            fl_search_done = TRUE;
-
-            /* update stats */
-            atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_no_reallocable_entries), 1ULL);
-
-        }
-    } /* end if ( ! fl_search_done ) */
-
 
     while ( ! fl_search_done ) {
 
-        sfirst = atomic_load(&(H5I_mt_g.id_info_fl_shead));
-        slast = atomic_load(&(H5I_mt_g.id_info_fl_stail));
+        fl_shead = atomic_load(&(H5I_mt_g.id_info_fl_shead));
+        fl_stail = atomic_load(&(H5I_mt_g.id_info_fl_stail));
 
-        assert(sfirst.ptr);
-        assert(slast.ptr);
+        assert(fl_shead.ptr);
+        assert(fl_stail.ptr);
 
-        snext = atomic_load(&(sfirst.ptr->fl_snext));
+        snext = atomic_load(&(fl_shead.ptr->fl_snext));
 
-        test_sfirst = atomic_load(&(H5I_mt_g.id_info_fl_shead));
+        test_fl_shead = atomic_load(&(H5I_mt_g.id_info_fl_shead));
 
-        if ( ( test_sfirst.ptr == sfirst.ptr ) && ( test_sfirst.sn == sfirst.sn ) ) {
+        if ( ( test_fl_shead.ptr == fl_shead.ptr ) && ( test_fl_shead.sn == fl_shead.sn ) ) {
 
-            if ( sfirst.ptr == slast.ptr ) {
+            uint64_t serial_num;
+
+            if ( fl_shead.ptr == fl_stail.ptr ) {
 
                 if ( NULL == snext.ptr ) {
 
@@ -9444,20 +9117,31 @@ H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * o
                  *
                  * that said, it doesn't hurt to collect stats
                  */
-                new_slast.ptr = snext.ptr;
-                new_slast.sn  = slast.sn + 1;
-                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_stail), &slast, new_slast) ) {
+                new_fl_stail.ptr = snext.ptr;
+                new_fl_stail.sn  = fl_stail.sn + 1;
+                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_stail), &fl_stail, new_fl_stail) ) {
 
                     atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_tail_update_cols), 1ULL);
                 }
+            } else if ( ( 0 < (serial_num = atomic_load(&(fl_shead.ptr->serial_num))) ) &&
+                        ( serial_num >= atomic_load(&(H5I_mt_g.id_max_realloc_sn)) ) ) {
+
+                /* if serial_num is zero, it should have already been removed from the free
+                 * list by another thread -- if so, the following attempt to remove if from
+                 * the free list will fail.  If this is not the case, we will catch the error
+                 * after we successfully remove the entry.
+                 */
+
+                /* No reallocable entries available -- just update stats and quit */
+                atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_no_reallocable_entries), 1ULL);
+                fl_search_done = TRUE; 
             } else {
 
-                /* set up new_sfirst now in case we need it later.  */
-                assert(snext.ptr);
-                new_sfirst.ptr = snext.ptr;
-                new_sfirst.sn  = sfirst.sn + 1;
+                /* set up new_fl_shead now in case we need it later.  */
+                new_fl_shead.ptr = snext.ptr;
+                new_fl_shead.sn  = fl_shead.sn + 1;
 
-                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_shead), &sfirst, new_sfirst) ) {
+                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_shead), &fl_shead, new_fl_shead) ) {
 
                     /* the attempt to remove the first item from the free list
                      * failed.  Update stats and try again.
@@ -9469,7 +9153,7 @@ H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * o
                     /* first has been removed from the free list.  Set fl_node_ptr to first,
                      * update stats, and exit the loop by setting fl_search_done to true.
                      */
-                    id_info_ptr = sfirst.ptr;
+                    id_info_ptr = fl_shead.ptr;
 
                     assert(H5I__ID_INFO == id_info_ptr->tag);
 
@@ -9477,6 +9161,19 @@ H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * o
 
                     assert(atomic_load(&(id_info_ptr->on_fl)));
                     atomic_store(&(id_info_ptr->on_fl), FALSE);
+
+                    assert( 0 < atomic_load(&(id_info_ptr->serial_num ) ) );
+
+                    /* the above assert only exists in production builds.  If id_info_ptr->serial_num
+                     * is zero and we get this far, increment H5I_mt_g.num_id_info_fl_head_sn_is_zero.
+                     */
+                    if ( 0 == atomic_load(&(id_info_ptr->serial_num)) ) {
+
+                        atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_head_sn_is_zero), 1ULL);
+
+                        /* should we throw an error here? */
+                    }
+                    atomic_store(&(id_info_ptr->serial_num), 0ULL);
 
                     new_snext.ptr = NULL;
                     new_snext.sn  = snext.sn + 1;
@@ -9497,6 +9194,7 @@ H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * o
 
                     atomic_fetch_sub(&(H5I_mt_g.id_info_fl_len), 1ULL);
                     atomic_fetch_add(&(H5I_mt_g.num_id_info_structs_alloced_from_fl), 1ULL);
+                    atomic_fetch_add(&(H5I_mt_g.num_id_serial_num_resets), 1ULL);
 
                     fl_search_done = true;
                 }
@@ -9522,6 +9220,7 @@ H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * o
         snext.ptr = NULL;
         snext.sn = 0ULL;
         atomic_init(&(id_info_ptr->fl_snext), snext);
+        atomic_init(&(id_info_ptr->serial_num), 0ULL);
     }
 
     assert(id_info_ptr);
@@ -9535,7 +9234,6 @@ done:
 
 } /* H5I__new_mt_id_info() */
 
-#endif /* new version */
 
 /************************************************************************
  *
@@ -9579,13 +9277,25 @@ H5I__clear_mt_type_info_free_list(void)
         assert(H5I__TYPE_INFO == type_info_ptr->tag);
         assert(0 == atomic_load(&(type_info_ptr->init_count)));
         assert(0 == atomic_load(&(type_info_ptr->id_count)));
-        assert(atomic_load(&(type_info_ptr->lfht_cleared)));
+
+        if ( ( type_info_ptr->cls ) &&
+             ( type_info_ptr->cls->flags & H5I_CLASS_IS_APPLICATION ) ) {
+
+            type_info_ptr->cls = H5MM_xfree_const(type_info_ptr->cls);
+        }
+
+        if ( ! atomic_load(&(type_info_ptr->lfht_cleared)) ) {
+
+            lfht_clear(&(type_info_ptr->lfht));
+            atomic_store(&(type_info_ptr->lfht_cleared), TRUE);
+        }
+
         assert(atomic_load(&(type_info_ptr->on_fl)));
 
         fl_head = atomic_load(&(type_info_ptr->fl_snext));
         fl_head_ptr = fl_head.ptr;
 
-        /* prepare *if_info_ptr for discard */
+        /* prepare *id_info_ptr for discard */
         type_info_ptr->tag = H5I__TYPE_INFO_INVALID;
         type_info_ptr->cls = NULL;
         atomic_store(&(type_info_ptr->fl_snext), null_snext);
@@ -9605,151 +9315,6 @@ done:
 
 } /* H5I__clear_mt_type_info_free_list() */
 
-#if 0 /* old version */
-
-/************************************************************************
- *
- * H5I__discard_mt_type_info
- *
- *     Append the supplied instance of H5I_mt_type_info_t on the type info
- *     free list and increment H5I_mt_t.type_info_fl_len.
- *
- *     If the free list length exceeds 
- *     H5I_mt_t.max_desired_type_info_fl_len, attempt the remove the node 
- *     at the head of the type info free list from the free list, and 
- *     discard it and decrement lfht_ptr->fl_len if successful.
- *     ---- skip for now ---
- *
- *                                          JRM -- 9/1/23
- *
- ************************************************************************/
-
-static herr_t 
-H5I__discard_mt_type_info(H5I_mt_type_info_t * type_info_ptr)
-{
-    hbool_t done = FALSE;
-    hbool_t on_fl = FALSE;
-    hbool_t result;
-    uint64_t fl_len;
-    uint64_t max_fl_len;
-    H5I_mt_type_info_sptr_t snext = {NULL, 0ULL};
-    H5I_mt_type_info_sptr_t new_snext;
-    H5I_mt_type_info_sptr_t fl_stail;
-    H5I_mt_type_info_sptr_t fl_snext;
-    H5I_mt_type_info_sptr_t new_fl_snext;
-    H5I_mt_type_info_sptr_t new_fl_stail;
-    H5I_mt_type_info_sptr_t test_fl_stail;
-    herr_t ret_value = SUCCEED; /* Return value */
-
-    FUNC_ENTER_NOAPI_NOERR
-
-    assert(type_info_ptr);
-    assert(H5I__TYPE_INFO == type_info_ptr->tag);
-
-    assert(0 == atomic_load(&(type_info_ptr->init_count)));
-    assert(0 == atomic_load(&(type_info_ptr->id_count)));
-
-    assert(atomic_load(&(type_info_ptr->lfht_cleared)));
-
-    assert(!atomic_load(&(type_info_ptr->on_fl)));
-
-    snext = atomic_load(&(type_info_ptr->fl_snext));
-
-    new_snext.ptr = NULL;
-    new_snext.sn = snext.sn + 1;
-
-    atomic_store(&(type_info_ptr->fl_snext), new_snext);
-
-    result = atomic_compare_exchange_strong(&(type_info_ptr->on_fl), &on_fl, TRUE);
-    assert(result);
-
-
-    while ( ! done ) {
-
-        fl_stail = atomic_load(&(H5I_mt_g.type_info_fl_stail));
-
-        assert(fl_stail.ptr);
-
-        /* it is possible that *fl_tail.ptr has passed through the free list
-         * and been re-allocated between the time we loaded it, and now.
-         * If so, fl_stail_ptr->on_fl will no longer be TRUE.
-         * This isn't a problem, but if so, the following if statement will fail.
-         */
-        // assert(atomic_load(&(fl_stail.ptr->on_fl)));
-
-        fl_snext = atomic_load(&(fl_stail.ptr->fl_snext));
-
-        test_fl_stail = atomic_load(&(H5I_mt_g.type_info_fl_stail));
-
-        if ( ( test_fl_stail.ptr == fl_stail.ptr ) && ( test_fl_stail.sn == fl_stail.sn ) ) {
-
-            if ( NULL == fl_snext.ptr ) {
-
-                /* attempt to append type_info_ptr by setting fl_tail->fl_snext.ptr to type_info_ptr.
-                 * If this succeeds, update stats and attempt to set H5I_mt_g.type_info_fl_stail.ptr
-                 * to type_info_ptr as well.  This may or may not succeed, but in either
-                 * case we are done.
-                 */
-                new_fl_snext.ptr = type_info_ptr;
-                new_fl_snext.sn  = fl_snext.sn + 1;
-                if ( atomic_compare_exchange_strong(&(fl_stail.ptr->fl_snext), &fl_snext, new_fl_snext) ) {
-
-                    atomic_fetch_add(&(H5I_mt_g.type_info_fl_len), 1);
-                    atomic_fetch_add(&(H5I_mt_g.num_type_info_structs_added_to_fl), 1);
-
-                    new_fl_stail.ptr = type_info_ptr;
-                    new_fl_stail.sn  = fl_stail.sn + 1;
-                    if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_stail), 
-                                                          &fl_stail, new_fl_stail) ) {
-
-                        atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_head_update_cols), 1);
-                    }
-
-                    /* if appropriate, attempt to update H5I_mt_g.max_type_info_fl_len.  In the
-                     * event of a collision, just ignore it and go on, as I don't see any
-                     * reasonable way to recover.
-                     */
-                    if ( (fl_len = atomic_load(&(H5I_mt_g.type_info_fl_len))) >
-                         (max_fl_len = atomic_load(&(H5I_mt_g.max_type_info_fl_len))) ) {
-
-                        atomic_compare_exchange_strong(&(H5I_mt_g.max_type_info_fl_len), &max_fl_len, fl_len);
-                    }
-
-                    done = true;
-
-                } else {
-
-                    /* append failed -- update stats and try again */
-                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_append_cols), 1);
-
-                }
-            } else {
-
-                // assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_next->tag)));
-
-                /* attempt to set lfht_ptr->fl_stail to fl_next.  It doesn't
-                 * matter whether we succeed or fail, as if we fail, it
-                 * just means that some other thread beat us to it.
-                 *
-                 * that satype, it doesn't hurt to collect stats
-                 */
-                new_fl_stail.ptr = fl_snext.ptr;
-                new_fl_stail.sn  = fl_stail.sn + 1;
-                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_stail), &fl_stail, new_fl_stail) ) {
-
-                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_tail_update_cols), 1);
-                }
-            }
-        }
-    }
-
-    /* don't implement frees for now -- may deal with this in H5I_mt_enter/exit() */
-
-    FUNC_LEAVE_NOAPI(ret_value)
-
-} /* H5I__discard_mt_type_info() */
-
-#else /* new version */
 
 /************************************************************************
  *
@@ -9774,7 +9339,6 @@ H5I__discard_mt_type_info(H5I_mt_type_info_t * type_info_ptr)
     hbool_t on_fl = FALSE;
     hbool_t result;
     hbool_t try_to_free_an_entry = FALSE;
-    hbool_t reallocable_entry_available = FALSE;
     uint64_t fl_len;
     uint64_t max_fl_len;
     uint64_t test_val;
@@ -9800,8 +9364,6 @@ H5I__discard_mt_type_info(H5I_mt_type_info_t * type_info_ptr)
     assert(0 == atomic_load(&(type_info_ptr->init_count)));
     assert(0 == atomic_load(&(type_info_ptr->id_count)));
 
-    assert(atomic_load(&(type_info_ptr->lfht_cleared)));
-
     assert(!atomic_load(&(type_info_ptr->on_fl)));
 
     snext = atomic_load(&(type_info_ptr->fl_snext));
@@ -9814,19 +9376,17 @@ H5I__discard_mt_type_info(H5I_mt_type_info_t * type_info_ptr)
     result = atomic_compare_exchange_strong(&(type_info_ptr->on_fl), &on_fl, TRUE);
     assert(result);
 
+    atomic_store(&(type_info_ptr->serial_num), atomic_fetch_add(&(H5I_mt_g.type_next_sn), 1ULL));
+
+    /* update stats */
+    atomic_fetch_add(&(H5I_mt_g.num_type_next_sn_assigned), 1ULL);
+
 
     while ( ! done ) {
 
         fl_stail = atomic_load(&(H5I_mt_g.type_info_fl_stail));
 
         assert(fl_stail.ptr);
-
-        /* it is possible that *fl_tail.ptr has passed through the free list
-         * and been re-allocated between the time we loaded it, and now.
-         * If so, fl_stail_ptr->on_fl will no longer be TRUE.
-         * This isn't a problem, but if so, the following if statement will fail.
-         */
-        // assert(atomic_load(&(fl_stail.ptr->on_fl)));
 
         fl_snext = atomic_load(&(fl_stail.ptr->fl_snext));
 
@@ -9876,13 +9436,11 @@ H5I__discard_mt_type_info(H5I_mt_type_info_t * type_info_ptr)
                 }
             } else {
 
-                // assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_next->tag)));
-
                 /* attempt to set lfht_ptr->fl_stail to fl_next.  It doesn't
                  * matter whether we succeed or fail, as if we fail, it
                  * just means that some other thread beat us to it.
                  *
-                 * that satype, it doesn't hurt to collect stats
+                 * that said, it doesn't hurt to collect stats
                  */
                 new_fl_stail.ptr = fl_snext.ptr;
                 new_fl_stail.sn  = fl_stail.sn + 1;
@@ -9895,28 +9453,16 @@ H5I__discard_mt_type_info(H5I_mt_type_info_t * type_info_ptr)
     }
 
 
-    /* test to see if both H5I_mt_g.type_info_fl_len and H5I_mt_g.num_type_info_fl_entries_reallocable 
-     * are greater than H5I_mt_g.max_desired_type_info_fl_len.  Check both, as while we want to 
-     * keep the free list length around H5I_mt_g.max_desired_type_info_fl_len, we also want to 
-     * have an ample supply of reallocable free list entries on hand.
+    /* Test to see if H5I_mt_g.type_info_fl_len is greater than H5I_mt_g.max_desired_id_info_fl_len.
+     *
+     * Note that this doesn't mean that there is a entry available for discard -- we will check this
+     * later.
      */
-#if 1
-    assert(atomic_load(&(H5I_mt_g.num_type_info_fl_entries_reallocable)) <= 
-           atomic_load(&(H5I_mt_g.type_info_fl_len)));
-#else
-    assert(atomic_load(&(H5I_mt_g.snum_type_info_fl_entries_reallocable)).val <= 
-           atomic_load(&(H5I_mt_g.type_info_fl_len)));
-#endif
 
-#if 1
-    if ( ( atomic_load(&(H5I_mt_g.type_info_fl_len)) > atomic_load(&(H5I_mt_g.max_desired_type_info_fl_len)) ) &&
-         ( atomic_load(&(H5I_mt_g.num_type_info_fl_entries_reallocable)) > 
-           atomic_load(&(H5I_mt_g.max_desired_type_info_fl_len)) ) ) {
-#else
-    if ( ( atomic_load(&(H5I_mt_g.type_info_fl_len)) > atomic_load(&(H5I_mt_g.max_desired_type_info_fl_len)) ) &&
-         ( atomic_load(&(H5I_mt_g.snum_type_info_fl_entries_reallocable)).val > 
-           atomic_load(&(H5I_mt_g.max_desired_type_info_fl_len)) ) ) {
-#endif
+    /* must rework this assert for the possibility that these fields will wrap around */
+    assert(atomic_load(&(H5I_mt_g.type_max_realloc_sn)) <= atomic_load(&(H5I_mt_g.type_next_sn)));
+
+    if ( atomic_load(&(H5I_mt_g.type_info_fl_len)) > atomic_load(&(H5I_mt_g.max_desired_type_info_fl_len)) ) {
 
         try_to_free_an_entry = TRUE;
 
@@ -9925,352 +9471,163 @@ H5I__discard_mt_type_info(H5I_mt_type_info_t * type_info_ptr)
         atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_fl_too_small), 1ULL);
     }
 
+
     if ( try_to_free_an_entry ) {
 
-#if 1
-        uint64_t num_fl_entries_reallocable;
-#else
-        H5I_suint64_t snum_fl_entries_reallocable;
-        H5I_suint64_t new_snum_fl_entries_reallocable;
-#endif
+        uint64_t serial_num;
 
-        /* While a reallocable entry is almost certainly available, there
-         * is the possibility that other threads have snapped up all 
-         * the reallocable entries in the time since we determined that 
-         * we should try to free an entry.  Hence the following:
-         */
-#if 1
-        while ( ( ! reallocable_entry_available ) &&
-                ( 0 < (num_fl_entries_reallocable = 
-                       atomic_load(&(H5I_mt_g.num_type_info_fl_entries_reallocable))) ) ) {
+        done = FALSE;
 
-            assert( 0 < num_fl_entries_reallocable );
+        while ( ! done ) {
 
-            if ( atomic_compare_exchange_strong(&(H5I_mt_g.num_type_info_fl_entries_reallocable),
-                                                &num_fl_entries_reallocable, (num_fl_entries_reallocable - 1)) ) {
+            fl_shead = atomic_load(&(H5I_mt_g.type_info_fl_shead));
+            fl_stail = atomic_load(&(H5I_mt_g.type_info_fl_stail));
 
-                reallocable_entry_available = TRUE;
+            assert(fl_shead.ptr);
+            assert(fl_stail.ptr);
 
-            } else {
+            fl_snext = atomic_load(&(fl_shead.ptr->fl_snext));
 
-                /* update stats */
-                atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions), 1ULL);
-            }
-        } /* end while */
-#else
-        while ( ( ! reallocable_entry_available ) &&
-                ( 0 < (snum_fl_entries_reallocable = 
-                       atomic_load(&(H5I_mt_g.snum_type_info_fl_entries_reallocable))).val ) ) {
+            test_fl_shead = atomic_load(&(H5I_mt_g.type_info_fl_shead));
 
-            assert( 0 < snum_fl_entries_reallocable.val );
+            if ( ( test_fl_shead.ptr == fl_shead.ptr ) && ( test_fl_shead.sn == fl_shead.sn ) ) {
 
-            new_snum_fl_entries_reallocable.val = snum_fl_entries_reallocable.val - 1;
-            new_snum_fl_entries_reallocable.sn  = snum_fl_entries_reallocable.sn + 1;
+                if ( fl_shead.ptr == fl_stail.ptr ) {
 
-            if ( atomic_compare_exchange_strong(&(H5I_mt_g.snum_type_info_fl_entries_reallocable),
-                                                &snum_fl_entries_reallocable, new_snum_fl_entries_reallocable) ) {
+                    if ( NULL == fl_snext.ptr ) {
 
-                reallocable_entry_available = TRUE;
+                        /* the free list is empty */
+                        atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_empty), 1);
+                        done = TRUE;
+                        break;
+                    }
 
-                fprintf(stderr, 
-                        "\ndisc: old/new snum_type_info_fl_entries_reallocable = {%lld, %lld} / {%lld, %lld}\n",
-                        (long long)snum_fl_entries_reallocable.val, 
-                        (long long)snum_fl_entries_reallocable.sn,
-                        (long long)new_snum_fl_entries_reallocable.val, 
-                        (long long)new_snum_fl_entries_reallocable.sn);
+                    /* attempt to set H5I_mt_g.type_info_fl_stail to fl_snext.  It doesn't
+                     * matter whether we succeed or fail, as if we fail, it
+                     * just means that some other thread beat us to it.
+                     *
+                     * that said, it doesn't hurt to collect stats
+                     */
+                    new_fl_stail.ptr = fl_snext.ptr;
+                    new_fl_stail.sn  = fl_stail.sn + 1;
 
-            } else {
+                    assert(new_fl_stail.ptr);
 
-                /* update stats */
-                atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions), 1ULL);
-            }
-        } /* end while */
-#endif
+                    if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_stail), &fl_stail, new_fl_stail) ) {
 
-        if ( ! reallocable_entry_available ) {
+                        atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_tail_update_cols), 1ULL);
+                    }
 
-            /* No reallocable entries available -- just update stats and quit */
+                } else if ( ( 0 < (serial_num = atomic_load(&(fl_shead.ptr->serial_num))) ) &&
+                            ( serial_num >= atomic_load(&(H5I_mt_g.type_max_realloc_sn)) ) ) {
 
-            atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_no_reallocable_entries), 1ULL);
+                    /* if serial_num is zero, it should have already been removed from the free
+                     * list by another thread -- if so, the following attempt to remove if from
+                     * the free list will fail.  If this is not the case, we will catch the error
+                     * after we successfully remove the entry.
+                     */
 
-        } else {
+                    /* No reallocable entries available -- just update stats and quit */
+                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_no_reallocable_entries), 1ULL);
+                    done = TRUE;
 
-            done = FALSE;
+                } else {
 
-            while ( ! done ) {
+                    /* set up new_fl_shead */
 
-                fl_shead = atomic_load(&(H5I_mt_g.type_info_fl_shead));
-                fl_stail = atomic_load(&(H5I_mt_g.type_info_fl_stail));
+                    assert(fl_snext.ptr);
 
-                assert(fl_shead.ptr);
-                assert(fl_stail.ptr);
+                    new_fl_shead.ptr = fl_snext.ptr;
+                    new_fl_shead.sn  = fl_shead.sn + 1;
 
-                fl_snext = atomic_load(&(fl_shead.ptr->fl_snext));
+                    if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_shead), &fl_shead, new_fl_shead) ) {
 
-                test_fl_shead = atomic_load(&(H5I_mt_g.type_info_fl_shead));
-
-                if ( ( test_fl_shead.ptr == fl_shead.ptr ) && ( test_fl_shead.sn == fl_shead.sn ) ) {
-
-                    if ( fl_shead.ptr == fl_stail.ptr ) {
-
-                        if ( NULL == fl_snext.ptr ) {
-
-                            /* the free list is empty */
-                            atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_empty), 1);
-                            done = TRUE;
-                            break;
-                        }
-
-                        /* attempt to set H5I_mt_g.type_info_fl_stail to fl_snext.  It doesn't
-                         * matter whether we succeed or fail, as if we fail, it
-                         * just means that some other thread beat us to it.
-                         *
-                         * that said, it doesn't hurt to collect stats
+                        /* the attempt to remove the first item from the free list
+                         * failed.  Update stats and try again.
                          */
-                        new_fl_stail.ptr = fl_snext.ptr;
-                        new_fl_stail.sn  = fl_stail.sn + 1;
-                        if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_stail), &fl_stail, 
-                                                              new_fl_stail) ) {
+                        atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_head_update_cols), 1ULL);
 
-                            atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_tail_update_cols), 1ULL);
-                        }
                     } else {
 
-                        /* set up new_fl_shead */
-                        assert(fl_snext.ptr);
-                        new_fl_shead.ptr = fl_snext.ptr;
-                        new_fl_shead.sn  = fl_shead.sn + 1;
+                        H5I_mt_type_info_sptr_t null_snext = {NULL, 0ULL};
 
-                        if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_shead), 
-                                                              &fl_shead, new_fl_shead) ) {
+                        /* first has been removed from the free list.  Set type_info_ptr to fl_shead.ptr,
+                         * discard *type_info_ptr, update stats, and exit the loop by setting done to true.
+                         */
+                        type_info_ptr = fl_shead.ptr;
 
-                            /* the attempt to remove the first item from the free list
-                             * failed.  Update stats and try again.
-                             */
-                            atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_head_update_cols), 1ULL);
+                        assert(H5I__TYPE_INFO == type_info_ptr->tag);
+                        assert(type_info_ptr->on_fl);
+                        assert(0 < atomic_load(&(type_info_ptr->serial_num)));
 
-                        } else {
+                        /* the above assert only exists in production builds.  If type_info_ptr->serial_num
+                         * is zero and we get this far, increment H5I_mt_g.num_id_info_fl_head_sn_is_zero.
+                         */
+                        if ( 0 == atomic_load(&(type_info_ptr->serial_num)) ) {
 
-                            H5I_mt_type_info_sptr_t null_snext = {NULL, 0ULL};
+                            atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_head_sn_is_zero), 1ULL);
 
-                            /* first has been removed from the free list.  Set type_info_ptr to fl_shead.ptr,
-                             * discard *type_info_ptr, update stats, and exit the loop by setting done to true.
-                             */
-                            type_info_ptr = fl_shead.ptr;
-
-                            assert(H5I__TYPE_INFO == type_info_ptr->tag);
-                            assert(type_info_ptr->on_fl);
-
-                            /* prepare *type_info_ptr for discard */
-                            type_info_ptr->tag = H5I__TYPE_INFO_INVALID;
-                            atomic_store(&(type_info_ptr->fl_snext), null_snext);
-
-                            free(type_info_ptr);
-
-                            /* update stats */
-                            atomic_fetch_add(&(H5I_mt_g.num_type_info_structs_freed), 1ULL);
-                            test_val = atomic_fetch_sub(&(H5I_mt_g.type_info_fl_len), 1ULL);
-                            assert( test_val > 0ULL);
-
-                            done = true;
+                            /* should we throw an error here? */
                         }
+
+                        /* prepare *type_info_ptr for discard */
+                        type_info_ptr->tag = H5I__TYPE_INFO_INVALID;
+                        atomic_store(&(type_info_ptr->fl_snext), null_snext);
+
+                        /* Note that we don't check to see if id_info_ptr->serial_num <
+                         * H5I_mt_g.id_max_realloc_sn.  This was already checked above.
+                         * Further, the algorithm for maintaining H5I_mt_g.id_max_realloc_sn
+                         * allows its value to bounce around a bit -- making it possible that
+                         * we would get a false assertion failure.
+                         */
+
+                        atomic_store(&(type_info_ptr->serial_num), 0ULL);
+
+                        /* because of the possibility of another thread acting on an id in 
+                         * the id type during takedown, we didn't discard the class (if a 
+                         * user type) and clear the lock free hash table.  
+                         *
+                         * Since the instance of H5I_mt_type_info_t is about to be freed,
+                         * it is now safe to do so.  
+                         *
+                         * Note that it is possible that the lock free hash table has never
+                         * been set up -- hence we must check type_info_ptr->lfht_cleared
+                         * before we attempt to do so.
+                         */
+
+                        /* Check if we should release the ID class */
+                        if ( ( type_info_ptr->cls ) &&
+                             ( type_info_ptr->cls->flags & H5I_CLASS_IS_APPLICATION ) ) {
+
+                            type_info_ptr->cls = H5MM_xfree_const(type_info_ptr->cls);
+                        }
+
+                        if ( ! atomic_load(&(type_info_ptr->lfht_cleared)) ) {
+
+                            lfht_clear(&(type_info_ptr->lfht));
+
+                            atomic_store(&(type_info_ptr->lfht_cleared), TRUE);
+                        }
+
+                        free(type_info_ptr);
+
+                        /* update stats */
+                        atomic_fetch_add(&(H5I_mt_g.num_type_info_structs_freed), 1ULL);
+                        test_val = atomic_fetch_sub(&(H5I_mt_g.type_info_fl_len), 1ULL);
+                        assert( test_val > 0ULL);
+                        atomic_fetch_add(&(H5I_mt_g.num_type_serial_num_resets), 1ULL);
+
+                        done = true;
                     }
                 }
-            } /* while ( ! done ) */
-        }
+            }
+        } /* while ( ! done ) */
     } /* if ( try_to_free_entry ) */
 
     FUNC_LEAVE_NOAPI(ret_value)
 
 } /* H5I__discard_mt_type_info() */
 
-
-#endif /* new version */
-
-#if 0 /* old version */
-
-/************************************************************************
- *
- * H5I__new_mt_type_info
- *
- *     Test to see if an instance of H5I_mt_type_info_t is available on the
- *     type info free list.  If there is, remove it from the free list, 
- *     re-initialize it, and return a pointer to it.
- *
- *     Otherwise, allocate and initialize an instance of struct
- *     lfht_fl_node_t and return a pointer to the included instance of
- *     lfht_node_t to the caller.
- *
- *     Return a pointer to the new instance on success, and NULL on
- *     failure.
- *
- *                                          JRM -- 8/30/23
- *
- ************************************************************************/
-
-static H5I_mt_type_info_t * 
-H5I__new_mt_type_info(const H5I_class_t *cls, unsigned reserved)
-{
-    hbool_t fl_search_done = FALSE;
-    hbool_t result;
-    H5I_mt_type_info_t * type_info_ptr = NULL;
-    H5I_mt_type_info_sptr_t sfirst;
-    H5I_mt_type_info_sptr_t new_sfirst;
-    H5I_mt_type_info_sptr_t test_sfirst;
-    H5I_mt_type_info_sptr_t slast;
-    H5I_mt_type_info_sptr_t new_slast;
-    H5I_mt_type_info_sptr_t snext;
-    H5I_mt_type_info_sptr_t new_snext;
-    H5I_mt_type_info_t * ret_value = NULL; /* Return value */
-
-    FUNC_ENTER_NOAPI(NULL)
-
-    sfirst = atomic_load(&(H5I_mt_g.type_info_fl_shead));
-
-    if ( NULL == sfirst.ptr ) {
-
-        /* free list is not yet initialized */
-        fl_search_done = TRUE;
-    }
-
-    while ( ! fl_search_done ) {
-
-        sfirst = atomic_load(&(H5I_mt_g.type_info_fl_shead));
-        slast = atomic_load(&(H5I_mt_g.type_info_fl_stail));
-
-        assert(sfirst.ptr);
-        assert(slast.ptr);
-
-        snext = atomic_load(&(sfirst.ptr->fl_snext));
-
-        test_sfirst = atomic_load(&(H5I_mt_g.type_info_fl_shead));
-
-        if ( ( test_sfirst.ptr == sfirst.ptr ) && ( test_sfirst.sn == sfirst.sn ) ) {
-
-            if ( sfirst.ptr == slast.ptr ) {
-
-                if ( NULL == snext.ptr ) {
-
-                    /* the free list is empty */
-                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty), 1);
-                    fl_search_done = TRUE;
-                    break;
-                }
-
-                /* attempt to set H5I_mt_g.type_info_fl_stail to snext.  It doesn't
-                 * matter whether we succeed or fail, as if we fail, it
-                 * just means that some other thread beat us to it.
-                 *
-                 * that satype, it doesn't hurt to collect stats
-                 */
-                new_slast.ptr = snext.ptr;
-                new_slast.sn  = slast.sn + 1;
-                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_stail), &slast, new_slast) ) {
-
-                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_tail_update_cols), 1ULL);
-                }
-            } else {
-
-                /* set up new_sfirst now in case we need it later.  */
-                assert(snext.ptr);
-                new_sfirst.ptr = snext.ptr;
-                new_sfirst.sn  = sfirst.sn + 1;
-
-                if ( ! atomic_load(&(sfirst.ptr->re_allocable)) ) {
-
-                    /* The entry at the head of the free list is not re allocable,
-                     * which means that there may be a pointer to it somewhere.  
-                     * Rather than take the risk, let it sit on the free list until 
-                     * is is marked as re allocable.
-                     */
-                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_head_not_reallocable), 1ULL);
-                    fl_search_done = TRUE;
-
-                } else if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_shead), &sfirst, new_sfirst) ) {
-
-                    /* the attempt to remove the first item from the free list
-                     * failed.  Update stats and try again.
-                     */
-                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_head_update_cols), 1ULL);
-
-                } else {
-
-                    /* first has been removed from the free list.  Set fl_node_ptr to first,
-                     * update stats, and exit the loop by setting fl_search_done to true.
-                     */
-                    type_info_ptr = sfirst.ptr;
-
-                    assert(H5I__TYPE_INFO == type_info_ptr->tag);
-
-                    type_info_ptr->cls = cls;
-
-                    atomic_store(&(type_info_ptr->init_count), 0);
-                    atomic_store(&(type_info_ptr->id_count), reserved);
-                    atomic_store(&(type_info_ptr->last_id_info), NULL);
-                    atomic_store(&(type_info_ptr->lfht_cleared), FALSE);
-
-                    lfht_init(&(type_info_ptr->lfht));
-
-                    assert(atomic_load(&(type_info_ptr->on_fl)));
-                    atomic_store(&(type_info_ptr->on_fl), FALSE);
-
-                    assert(atomic_load(&(type_info_ptr->re_allocable)));
-                    atomic_store(&(type_info_ptr->on_fl), FALSE);
-
-                    assert(atomic_load(&(type_info_ptr->re_allocable)));
-                    atomic_store(&(type_info_ptr->re_allocable), FALSE);
-
-                    new_snext.ptr = NULL;
-                    new_snext.sn  = snext.sn + 1;
-
-                    result = atomic_compare_exchange_strong(&(type_info_ptr->fl_snext), &snext, new_snext);
-                    assert(result);
-
-                    atomic_fetch_sub(&(H5I_mt_g.type_info_fl_len), 1ULL);
-                    atomic_fetch_add(&(H5I_mt_g.num_type_info_structs_alloced_from_fl), 1ULL);
-
-                    fl_search_done = true;
-                }
-            }
-        }
-    } /* while ( ! fl_search_done ) */
-
-    if ( NULL == type_info_ptr ) {
-
-        type_info_ptr = (H5I_mt_type_info_t *)malloc(sizeof(H5I_mt_type_info_t));
-
-        if ( NULL == type_info_ptr )
-            HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, NULL, "ID info allocation failed");
-
-        atomic_fetch_add(&(H5I_mt_g.num_type_info_structs_alloced_from_heap), 1ULL);
-
-        type_info_ptr->tag = H5I__TYPE_INFO;
-        type_info_ptr->cls = cls;
-        atomic_init(&(type_info_ptr->init_count), 0);
-        atomic_init(&(type_info_ptr->id_count), 0ULL);
-        atomic_init(&(type_info_ptr->nextid), reserved);
-        atomic_init(&(type_info_ptr->last_id_info), NULL);
-        atomic_init(&(type_info_ptr->lfht_cleared), FALSE);
-        lfht_init(&(type_info_ptr->lfht));
-        atomic_init(&(type_info_ptr->on_fl), FALSE);
-        atomic_init(&(type_info_ptr->re_allocable), FALSE);
-        snext.ptr = NULL;
-        snext.sn = 0ULL;
-        atomic_init(&(type_info_ptr->fl_snext), snext);
-    }
-
-    assert(type_info_ptr);
-
-    /* Set return value */
-    ret_value = type_info_ptr;
-
-done:
-
-    FUNC_LEAVE_NOAPI(ret_value)
-
-} /* H5I__new_mt_type_info() */
-
-#else /* new version */
 
 /************************************************************************
  *
@@ -10295,120 +9652,50 @@ H5I__new_mt_type_info(const H5I_class_t *cls, unsigned reserved)
 {
     hbool_t fl_search_done = FALSE;;
     hbool_t result;
-    hbool_t reallocable_entry_available = FALSE;
-#if 1
-    uint64_t num_fl_entries_reallocable;
-#else
-    H5I_suint64_t snum_fl_entries_reallocable;
-    H5I_suint64_t new_snum_fl_entries_reallocable;
-#endif
     H5I_mt_type_info_t * type_info_ptr = NULL;
-    H5I_mt_type_info_sptr_t sfirst;
-    H5I_mt_type_info_sptr_t new_sfirst;
-    H5I_mt_type_info_sptr_t test_sfirst;
-    H5I_mt_type_info_sptr_t slast;
-    H5I_mt_type_info_sptr_t new_slast;
+    H5I_mt_type_info_sptr_t fl_shead;
+    H5I_mt_type_info_sptr_t new_fl_shead;
+    H5I_mt_type_info_sptr_t test_fl_shead;
+    H5I_mt_type_info_sptr_t fl_stail;
+    H5I_mt_type_info_sptr_t new_fl_stail;
     H5I_mt_type_info_sptr_t snext;
     H5I_mt_type_info_sptr_t new_snext;
+    uint64_t shead_sn;
+    uint64_t current_max_sn; 
+    uint64_t test_val;
     H5I_mt_type_info_t * ret_value = NULL; /* Return value */
 
     FUNC_ENTER_NOAPI(NULL)
 
     atomic_fetch_add(&(H5I_mt_g.H5I__new_mt_type_info__num_calls), 1ULL);
 
-    sfirst = atomic_load(&(H5I_mt_g.type_info_fl_shead));
+    fl_shead = atomic_load(&(H5I_mt_g.type_info_fl_shead));
+
 
     /* test to see if the free list has been initialized */
-
-    if ( NULL == sfirst.ptr ) {
+    if ( NULL == fl_shead.ptr ) {
 
         /* free list is not yet initialized */
         fl_search_done = TRUE;
     }
 
-    /* Test to see if there is a re-allocable entry on the free list.  Conceptually, we test to see
-     * if H5I_mt_g.num_type_info_fl_entries_reallocable is positive, we decrement it and set entry_reallocable
-     * to TRUE.  Practically, it is a bit more complicated, as it is possible that 
-     * H5I_mt_g.num_type_info_fl_entries_reallocable between the time that we read it to see if it is 
-     * positive, and we decrement it.  To deal with this, we use an atomic compare exchange to set 
-     * the new value, and retry if there is a collision.
-     */
-    if ( ! fl_search_done ) {
-#if 1
-        while ( ( ! reallocable_entry_available ) && 
-                ( 0 < (num_fl_entries_reallocable = 
-                       atomic_load(&(H5I_mt_g.num_type_info_fl_entries_reallocable))) ) ) {
-
-            assert( 0 < num_fl_entries_reallocable );
-
-            if ( atomic_compare_exchange_strong(&(H5I_mt_g.num_type_info_fl_entries_reallocable),
-                                                &num_fl_entries_reallocable, (num_fl_entries_reallocable - 1)) ) {
-
-                reallocable_entry_available = TRUE;
-            
-            } else { 
-
-                /* update stats */
-                atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions), 1ULL);
-            }
-        } /* end while */
-#else
-        while ( ( ! reallocable_entry_available ) && 
-                ( 0 < (snum_fl_entries_reallocable = 
-                       atomic_load(&(H5I_mt_g.snum_type_info_fl_entries_reallocable))).val ) ) {
-
-            assert( 0 < snum_fl_entries_reallocable.val);
-
-            new_snum_fl_entries_reallocable.val = snum_fl_entries_reallocable.val - 1;
-            new_snum_fl_entries_reallocable.sn  = snum_fl_entries_reallocable.sn + 1;
-
-            if ( atomic_compare_exchange_strong(&(H5I_mt_g.snum_type_info_fl_entries_reallocable),
-                                                &snum_fl_entries_reallocable, new_snum_fl_entries_reallocable) ) {
-
-                reallocable_entry_available = TRUE;
-
-                fprintf(stderr, 
-                        "\nalloc: old/new snum_type_info_fl_entries_reallocable = {%lld, %lld} / {%lld, %lld}\n",
-                        (long long)snum_fl_entries_reallocable.val, 
-                        (long long)snum_fl_entries_reallocable.sn,
-                        (long long)new_snum_fl_entries_reallocable.val, 
-                        (long long)new_snum_fl_entries_reallocable.sn);
-            
-            } else { 
-
-                /* update stats */
-                atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions), 1ULL);
-            }
-        } /* end while */
-#endif
-        if ( ! reallocable_entry_available ) {
-
-            /* No reallocable entries available, so set fl_search_done = TRUE */
-
-            fl_search_done = TRUE;
-
-            /* update stats */
-            atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_no_reallocable_entries), 1ULL);
-
-        }
-    } /* end if ( ! fl_search_done ) */
-
-
     while ( ! fl_search_done ) {
 
-        sfirst = atomic_load(&(H5I_mt_g.type_info_fl_shead));
-        slast = atomic_load(&(H5I_mt_g.type_info_fl_stail));
+        fl_shead = atomic_load(&(H5I_mt_g.type_info_fl_shead));
+        fl_stail = atomic_load(&(H5I_mt_g.type_info_fl_stail));
 
-        assert(sfirst.ptr);
-        assert(slast.ptr);
+        assert(fl_shead.ptr);
+        assert(fl_stail.ptr);
 
-        snext = atomic_load(&(sfirst.ptr->fl_snext));
+        snext = atomic_load(&(fl_shead.ptr->fl_snext));
 
-        test_sfirst = atomic_load(&(H5I_mt_g.type_info_fl_shead));
+        test_fl_shead = atomic_load(&(H5I_mt_g.type_info_fl_shead));
 
-        if ( ( test_sfirst.ptr == sfirst.ptr ) && ( test_sfirst.sn == sfirst.sn ) ) {
+        if ( ( test_fl_shead.ptr == fl_shead.ptr ) && ( test_fl_shead.sn == fl_shead.sn ) ) {
 
-            if ( sfirst.ptr == slast.ptr ) {
+            uint64_t serial_num;
+
+            if ( fl_shead.ptr == fl_stail.ptr ) {
 
                 if ( NULL == snext.ptr ) {
 
@@ -10424,20 +9711,33 @@ H5I__new_mt_type_info(const H5I_class_t *cls, unsigned reserved)
                  *
                  * that said, it doesn't hurt to collect stats
                  */
-                new_slast.ptr = snext.ptr;
-                new_slast.sn  = slast.sn + 1;
-                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_stail), &slast, new_slast) ) {
+                new_fl_stail.ptr = snext.ptr;
+                new_fl_stail.sn  = fl_stail.sn + 1;
+                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_stail), &fl_stail, new_fl_stail) ) {
 
                     atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_tail_update_cols), 1ULL);
                 }
+            } else if ( ( 0 < (serial_num = atomic_load(&(fl_shead.ptr->serial_num))) ) &&
+                        ( serial_num >= atomic_load(&(H5I_mt_g.type_max_realloc_sn)) ) ) {
+
+                /* if serial_num is zero, it should have already been removed from the free
+                 * list by another thread -- if so, the following attempt to remove if from
+                 * the free list will fail.  If this is not the case, we will catch the error
+                 * after we successfully remove the entry.
+                 */
+
+                /* No reallocable entries available -- just update stats and quit */
+                atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_no_reallocable_entries), 1ULL);
+
+                fl_search_done = TRUE;
+
             } else {
 
-                /* set up new_sfirst now in case we need it later.  */
-                assert(snext.ptr);
-                new_sfirst.ptr = snext.ptr;
-                new_sfirst.sn  = sfirst.sn + 1;
+                /* set up new_fl_shead now in case we need it later.  */
+                new_fl_shead.ptr = snext.ptr;
+                new_fl_shead.sn  = fl_shead.sn + 1;
 
-                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_shead), &sfirst, new_sfirst) ) {
+                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_shead), &fl_shead, new_fl_shead) ) {
 
                     /* the attempt to remove the first item from the free list
                      * failed.  Update stats and try again.
@@ -10446,12 +9746,54 @@ H5I__new_mt_type_info(const H5I_class_t *cls, unsigned reserved)
 
                 } else {
 
-                    /* first has been removed from the free list.  Set fl_node_ptr to first,
-                     * update stats, and exit the loop by setting fl_search_done to true.
+                    /* the first entry on the free list has been successfully removed.
+                     *
+                     * Perform some sanity checks, and then prepare the instance of H5I_mt_type_info_t
+                     * for reallocation.
                      */
-                    type_info_ptr = sfirst.ptr;
+                    type_info_ptr = fl_shead.ptr;
 
                     assert(H5I__TYPE_INFO == type_info_ptr->tag);
+
+                    assert(atomic_load(&(type_info_ptr->on_fl)));
+                    atomic_store(&(type_info_ptr->on_fl), FALSE);
+
+                    assert( 0 < atomic_load(&(type_info_ptr->serial_num ) ) );
+
+                    /* the above assert only exists in production builds.  If type_info_ptr->serial_num
+                     * is zero and we get this far, increment H5I_mt_g.num_id_info_fl_head_sn_is_zero.
+                     */
+                    if ( 0 == atomic_load(&(type_info_ptr->serial_num)) ) {
+
+                        atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_head_sn_is_zero), 1ULL);
+
+                        /* should we throw an error here? */
+                    }
+                    atomic_store(&(type_info_ptr->serial_num), 0ULL);
+
+                    /* because of the possibility of another thread acting on an id in 
+                     * the id type during takedown, we didn't discard the class (if a 
+                     * user type) and clear the lock free hash table.  
+                     *
+                     * Since the instance of H5I_mt_type_info_t is about to be reallocated
+                     * it is now safe to do so.  
+                     */
+
+                    /* Check if we should release the ID class */
+                    if ( ( type_info_ptr->cls ) &&
+                         ( type_info_ptr->cls->flags & H5I_CLASS_IS_APPLICATION ) ) {
+
+                        type_info_ptr->cls = H5MM_xfree_const(type_info_ptr->cls);
+                    }
+
+                    if ( ! atomic_load(&(type_info_ptr->lfht_cleared)) ) {
+
+                        lfht_clear(&(type_info_ptr->lfht));
+
+                        atomic_store(&(type_info_ptr->lfht_cleared), TRUE);
+                    }
+
+                    /* Now initialize *type_info_ptr as required for reallocation */
 
                     type_info_ptr->cls = cls;
 
@@ -10462,30 +9804,34 @@ H5I__new_mt_type_info(const H5I_class_t *cls, unsigned reserved)
 
                     lfht_init(&(type_info_ptr->lfht));
 
-                    assert(atomic_load(&(type_info_ptr->on_fl)));
-                    atomic_store(&(type_info_ptr->on_fl), FALSE);
-
                     new_snext.ptr = NULL;
                     new_snext.sn  = snext.sn + 1;
 
                     result = atomic_compare_exchange_strong(&(type_info_ptr->fl_snext), &snext, new_snext);
                     assert(result);
 
-                    atomic_fetch_sub(&(H5I_mt_g.type_info_fl_len), 1ULL);
+                    /* update stats */
                     atomic_fetch_add(&(H5I_mt_g.num_type_info_structs_alloced_from_fl), 1ULL);
+                    atomic_fetch_add(&(H5I_mt_g.num_type_serial_num_resets), 1ULL);
+
+                    /* decrement the length of the type info free list */
+                    test_val = atomic_fetch_sub(&(H5I_mt_g.type_info_fl_len), 1ULL);
+                    assert(test_val > 0ULL);
 
                     fl_search_done = true;
-                }
+
+                } 
             }
-        }
-    } /* while ( ! fl_search_done ) */
+        } /* end if ( ( test_fl_sfirst.ptr == fl_sfirst.ptr ) && ( test_fl_sfirst.sn == fl_sfirst.sn ) ) */
+    }/* end while ( ! fl_search_done ) */
 
-    if ( NULL == type_info_ptr ) {
-
+    /* If an entry was not grabbed from the free list alloc and initalize a new one */
+    if ( NULL == type_info_ptr )
+    {
         type_info_ptr = (H5I_mt_type_info_t *)malloc(sizeof(H5I_mt_type_info_t));
 
         if ( NULL == type_info_ptr )
-            HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, NULL, "ID info allocation failed");
+            HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, NULL, "Type info allocation failed");
 
         atomic_fetch_add(&(H5I_mt_g.num_type_info_structs_alloced_from_heap), 1ULL);
 
@@ -10498,6 +9844,7 @@ H5I__new_mt_type_info(const H5I_class_t *cls, unsigned reserved)
         atomic_init(&(type_info_ptr->lfht_cleared), FALSE);
         lfht_init(&(type_info_ptr->lfht));
         atomic_init(&(type_info_ptr->on_fl), FALSE);
+        atomic_init(&(type_info_ptr->serial_num), 0ULL);
         snext.ptr = NULL;
         snext.sn = 0ULL;
         atomic_init(&(type_info_ptr->fl_snext), snext);
@@ -10512,9 +9859,8 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 
-} /* H5I__new_mt_id_info() */
+} /* end H5I__new_mt_id_info() */
 
-#endif /* new version */
 
 /************************************************************************
  *
@@ -10579,170 +9925,138 @@ H5I__exit(void)
     uint64_t post_api_entries;
     uint64_t pre_internal_entries;
     uint64_t post_internal_entries;
-    uint64_t num_id_info_fl_entries_reallocable;
-    uint64_t id_info_fl_len;
-#if 1
-    uint64_t num_type_info_fl_entries_reallocable;
-#else
-    H5I_suint64_t snum_type_info_fl_entries_reallocable;
-#endif
-    uint64_t type_info_fl_len;
+    uint64_t id_next_sn;
+    uint64_t id_max_realloc_sn;
+    uint64_t type_next_sn;
+    uint64_t type_max_realloc_sn;
 
-    if ( 1ULL == atomic_fetch_sub(&(H5I_mt_g.active_threads), 1ULL) ) {
-
+    if ( 1ULL == atomic_fetch_sub(&(H5I_mt_g.active_threads), 1ULL) )
+    {
         atomic_fetch_add(&(H5I_mt_g.times_active_threads_is_zero), 1ULL);
 
-        /* This is the only entry in H5I -- since we are about to exit, the 
-         * the entire id free list must be reallocable.  Attempt to update 
-         * H5I_mt_g.num_id_info_fl_entries_reallocable accordingly.  Note 
-         * that we must verify that no thread becomes active during this 
-         * process, and abort if one does. 
+        /* This is the only thread in H5I and since we are about to exit, the
+         * entire id and type free lists must be re-allocatable. Note we must verify 
+         * that no thread becomes active during this process, and abort if one does.
          */
         pre_api_entries = atomic_load(&(H5I_mt_g.num_H5I_entries_via_public_API));
         pre_internal_entries = atomic_load(&(H5I_mt_g.num_H5I_entries_via_internal_API));
 
         active_threads = atomic_load(&(H5I_mt_g.active_threads));
 
-        num_id_info_fl_entries_reallocable = atomic_load(&(H5I_mt_g.num_id_info_fl_entries_reallocable));
-        id_info_fl_len = atomic_load(&(H5I_mt_g.id_info_fl_len));
+        id_next_sn = atomic_load(&(H5I_mt_g.id_next_sn));
+        id_max_realloc_sn = atomic_load(&(H5I_mt_g.id_max_realloc_sn));
 
-#if 1
-        num_type_info_fl_entries_reallocable = atomic_load(&(H5I_mt_g.num_type_info_fl_entries_reallocable));
-#else
-        snum_type_info_fl_entries_reallocable = atomic_load(&(H5I_mt_g.snum_type_info_fl_entries_reallocable));
-#endif
-        type_info_fl_len = atomic_load(&(H5I_mt_g.type_info_fl_len));
+        type_next_sn = atomic_load(&(H5I_mt_g.type_next_sn));
+        type_max_realloc_sn = atomic_load(&(H5I_mt_g.type_max_realloc_sn));
 
         post_api_entries = atomic_load(&(H5I_mt_g.num_H5I_entries_via_public_API));
         post_internal_entries = atomic_load(&(H5I_mt_g.num_H5I_entries_via_internal_API));
 
-        /* test to see if any threads have entered while we were collecting the 
-         * data on the free lists.  If any have, abort, as our data on the free lists
-         * may be inconsistent.
+        /* Test to see if any threads have entered while we were collecting the data
+         * on the free lists. If any have, abort, as out data on the free lists may
+         * be inconsistent.
          */
-        if ( ( active_threads != 0 ) || ( pre_api_entries != post_api_entries ) || 
-             ( pre_internal_entries != post_internal_entries ) ) {
-
-            /* one or more threads entered while we were collecting data.  Update
-             * stats and do nothing.
+        if ( ( active_threads != 0 ) || ( pre_api_entries != post_api_entries ) ||
+             ( pre_internal_entries != post_internal_entries ) )
+        {
+            /* One or more threads entered while collecting data. 
+             * Update stats and do nothing.
              */
-            atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_aborts), 1ULL);
+            atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_max_sn_update_aborts), 1ULL);
+            atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_max_sn_update_aborts), 1ULL);
+        }
+        else /* No new threads entered while collecting data */
+        {
+            /* Must update these assertions to account for the possibility that the 
+             * serial numbers can roll over if the library runs long enough.
+             */
+            assert( id_max_realloc_sn + 1 <= id_next_sn );
+            assert( type_max_realloc_sn + 1 <= type_next_sn );
 
-        } else {
+            if ( id_max_realloc_sn + 1 == id_next_sn ) {
 
-            assert( 0 == active_threads );
-
-            if ( id_info_fl_len == num_id_info_fl_entries_reallocable ) {
-
-                /* All entries in the id info free list are already maked as reallocable --
-                 * Nothing to do here -- just update stats
-                 */
-                atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_noops), 1ULL);
+                atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_max_sn_update_noops), 1ULL);
 
             } else {
 
-                uint64_t delta;
-                uint64_t new_num_id_info_fl_entries_reallocable;
+                uint64_t saved_id_max_realloc_sn = id_max_realloc_sn;
+                
+                if ( atomic_compare_exchange_strong(&(H5I_mt_g.id_max_realloc_sn), 
+                                                    &id_max_realloc_sn, id_next_sn - 1) ) {
 
-                assert( num_id_info_fl_entries_reallocable < id_info_fl_len );
-
-                delta = id_info_fl_len - num_id_info_fl_entries_reallocable;
-
-                /* It is possible that another thread is also trying to update 
-                 * H5I_mt_g.num_id_info_fl_entries_reallocable.  To avoid duplicate
-                 * increments, update H5I_mt_g.num_id_info_fl_entries_reallocable via
-                 * a call to atomic_compare_exchange_strong().  If this fails, just 
-                 * update stats and don't attempt a re-try.
-                 */
-                new_num_id_info_fl_entries_reallocable = num_id_info_fl_entries_reallocable + delta;
-
-                if ( atomic_compare_exchange_strong(&(H5I_mt_g.num_id_info_fl_entries_reallocable),
-                                                    &num_id_info_fl_entries_reallocable,
-                                                    new_num_id_info_fl_entries_reallocable) ) {
-
-                    /* success -- update stats accordingly */
-                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_num_reallocable_updates), 1ULL);
-                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_num_reallocable_total), delta);
+                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_max_sn_updates), 1ULL);
 
                 } else {
 
-                    /* failure -- update stats accordingly */
-                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_num_reallocable_update_collisions), 1ULL);
+                    uint64_t delta;
 
+                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_max_sn_update_cols), 1ULL);
+
+                    /* collect stats on the largest positive and negaive deltas between the 
+                     * expected and actual values of H5I_mt_g.id_max_realloc_sn.
+                     */
+                    if ( saved_id_max_realloc_sn > id_max_realloc_sn ) {
+
+                        delta = saved_id_max_realloc_sn - id_max_realloc_sn;
+
+                        if ( delta > atomic_load(&(H5I_mt_g.max_id_info_fl_max_sn_update_col_delta)) ) {
+
+                            atomic_store(&(H5I_mt_g.max_id_info_fl_max_sn_update_col_delta), delta);
+                        }
+                    } else {
+
+                        assert(saved_id_max_realloc_sn < id_max_realloc_sn);
+
+                        delta = id_max_realloc_sn - saved_id_max_realloc_sn;
+
+                        if ( delta > atomic_load(&(H5I_mt_g.min_id_info_fl_max_sn_update_col_delta)) ) {
+
+                            atomic_store(&(H5I_mt_g.min_id_info_fl_max_sn_update_col_delta), delta);
+                        }
+                    }
                 }
             }
 
-#if 1
-            if ( type_info_fl_len == num_type_info_fl_entries_reallocable ) {
-#else
-            if ( type_info_fl_len == snum_type_info_fl_entries_reallocable.val ) {
-#endif
+            if ( type_max_realloc_sn + 1 == type_next_sn ) {
 
-                /* All entries in the type info free list are already maked as reallocable --
-                 * Nothing to do here -- just update stats
-                 */
-                atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_noops), 1ULL);
+                atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_max_sn_update_noops), 1ULL);
 
             } else {
 
-                uint64_t delta;
-#if 1
-                uint64_t new_num_type_info_fl_entries_reallocable;
-#else
-                H5I_suint64_t new_snum_type_info_fl_entries_reallocable;
-#endif
+                uint64_t saved_type_max_realloc_sn = id_max_realloc_sn;
+                
+                if ( atomic_compare_exchange_strong(&(H5I_mt_g.type_max_realloc_sn), 
+                                                      &type_max_realloc_sn, type_next_sn - 1) ) {
 
-#if 1
-                assert( num_type_info_fl_entries_reallocable < type_info_fl_len );
-#else
-                assert( snum_type_info_fl_entries_reallocable.val < type_info_fl_len );
-#endif
-
-#if 1
-                delta = type_info_fl_len - num_type_info_fl_entries_reallocable;
-#else
-                delta = type_info_fl_len - snum_type_info_fl_entries_reallocable.val;
-#endif
-
-                /* It is possible that another thread is also trying to update 
-                 * H5I_mt_g.num_type_info_fl_entries_reallocable.  To avoid duplicate
-                 * increments, update H5I_mt_g.num_type_info_fl_entries_reallocable via
-                 * a call to atomic_compare_exchange_strong().  If this fails, just 
-                 * update stats and don't attempt a re-try.
-                 */
-#if 1
-                new_num_type_info_fl_entries_reallocable = num_type_info_fl_entries_reallocable + delta;
-#else
-                new_snum_type_info_fl_entries_reallocable.val = snum_type_info_fl_entries_reallocable.val + delta;
-                new_snum_type_info_fl_entries_reallocable.sn  = snum_type_info_fl_entries_reallocable.sn + 1;
-#endif
-
-#if 1
-                if ( atomic_compare_exchange_strong(&(H5I_mt_g.num_type_info_fl_entries_reallocable),
-                                                    &num_type_info_fl_entries_reallocable,
-                                                    new_num_type_info_fl_entries_reallocable) ) {
-#else
-                if ( atomic_compare_exchange_strong(&(H5I_mt_g.snum_type_info_fl_entries_reallocable),
-                                                    &snum_type_info_fl_entries_reallocable,
-                                                    new_snum_type_info_fl_entries_reallocable) ) {
-
-                    fprintf(stderr, 
-                            "\nexit: old/new snum_type_info_fl_entries_reallocable = {%lld, %lld} / {%lld, %lld}\n",
-                            (long long)snum_type_info_fl_entries_reallocable.val, 
-                            (long long)snum_type_info_fl_entries_reallocable.sn,
-                            (long long)new_snum_type_info_fl_entries_reallocable.val, 
-                            (long long)new_snum_type_info_fl_entries_reallocable.sn);
-#endif
-
-                    /* success -- update stats accordingly */
-                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_num_reallocable_updates), 1ULL);
-                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_num_reallocable_total), delta);
+                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_max_sn_updates), 1ULL);
 
                 } else {
+                    uint64_t delta;
 
-                    /* failure -- update stats accordingly */
-                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_num_reallocable_update_collisions), 1ULL);
+                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_max_sn_update_cols), 1ULL);
 
+                    /* collect stats on the largest positive and negaive deltas between the 
+                     * expected and actual values of H5I_mt_g.type_max_realloc_sn.
+                     */
+                    if ( saved_type_max_realloc_sn > type_max_realloc_sn ) {
+
+                        delta = saved_type_max_realloc_sn - type_max_realloc_sn;
+
+                        if ( delta > atomic_load(&(H5I_mt_g.max_type_info_fl_max_sn_update_col_delta) )) {
+
+                            atomic_store(&(H5I_mt_g.max_type_info_fl_max_sn_update_col_delta), delta);
+                        }
+                    } else {
+
+                        assert(saved_type_max_realloc_sn < type_max_realloc_sn);
+
+                        delta = type_max_realloc_sn - saved_type_max_realloc_sn;
+
+                        if ( delta > atomic_load(&(H5I_mt_g.min_type_info_fl_max_sn_update_col_delta)) ) {
+
+                            atomic_store(&(H5I_mt_g.min_type_info_fl_max_sn_update_col_delta), delta);
+                        }
+                    }
                 }
             }
         }
@@ -10750,7 +10064,7 @@ H5I__exit(void)
 
     return;
 
-} /* H5I__exit() */
+} /* end H5I__exit() */
 
 #endif /* H5_HAVE_MULTITHREAD */
 

--- a/src/H5Ipkg.h
+++ b/src/H5Ipkg.h
@@ -220,14 +220,13 @@ typedef struct H5I_suint64_t {
  *      Second, instead of booleans, the cells are integers to allow for 
  *      multiple threads setting and re-setting it.
  *
- *      The primary impetus for this change to to prevent interference between 
- *      different threads working on different types interfering with each other 
- *      via a shared marking flag.  While this doesn't seem to be much of a 
- *      problem in normal operation, it can cause major memory leaks during 
- *      type destroys.
+ *      The primary impetus for this change is to prevent different threads 
+ *      working on different types interfering with each other via a shared marking 
+ *      flag.  While this doesn't seem to be much of a problem in normal operation, 
+ *      it can cause major memory leaks during type destroys.
  *
  *      Note that the introduction of the marking_array doesn't completely solve
- *      the problem, as there is still the possibility of interverience between 
+ *      the problem, as there is still the possibility of interferience between 
  *      multiple threads acting on the same type.  However, it does greatly 
  *      ameliorate the issue.
  *
@@ -271,12 +270,20 @@ typedef struct H5I_suint64_t {
  *      id info free list length.  This is of necessity a soft limit as entries cannot
  *      be removed from the head of the free list unless they are re-allocable.
  *
- * num_id_info_fl_entries_reallocable:  Atomic uint64_t containing the number of entries 
- *      in the id info free list that are known to have no remaining threads in H5I
- *      that retain pointers to them, and are thus reallocable.  If this field is positive,
- *      any thread may decrement it, and take the next entry off the head of the id info 
- *      free list and re-use it.
- *
+ * id_next_sn: Atomic uint64_t containing the serial number for the next entry on the ID 
+ *      info free list. Whenever an entry is added to the id info free list, that entry's
+ *      serial_num field is set equal to id_next_sn and id_next_sn gets incremented. The
+ *      entry's serial_num field is compared to the id_max_realloc_sn field below and if
+ *      serial_num is smaller than it can be reallocated.
+ * 
+ *      For this iteration the assumption is made that id_next_sn will not be incremented
+ *      enough to overflow, but eventually this must be taken into account.
+ * 
+ * id_max_realloc_sn: Atomic uint64_t containing one plus the maximum serial number that
+ *      can be reallocated. When an entry's serial number gets compared to this field, if
+ *      it is less than this field, then it can be reallocated. This field is updated 
+ *      in H5I__exit() if there are not other threads in H5I -- in which case it is 
+ *      set to one greater than id_next_sn.
  *
  * type_info_fl_shead: Atomic instance of struct H5I_mt_type_info_sptr_t, which contains 
  *      a pointer (ptr) to the head of the type info free list, and a serial number (sn) 
@@ -307,11 +314,20 @@ typedef struct H5I_suint64_t {
  *      type info free list length.  This is of necessity a soft limit as entries cannot
  *      be removed from the head of the free list unless they are re-allocable.
  *
- * num_type_info_fl_entries_reallocable:  Atomic uint64_t containing the number of entries 
- *      in the type info free list that are known to have no remaining threads in H5I
- *      that retain pointers to them, and are thus reallocable.  If this field is positive, 
- *      any thread may decrement it, and then take the next entry off the head of the type
- *      info list and re-use it.
+ * type_next_sn: Atomic uint64_t containing the serial number for the next entry on the 
+ *      type info free list. Whenever an entry is added to the id info free list, that 
+ *      entry's serial_num field is set equal to id_next_sn and id_next_sn gets incremented. 
+ *      The entry's serial_num field is compared to the id_max_realloc_sn field below and 
+ *      if serial_num is smaller than it can be reallocated.
+ * 
+ *      For this iteration the assumption is made that type_next_sn will not be incremented
+ *      enough to overflow, but eventually this must be taken into account.
+ * 
+ * type_max_realloc_sn: Atomic uint64_t containing one plus the maximum serial number that
+ *      can be reallocated. When an entry's serial number gets compared to this field, if
+ *      it is less than this field, then it can be reallocated. This field is updated
+ *      in H5I__exit() if there are not other threads in H5I -- in which case it is
+ *      set to one greater than id_next_sn.
  *
  *
  * Statistics:
@@ -355,14 +371,6 @@ typedef struct H5I_suint64_t {
  * num_id_info_fl_append_cols: Number of collisions when appending an instance of 
  *     H5I_mt_id_info_t to the id info free list.
  *
- * num_id_info_structs_marked_reallocatable: Each instance of H5I_mt_id_info_t has its 
- *      reallocatable field set to FALSE when it is allocated, or it is inserted
- *      on the id info free list. This field is set to TRUE when it is known that all
- *      threads that might have a pointer to the instance of H5I_mt_id_info_t have left
- *      H5I.  num_id_info_structs_marked_reallocatable is incremented each time the 
- *      reallocatable field of an instance of H5I_mt_id_info_t is set to TRUE.  Note
- *      that this should only happen when an instance is on the id info free list.
- *
  * num_id_info_fl_alloc_req_denied_due_to_empty:  Number of times an alloc request
  *      for an instance of H5I_mt_id_info_t has had to be satisfied from the heap
  *      instead of the free list because the id info free list is empty.  Recall 
@@ -371,7 +379,8 @@ typedef struct H5I_suint64_t {
  *
  * num_id_info_fl_alloc_req_denied_due_to_no_reallocable_entries:  Number of times an 
  *      alloc request for an instance of H5I_mt_id_info_t has had to be satisfied from
- *      the heap because num_id_info_fl_entries_reallocable is zero.
+ *      the heap because the serial number of the entry at the head of the free list
+ *      has serial number greater than or equal to id_max_realloc_sn,
  *
  * num_id_info_fl_frees_skipped_due_to_empty: Number of times that an instance of 
  *      H5I_mt_id_info_t on the id info free list is not released to the heap because
@@ -384,26 +393,9 @@ typedef struct H5I_suint64_t {
  *
  * num_id_info_fl_frees_skipped_due_to_no_reallocable_entries: Number of times that an 
  *      instance of H5I_mt_id_info_t on the id info free list is not released to the heap 
- *      because num_id_info_fl_entries_reallocable is zero.
- *
- * num_id_info_fl_num_reallocable_update_aborts:  Number of times that an attempt to 
- *      update the number of reallocable entries on the id info free list has had to 
- *      be aborted due to the entry of another thread into H5I during the collection 
- *      of data needed to compute the new value of num_id_info_fl_entries_reallocable.
- *
- * num_id_info_fl_num_reallocable_update_noops: Number of times that an attempt to
- *      update the number of reallocable entries on the id info free list has been 
- *      skipped because all entries on the list are already reallocable.
- *
- * num_id_info_fl_num_reallocable_update_collisions: Number of collisions while attempting
- *      to update num_id_info_fl_entries_reallocable.
- *
- * num_id_info_fl_num_reallocable_updates: Number of successful updates of 
- *      num_id_info_fl_entries_reallocable.
- *
- * num_id_info_fl_num_reallocable_total; Sum of all the deltas added to 
- *      num_id_info_fl_entries_reallocable.
- *
+ *      because the entry at the head of the free list has serial number greater than 
+ *      or equal to id_max_realloc_sn.
+ * 
  * H5I__discard_mt_id_info__num_calls: Number of times that H5I__discard_mt_id_info() is 
  *      called.
  *
@@ -411,6 +403,45 @@ typedef struct H5I_suint64_t {
  *
  * H5I__clear_mt_id_info_free_list__num_calls: Number of times that 
  *      H5I__clear_mt_id_info_free_list() is called.
+ *
+ * num_id_next_sn_assigned: Number of times the serial_num field of an instance of
+ *      H5I_mt_id_info_t is successfully set to H5I_mt_t.id_next_sn on append to the 
+ *      id free list.
+ * 
+ * num_id_serial_num_resets: Number of times the serial_num field of an instance of
+ *      H5I_mt_id_info_t is successfully set to zero on removal of the struct from 
+ *      the free list either for reallocation or release to the heap.
+ * 
+ * num_id_info_fl_head_sn_is_zero: Number of times that the head of the id info free 
+ *      list is found to have a zero serial number. 
+ *
+ *      This should be impossible.  The statistic is kept to verify this.
+ * 
+ * num_id_info_fl_max_sn_update_noops: Number of times that an attempt to update the 
+ *      maximum reallocable serial number on the id info free list has been skipped 
+ *      because all entries on the list are already reallocable.
+ * 
+ * num_id_info_fl_max_sn_update_aborts: Number of times that an attempt to update the
+ *      maximum reallocable serial number on the id free list has had to be aborted due to
+ *      the entry of another thread into H5I during the collection of data needed to compute 
+ *      the new value of id_max_realloc_sn.
+ * 
+ * num_id_info_fl_max_sn_updates: Number of successful updates of id_max_realloc_sn.
+ * 
+ * num_id_info_fl_max_sn_update_decrement: Number of times that the maximum reallocable
+ *      serial number was updated and the max prior to the update was larger than 
+ *      id_next_sn field.
+ * 
+ * num_id_info_fl_max_sn_update_cols: Number of collisions while attempting to update 
+ *      id_max_realloc_sn.
+ * 
+ * max_id_info_fl_max_sn_update_col_delta: Maximum positive difference between the 
+ *      expected and actual values of id_max_realloc_sn found on a id_max_realloc_sn
+ *      collision.
+ *
+ * min_id_info_fl_max_sn_update_col_delta; Maximum negative difference between the
+ *      expected and actual values of id_max_realloc_sn found on a id_max_realloc_sn
+ *      update collision.
  *
  *
  * Type Info Free List Statistics:
@@ -438,14 +469,6 @@ typedef struct H5I_suint64_t {
  * num_type_info_fl_append_cols: Number of collisions when appending an instance of 
  *     H5I_mt_type_info_t to the type info free list.
  *
- * num_type_info_structs_marked_reallocatable: Each instance of H5I_mt_type_info_t has its 
- *      reallocatable field set to FALSE when it is allocated, or it is inserted
- *      on the type info free list. This field is set to TRUE when it is known that all
- *      threads that might have a pointer to the instance of H5I_mt_type_info_t have left
- *      H5I.  num_type_info_structs_marked_reallocatable is incremented each time the 
- *      reallocatable field of an instance of H5I_mt_type_info_t is set to TRUE.  Note
- *      that this should only happen when an instance is on the type info free list.
- *
  * num_type_info_fl_alloc_req_denied_due_to_empty:  Number of times an alloc request
  *      for an instance of H5I_mt_type_info_t has had to be satisfied from the heap
  *      instead of the free list because the type info free list is empty.  Recall 
@@ -454,7 +477,8 @@ typedef struct H5I_suint64_t {
  *
  * num_type_info_fl_alloc_req_denied_due_to_no_reallocable_entries:  Number of times an 
  *      alloc request for an instance of H5I_mt_type_info_t has had to be satisfied from
- *      the heap because num_type_info_fl_entries_reallocable is zero.
+ *      the heap because the entry at the head of the free list has serial number greater
+ *      than or equal to type_max_realloc_sn.
  *
  * num_type_info_fl_frees_skipped_due_to_empty: Number of times that an instance of 
  *      H5I_mt_type_info_t on the type info free list is not released to the heap because
@@ -467,26 +491,9 @@ typedef struct H5I_suint64_t {
  *
  * num_type_info_fl_frees_skipped_due_to_no_reallocable_entries: Number of times that an 
  *      instance of H5I_mt_type_info_t on the type info free list is not released to the heap 
- *      because num_type_info_fl_entries_reallocable is zero.
- *
- * num_type_info_fl_num_reallocable_update_aborts:  Number of times that an attempt to 
- *      update the number of reallocable entries on the type info free list has had to 
- *      be aborted due to the entry of another thread into H5I during the collection 
- *      of data needed to compute the new value of num_type_info_fl_entries_reallocable.
- *
- * num_type_info_fl_num_reallocable_update_noops: Number of times that an attempt to
- *      update the number of reallocable entries on the type info free list has been 
- *      skipped because all entries on the list are already reallocable.
- *
- * num_type_info_fl_num_reallocable_update_collisions: Number of collisions while attempting
- *      to update num_type_info_fl_entries_reallocable.
- *
- * num_type_info_fl_num_reallocable_updates: Number of successful updates of 
- *      num_type_info_fl_entries_reallocable.
- *
- * num_type_info_fl_num_reallocable_total; Sum of all the deltas added to 
- *      num_type_info_fl_entries_reallocable.
- *
+ *      because the entry at the head of the free list has serial number greater than 
+ *      or equal to type_max_realloc_sn.
+ * 
  * H5I__discard_mt_type_info__num_calls: Number of times that H5I__discard_mt_type_info() is 
  *      called.
  *
@@ -494,6 +501,50 @@ typedef struct H5I_suint64_t {
  *
  * H5I__clear_mt_type_info_free_list__num_calls: Number of times that 
  *      H5I__clear_mt_type_info_free_list() is called.
+ *
+ * num_type_info_fl_num_reallocable_update_aborts: Number of times that an attempt to update the
+ *      maximum reallocable serial number on the type info free list has had to be aborted due to
+ *      the entry of another thread into H5I during the collection of data needed to compute 
+ *      the new value of type_max_realloc_sn.
+ * 
+ * num_type_next_sn_assigned: Number of times the serial_num field of an instance of
+ *      H5I_mt_type_info_t is successfully set to H5I_mt_t.type_next_sn on append to the 
+ *      type free list.
+ * 
+ * num_type_serial_num_resets: Number of times the serial_num field of an instance of
+ *      H5I_mt_type_info_t is successfully set to zero on removal of the struct from 
+ *      the type free list.
+ * 
+ * num_type_info_fl_head_sn_is_zero: Number of times that the head of the type info free 
+ *      list is found to have a zero serial number. 
+ *
+ *      This should be impossible.  The statistic is kept to verify this.
+ * 
+ * num_type_info_fl_max_sn_update_noops: Number of times that an attempt to update the 
+ *      maximum reallocable serial number on the type info free list has been skipped 
+ *      because all entries on the list are already reallocable.
+ * 
+ * num_type_info_fl_max_sn_update_aborts: Number of times that an attempt to update the
+ *      maximum reallocable serial number on the type free list has had to be aborted due to
+ *      the entry of another thread into H5I during the collection of data needed to compute 
+ *      the new value of type_max_realloc_sn.
+ * 
+ * num_type_info_fl_max_sn_updates: Number of successful updates of type_max_realloc_sn.
+ * 
+ * num_type_info_fl_max_sn_update_decrement: Number of times that the maximum reallocable
+ *      serial number was updated and the max prior to the update was larger than 
+ *      type_next_sn field.
+ * 
+ * num_type_info_fl_max_sn_update_cols: Number of collisions while attempting to update 
+ *      type_max_realloc_sn.
+ * 
+ * max_type_info_fl_max_sn_update_col_delta: Maximum positive difference between the 
+ *      expected and actual values of type_max_realloc_sn found on a type_max_realloc_sn
+ *      collision.
+ *
+ * min_type_info_fl_max_sn_update_col_delta; Maximum negative difference between the
+ *      expected and actual values of type_max_realloc_sn found on a type_max_realloc_sn
+ *      update collision.
  *
  * 
  *
@@ -905,13 +956,15 @@ typedef struct H5I_mt_t {
     _Atomic H5I_mt_id_info_sptr_t   id_info_fl_stail;
     _Atomic uint64_t                id_info_fl_len;
     _Atomic uint64_t                max_desired_id_info_fl_len;
-    _Atomic uint64_t                num_id_info_fl_entries_reallocable;
+    _Atomic uint64_t                id_next_sn;
+    _Atomic uint64_t                id_max_realloc_sn;
 
     _Atomic H5I_mt_type_info_sptr_t type_info_fl_shead;
     _Atomic H5I_mt_type_info_sptr_t type_info_fl_stail;
     _Atomic uint64_t                type_info_fl_len;
     _Atomic uint64_t                max_desired_type_info_fl_len;
-    _Atomic uint64_t                num_type_info_fl_entries_reallocable;
+    _Atomic uint64_t                type_next_sn;
+    _Atomic uint64_t                type_max_realloc_sn;
 
     /* Statistics: */
 
@@ -931,20 +984,24 @@ typedef struct H5I_mt_t {
     _Atomic uint64_t num_id_info_fl_head_update_cols;
     _Atomic uint64_t num_id_info_fl_tail_update_cols;
     _Atomic uint64_t num_id_info_fl_append_cols;
-    _Atomic uint64_t num_id_info_structs_marked_reallocatable;
     _Atomic uint64_t num_id_info_fl_alloc_req_denied_due_to_empty;
     _Atomic uint64_t num_id_info_fl_alloc_req_denied_due_to_no_reallocable_entries;
     _Atomic uint64_t num_id_info_fl_frees_skipped_due_to_empty;
     _Atomic uint64_t num_id_info_fl_frees_skipped_due_to_fl_too_small;
     _Atomic uint64_t num_id_info_fl_frees_skipped_due_to_no_reallocable_entries;
-    _Atomic uint64_t num_id_info_fl_num_reallocable_update_aborts;
-    _Atomic uint64_t num_id_info_fl_num_reallocable_update_noops;
-    _Atomic uint64_t num_id_info_fl_num_reallocable_update_collisions;
-    _Atomic uint64_t num_id_info_fl_num_reallocable_updates;
-    _Atomic uint64_t num_id_info_fl_num_reallocable_total;
     _Atomic uint64_t H5I__discard_mt_id_info__num_calls;
     _Atomic uint64_t H5I__new_mt_id_info__num_calls;
     _Atomic uint64_t H5I__clear_mt_id_info_free_list__num_calls;
+
+    _Atomic uint64_t num_id_next_sn_assigned;
+    _Atomic uint64_t num_id_serial_num_resets;
+    _Atomic uint64_t num_id_info_fl_head_sn_is_zero;
+    _Atomic uint64_t num_id_info_fl_max_sn_update_noops;
+    _Atomic uint64_t num_id_info_fl_max_sn_update_aborts;
+    _Atomic uint64_t num_id_info_fl_max_sn_updates;
+    _Atomic uint64_t num_id_info_fl_max_sn_update_cols;
+    _Atomic uint64_t max_id_info_fl_max_sn_update_col_delta;
+    _Atomic uint64_t min_id_info_fl_max_sn_update_col_delta;
 
 
     /* type info free list stats */
@@ -956,20 +1013,25 @@ typedef struct H5I_mt_t {
     _Atomic uint64_t num_type_info_fl_head_update_cols;
     _Atomic uint64_t num_type_info_fl_tail_update_cols;
     _Atomic uint64_t num_type_info_fl_append_cols;
-    _Atomic uint64_t num_type_info_structs_marked_reallocatable;
     _Atomic uint64_t num_type_info_fl_alloc_req_denied_due_to_empty;
     _Atomic uint64_t num_type_info_fl_alloc_req_denied_due_to_no_reallocable_entries;
     _Atomic uint64_t num_type_info_fl_frees_skipped_due_to_empty;
     _Atomic uint64_t num_type_info_fl_frees_skipped_due_to_fl_too_small;
     _Atomic uint64_t num_type_info_fl_frees_skipped_due_to_no_reallocable_entries;
-    _Atomic uint64_t num_type_info_fl_num_reallocable_update_aborts;
-    _Atomic uint64_t num_type_info_fl_num_reallocable_update_noops;
-    _Atomic uint64_t num_type_info_fl_num_reallocable_update_collisions;
-    _Atomic uint64_t num_type_info_fl_num_reallocable_updates;
-    _Atomic uint64_t num_type_info_fl_num_reallocable_total;
     _Atomic uint64_t H5I__discard_mt_type_info__num_calls;
     _Atomic uint64_t H5I__new_mt_type_info__num_calls;
     _Atomic uint64_t H5I__clear_mt_type_info_free_list__num_calls;
+
+    _Atomic uint64_t num_type_next_sn_assigned;
+    _Atomic uint64_t num_type_serial_num_resets;
+    _Atomic uint64_t num_type_info_fl_head_sn_is_zero;
+    _Atomic uint64_t num_type_info_fl_max_sn_update_noops;
+    _Atomic uint64_t num_type_info_fl_max_sn_update_aborts;
+    _Atomic uint64_t num_type_info_fl_max_sn_updates;
+    _Atomic uint64_t num_type_info_fl_max_sn_update_decrement;
+    _Atomic uint64_t num_type_info_fl_max_sn_update_cols;
+    _Atomic uint64_t max_type_info_fl_max_sn_update_col_delta;
+    _Atomic uint64_t min_type_info_fl_max_sn_update_col_delta;
 
 
     /* H5I__mark_node() stats */
@@ -1130,7 +1192,6 @@ typedef struct H5I_mt_t {
  * id:  ID associated with this instance of H5I_mt_id_info_t.  This is the id used to 
  *      locate the instance in the lock free hash table. 
  * 
- * 
  * k:   The non-MT version of H5I_mt_id_info_t has a number of variables that must be
  *      kept in synchronization.  The obvious way of doing this would be to protect
  *      them with a mutex.  However, it seems best to avoid locking to the extent
@@ -1247,7 +1308,7 @@ typedef struct H5I_mt_t {
  * 
  *          Otherwise: 
  * 
- *       5) Set the do_not_disturb flag and the hsve_global_mutex flag as well if 
+ *       5) Set the do_not_disturb flag and the have_global_mutex flag as well if 
  *          either the global mutex is already held, or if the callback is not thread
  *          safe (always for now) in the local copy of the kernel, and attempt 
  *          to overwrite the global copy of the kernel with the local copy via a 
@@ -1255,7 +1316,7 @@ typedef struct H5I_mt_t {
  * 
  *          If this fails, do a thread yield or sleep, and return to 1. 
  * 
- *          If it succeeds, we know that s thread has exclusive access to the kernel until 
+ *          If it succeeds, we know that a thread has exclusive access to the kernel until 
  *          we reset the do_not_disturb flag on the global copy, as no new thread 
  *          looking at the kernel will proceed beyond reading the flag, and the 
  *          compare_exchange_strong() of any existing thread attempting to modify the 
@@ -1381,6 +1442,23 @@ typedef struct H5I_mt_t {
  *      id info free list.  The structure contains both a pointer and a serial   
  *      number, which facilitates the avoidance of ABA bugs when managing the free
  *      list. 
+ *
+ * serial_num: unsigned int 64 that is always 0 when not on the ID free list.
+ *      When added to the free list this value is set equal to H5I_mt_g's 
+ *      id_next_sn field, and that field is then incremented. The value of serial_num
+ *      is used by the free list to determine if an entry can be reallocated. 
+ *
+ *      When a new instance of H5I_mt_id_info_t is needed, the free list is checked.
+ *      If the list contains more than one entry, and the serial_num field of the 
+ *      entry at the head of the list is less than H5I_mt_g.id_max_realloc_sn, the 
+ *      entry at the head of the free list may be removed from the free list and 
+ *      reallocated.  
+ *
+ *      The serial_num field is set to zero on removal from the free list, 
+ * 
+ *      At present, there is no provision for the case in which H5I_mt_g.id_next_sn 
+ *      wraps around.  While it is unlikely that this will be a problem any time 
+ *      soon, this issue must be addressed in the production version.
  * 
  ************************************************************************************/
 
@@ -1415,6 +1493,8 @@ typedef struct H5I_mt_id_info_t {
     _Atomic hbool_t on_fl;
 
     _Atomic H5I_mt_id_info_sptr_t fl_snext;
+
+    _Atomic uint64_t serial_num;
 
 } H5I_mt_id_info_t;
 
@@ -1467,6 +1547,24 @@ typedef struct H5I_mt_id_info_t {
  * fl_snext: Atomic instance of H5I_mt_type_info_sptr_t used in the maintenance of the 
  *      type info free list.  The structure contains both a pointer and a serial number,
  *      which facilitates the avoidance of ABA bugs when managing the free list.
+ *
+ * serial_num: unsigned int 64 that is always 0 when not on the type info free list.
+ *      When added to the free list this value is set equal to H5I_mt_g's 
+ *      type_next_sn field, and that field is then incremented. The value of serial_num
+ *      is used by the free list to determine if an entry can be reallocated. 
+ *
+ *      When a new instance of H5I_mt_type_info_t is needed, the free list is checked.
+ *      If the list contains more than one entry, and the serial_num field of the 
+ *      entry at the head of the list is less than H5I_mt_g.type_max_realloc_sn, the 
+ *      entry at the head of the free list may be removed from the free list and 
+ *      reallocated.  
+ *
+ *      The serial_num field is set to zero on removal from the free list, 
+ * 
+ *      At present, there is no provision for the case in which H5I_mt_g.type_next_sn 
+ *      wraps around.  While it is unlikely that this will be a problem any time 
+ *      soon, this issue must be addressed in the production version.
+ * 
  * 
  ****************************************************************************************/
 
@@ -1485,6 +1583,9 @@ typedef struct H5I_mt_type_info_t {
     lfht_t                          lfht;         /* lock free hash table for this ID type */
     _Atomic hbool_t                 on_fl;
     _Atomic H5I_mt_type_info_sptr_t fl_snext;
+
+    _Atomic uint64_t                serial_num;
+
 } H5I_type_info_t;
 
 #else /* H5_HAVE_MULTITHREAD */ /********************************************************************************/
@@ -1544,9 +1645,9 @@ H5_DLLVAR H5I_type_info_t *H5I_type_info_array_g[H5I_MAX_NUM_TYPES];
 H5_DLLVAR int H5I_next_type_g;
 #endif /* H5_HAVE_MULTITHREAD */
 
-/******************************/
-/* Package Private Prototypes */
-/******************************/
+/*****************************/
+/* Package Private Variables */
+/*****************************/
 
 H5_DLL hid_t          H5I__register(H5I_type_t type, const void *object, hbool_t app_ref,
                                     H5I_future_realize_func_t realize_cb, H5I_future_discard_func_t discard_cb);

--- a/src/H5Pint_mt.c
+++ b/src/H5Pint_mt.c
@@ -1,0 +1,944 @@
+/*
+ * Purpose: Multi-Thread Safe Generic Property Functions
+ */
+
+/****************/
+/* Module Setup */
+/****************/
+
+#include "H5Pmodule.h" /* This source code file is part of the H5P module */
+
+/***********/
+/* Headers */
+/***********/
+#include "H5private.h" /* Generic Functions			*/
+#ifdef H5_HAVE_PARALLEL
+#include "H5ACprivate.h" /* Metadata cache                       */
+#endif                   /* H5_HAVE_PARALLEL */
+#include "H5Eprivate.h"  /* Error handling		  	*/
+#include "H5Fprivate.h"  /* File access				*/
+#include "H5FLprivate.h" /* Free lists                           */
+#include "H5Iprivate.h"  /* IDs			  		*/
+#include "H5MMprivate.h" /* Memory management			*/
+#include "H5Ppkg.h"      /* Property lists		  	*/
+#include "H5Ppkg_mt.h"
+
+
+/****************/
+/* Local Macros */
+/****************/
+
+#ifdef H5_HAVE_MULTITHREAD
+
+#define H5P_MT_DEBUG 0
+
+
+/******************/
+/* Local Typedefs */
+/******************/
+
+typedef enum { PCLASS, PLIST } type_t;
+
+typedef union 
+{
+    H5P_mt_class_t *pclass;
+    H5P_mt_list_t  *plist;
+
+} type_union_t;
+
+typedef struct 
+{
+    type_t       type;
+    type_union_t data;
+
+} param_t;
+
+/********************/
+/* Package Typedefs */
+/********************/
+
+/********************/
+/* Local Prototypes */
+/********************/
+H5P_mt_class_t * H5P__create_class(H5P_mt_class_t *parent, uint64_t parent_version,
+                                   const char *name, H5P_plist_type_t type);
+
+int64_t H5P__calc_checksum(const char *name);
+
+H5P_mt_prop_t *
+    H5P__create_prop(const char *name, void *value_ptr, size_t value_size, 
+                     bool in_prop_class, uint64_t create_version);
+
+herr_t H5P__insert_prop_class(H5P_mt_prop_t *prop, H5P_mt_class_t *class);
+
+herr_t H5P__delete_prop_class(H5P_mt_prop_t *prop, H5P_mt_class_t *class);
+
+H5P_mt_prop_t * H5P__search_prop_class(H5P_mt_prop_t *prop, H5P_mt_class_t *class);
+
+void find_mod_point(H5P_mt_class_t *class, H5P_mt_prop_t **first_ptr_ptr, 
+                    H5P_mt_prop_t **second_ptr, int32_t *deletes_comp, 
+                    int32_t *nodes_visited, int32_t *thrd_cols,
+                    int64_t target_chksum);
+
+
+herr_t H5P__insert_prop_list(H5P_mt_prop_t prop, H5P_mt_list_t list);
+herr_t H5P__delete_prop_list(H5P_mt_prop_t prop, H5P_mt_list_t list);
+H5P_mt_prop_t H5P__search_prop_list(H5P_mt_prop_t prop, H5P_mt_list_t list);
+
+
+/*********************/
+/* Package Variables */
+/*********************/
+
+H5P_mt_class_t *H5P_CLS_ROOT_g = NULL;
+
+/*****************************/
+/* Library Private Variables */
+/*****************************/
+
+/*******************/
+/* Local Variables */
+/*******************/
+
+/*-------------------------------------------------------------------------
+ * Function:    H5P_init
+ *
+ * Purpose:     Initialize the interface from some other layer.
+ *
+ *              At present, this function performs initializations needed
+ *              for the multi-thread build of H5P.  Thus it need not be 
+ *              called in other contexts.
+ *
+ * Return:      SUCCEED/FAIL    
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5P_init(void)
+{
+    H5P_mt_prop_t  * neg_sentinel;
+    H5P_mt_prop_t  * pos_sentinel;
+
+    H5P_mt_class_t * root_class;
+
+    herr_t           ret_value = SUCCEED;
+
+
+    /* Allocating and initializing the two sentinel nodes for the LFSLL in the class */
+    neg_sentinel = H5P__create_prop("neg_sentinel", NULL, 0, FALSE, 0);
+    pos_sentinel = H5P__create_prop("pos_sentinel", NULL, 0, FALSE, 0);
+
+    /* Adjusting the sentinel bool to TRUE */
+    neg_sentinel->sentinel = TRUE;
+    pos_sentinel->sentinel = TRUE;
+
+    /* Adjusting chksum to the min and max of int64_t for these to be sentinel nodes */
+    neg_sentinel->chksum = LLONG_MIN;
+    pos_sentinel->chksum = LLONG_MAX;
+
+    atomic_store(&(neg_sentinel->next.ptr), pos_sentinel);
+
+
+    /* Allocating and Initializing the root property list class */
+
+    /* Allocate memory for the root property list class */
+    root_class = (H5P_mt_class_t *)malloc(sizeof(H5P_mt_class_t));
+    if ( ! root_class )
+        printf(stderr, "New class allocation failed.");
+
+    /* Initialize class fields */
+    root_class->tag = H5P_MT_CLASS_TAG;
+
+    root_class->parent_id      = 0;
+    root_class->parent_ptr     = NULL;
+    root_class->parent_version = 0;
+
+    root_class->name = "root";
+    atomic_store(&(root_class->id), H5I_INVALID_HID);
+    root_class->type = H5P_TYPE_ROOT;
+
+    atomic_store(&(root_class->curr_version), 1);
+    atomic_store(&(root_class->next_version), 2);
+
+    root_class->pl_head = neg_sentinel;
+    atomic_store(&(root_class->log_pl_len),  0);
+    atomic_store(&(root_class->phys_pl_len), 2);
+
+    atomic_store(&(root_class->ref_count.pl),      0);
+    atomic_store(&(root_class->ref_count.plc),     0);
+    atomic_store(&(root_class->ref_count.deleted), FALSE);
+
+    atomic_store(&(root_class->thrd.count),   1);
+    atomic_store(&(root_class->thrd.opening), TRUE);
+    atomic_store(&(root_class->thrd.closing), FALSE);
+
+    atomic_store(&(root_class->fl_next.ptr), NULL);
+    atomic_store(&(root_class->fl_next.sn),  0);
+
+
+} /* H5P_init() */
+
+
+
+H5P_mt_class_t *
+H5P__create_class(H5P_mt_class_t *parent, uint64_t parent_version, 
+                  const char *name, H5P_plist_type_t type)
+{
+    H5P_mt_class_t * new_class;
+
+    H5P_mt_class_t * ret_value = NULL;
+
+    /* Allocate memory for the new property list class */
+    new_class = (H5P_mt_class_t *)malloc(sizeof(H5P_mt_class_t));
+    if ( ! new_class )
+        printf(stderr, "New class allocation failed.");
+
+    /* Initialize class fields */
+    new_class->tag = H5P_MT_CLASS_TAG;
+
+    new_class->parent_id      = parent->id;
+    new_class->parent_ptr     = parent;
+    new_class->parent_version = parent_version;
+
+    new_class->name = name;
+    atomic_store(&(new_class->id), H5I_INVALID_HID);
+    new_class->type = type;
+
+    atomic_store(&(new_class->curr_version), 1);
+    atomic_store(&(new_class->next_version), 2);
+
+    new_class->pl_head = NULL;
+    atomic_store(&(new_class->log_pl_len),  0);
+    atomic_store(&(new_class->phys_pl_len), 2);
+
+    atomic_store(&(new_class->ref_count.pl),      0);
+    atomic_store(&(new_class->ref_count.plc),     0);
+    atomic_store(&(new_class->ref_count.deleted), FALSE);
+
+    atomic_store(&(new_class->thrd.count),   1);
+    atomic_store(&(new_class->thrd.opening), TRUE);
+    atomic_store(&(new_class->thrd.closing), FALSE);
+
+    atomic_store(&(new_class->fl_next.ptr), NULL);
+    atomic_store(&(new_class->fl_next.sn),  0);
+
+
+} /* H5P__create_class() */
+
+
+
+int64_t 
+H5P__calc_checksum(const char* name)
+{
+    uint32_t        sum1; /* First Fletcher chksum accumulator */
+    uint32_t        sum2; /* Second Fletcher chksum accumulator */
+    const uint8_t * data; /* value to hold input name in bytes */
+    size_t          len;  /* Length of the input name */
+    size_t          tlen; /* temp length if name is long enough to be broken up */
+
+    assert(name);
+
+    /* Initializes the accumulators */
+    sum1 = 0xFFFF; 
+    sum2 = 0xFFFF; 
+
+    /* Casts the input name to bytes */
+    data = (const uint8_t *)name; 
+    len = strlen(name);  
+
+    /**
+     * Loop to process the name in chunks
+     * NOTE: Most names should be processed in only one chunk, but this is
+     * still set up as a safety net to prevent integer overflow.
+     */
+    while (len) 
+    {
+        /* Process chucks of 360 bytes */
+        size_t tlen = (len > 360) ? 360 : len; 
+        len -= tlen;
+
+        do 
+        {
+            sum1 += *data++; /* Add the current byte to sum1 */
+            sum2 += sum1;    /* Add the updated sum1 to sum2 */
+            tlen--;
+
+        } while (tlen);
+
+        /* Reduce sums to 16 bits */
+        sum1 = (sum1 & 0xFFFF) + (sum1 >> 16);
+        sum2 = (sum2 & 0xFFFF) + (sum2 >> 16);
+
+    } /* end while (len) */
+
+    /* Final reduction to 16 bits */
+    sum1 = (sum1 & 0xFFFF) + (sum1 >> 16);
+    sum2 = (sum2 & 0xFFFF) + (sum2 >> 16);
+
+    return (sum2 << 16) | sum1; /* Combine the two 16-bit sums into a 32-bit checksum */
+
+} /* H5P__calc_checksum() */
+
+
+
+H5P_mt_prop_t *
+H5P__create_prop(const char *name, void *value_ptr, size_t value_size, 
+                 bool in_prop_class, uint64_t version)
+{
+    H5P_mt_prop_t * new_prop;
+
+    H5P_mt_prop_t * ret_value = NULL;
+
+    assert(name);
+
+    /* Allocate memory for the new property */
+    new_prop = (H5P_mt_prop_t *)malloc(sizeof(H5P_mt_prop_t));
+    if ( ! new_prop )
+        printf(stderr, "New property allocation failed."); 
+
+    /* Initalize property fields */
+    new_prop->tag = H5P_MT_PROP_TAG;
+
+    atomic_store(&(new_prop->next.ptr),     NULL);
+    atomic_store(&(new_prop->next.deleted), FALSE);
+
+    new_prop->sentinel      = FALSE;
+    new_prop->in_prop_class = in_prop_class;
+
+    /* ref_count is only used if the property is in a property class. */
+    atomic_store(&(new_prop->ref_count), 0);
+
+    new_prop->chksum = H5P__calc_checksum(name);
+
+    new_prop->name = (char *)name;
+
+    atomic_store(&(new_prop->value.ptr),  value_ptr);
+    atomic_store(&(new_prop->value.size), value_size);
+    
+    atomic_store(&(new_prop->create_version), version);
+    atomic_store(&(new_prop->delete_version), 0); /* Set to 0 because it's not deleted */
+
+    ret_value = new_prop;
+
+    return ret_value;
+
+} /* H5P__create_prop() */
+
+
+
+herr_t 
+H5P__insert_prop_class(H5P_mt_prop_t *new_prop, H5P_mt_class_t *class)
+{
+    bool done = FALSE;
+    H5P_mt_prop_t * prev_prop;
+    H5P_mt_prop_t * curr_prop;
+
+    herr_t ret_value = SUCCEED;
+
+    assert(class);
+    assert(!class->ref_count.deleted);
+    assert(class->tag == H5P_MT_CLASS_TAG);
+
+    assert(new_prop);
+    assert(new_prop->tag == H5P_MT_PROP_TAG);
+    assert(!new_prop->next.deleted);
+
+    /* update stats */
+    /* H5P__insert_prop_class__num_calls */
+
+
+    /** 
+     * Iterates through the LFSLL of H5P_mt_prop_t (properites), to find the correct
+     * location to insert the new property. chksum is used to determine insert location
+     * by increasing value. 
+     * 
+     * If there is a chksum collision then property names in lexicographical order. 
+     * 
+     * If there again is a collision with names, then version number is used in 
+     * decreasing order (newest version (higher number) first, oldest version last).
+     */
+    while (!done)
+    {
+        prev_prop == class->pl_head;
+        assert(prev_prop->sentinel);
+        
+        atomic_store(&(curr_prop), prev_prop->next.ptr);
+        assert(prev_prop != curr_prop);
+        assert(curr_prop->tag == H5P_MT_PROP_TAG);
+
+        if ( curr_prop->chksum > new_prop->chksum )
+        {
+            /* prep new_prop to be inserted between prev_prop and curr_prop */
+            atomic_store(&(new_prop->next.ptr), curr_prop);
+            
+            /** Attempt to atomically insert new_prop 
+             * 
+             * NOTE: If this fails, another thread modified the LFSLL and we must 
+             * update stats and restart to ensure new_prop is correctly inserted.
+             */
+            if ( !atomic_compare_exchange_strong(&(prev_prop->next.ptr), 
+                                                 &curr_prop, new_prop) )
+            {
+                /* update stats */
+                /* num_insert_prop_class_cols */
+
+                continue;
+            }
+            /* The attempt was successful. Update lengths and stats */
+            else
+            {
+                atomic_fetch_add(&(class->log_pl_len), 1);
+                atomic_fetch_add(&(class->phys_pl_len), 1);
+
+                done = TRUE;
+
+                /* update stats */
+                /* num_insert_prop_class_success */
+            }
+        }
+        else if ( curr_prop->chksum == new_prop->chksum )
+        {
+            int32_t        cmp_result;
+            H5P_mt_prop_t *next_prop;
+            bool           str_cmp_done = FALSE;
+
+            while ( ! str_cmp_done )
+            { 
+                /* update stats */
+                /* num_insert_prop_class_chksum_cols */
+
+                cmp_result = strcmp(curr_prop->name, new_prop->name);
+
+                /* new_prop is less than curr_prop lexicographically */
+                if ( cmp_result > 0 )
+                {
+                    /* prep new_prop to insert between prev_prop and curr_prop */
+                    atomic_store(&(new_prop->next.ptr), curr_prop);
+
+                    /** Attempt to atomically insert new_prop 
+                     * 
+                     * NOTE: If this fails, another thread modified the LFSLL and we must 
+                     * update stats and restart to ensure new_prop is correctly inserted.
+                    */
+                    if ( !atomic_compare_exchange_strong(&(prev_prop->next.ptr), 
+                                                         &curr_prop, new_prop) )
+                    {
+                        /* update stats */
+                        /* num_insert_prop_class_cols */
+
+                        break;
+
+                    }
+                    /* The attempt was successful. Update lengths and stats */
+                    else 
+                    {
+                        atomic_fetch_add(&(class->log_pl_len), 1);
+                        atomic_fetch_add(&(class->phys_pl_len), 1);
+
+                        done = TRUE;
+                        str_cmp_done = TRUE;
+
+                        /* update stats */
+                        /* num_insert_prop_class_success */
+                    }
+                }
+                else if ( cmp_result < 0 )
+                {
+
+                    atomic_store(&(next_prop), curr_prop->next.ptr);
+
+                    assert(next_prop->chksum >= curr_prop->chksum);
+
+                    /** 
+                     * If the next property in the LFSLL doesn't have the same chksum,
+                     * then new_prop gets inserted between curr_prop and new_prop since
+                     * chksum is used to sort first.
+                     */
+                    if ( next_prop->chksum != curr_prop->chksum )
+                    {
+                        /* Prep new_prop to be inserted between curr_prop and next_prop */
+                        atomic_store(&(new_prop->next.ptr), next_prop);
+
+                        /** Attempt to atomically insert new_prop 
+                         * 
+                         * NOTE: If this fails, another thread modified the LFSLL and we must 
+                         * update stats and restart to ensure new_prop is correctly inserted.
+                        */
+                        if ( !atomic_compare_exchange_strong(&(curr_prop->next.ptr), 
+                                                            &next_prop, new_prop) )
+                        {
+                            /* update stats */
+                            /* num_insert_prop_class_success */
+
+                            break;
+
+                        }
+                        /* The attempt was successful. Update lengths and stats */
+                        else
+                        {
+                            atomic_fetch_add(&(class->log_pl_len), 1);
+                            atomic_fetch_add(&(class->phys_pl_len), 1);
+
+                            done = TRUE;
+                            str_cmp_done = TRUE;
+
+                            /* update stats */
+                            /* num_insert_prop_class_success */
+                        }
+                    } /* end if ( next_prop->chksum != curr_prop->chksum ) */
+  
+                } 
+                else /* cmp_results == 0 */
+                {
+                    /* update stats */
+                    /* num_insert_prop_class_string_cols */
+
+                    /**
+                     * If the name's of curr_prop and new_prop are the same, we must
+                     * move on to using version number to determine insert location.
+                     */
+                    if ( new_prop->create_version > curr_prop->create_version )
+                    {
+                        atomic_store(&(new_prop->next.ptr), curr_prop);
+
+                        if ( !atomic_compare_exchange_strong(&(prev_prop->next.ptr), 
+                                                             &curr_prop, new_prop) )
+                        {
+                            /* update stats */
+                            /* num_insert_prop_class_cols */
+
+                            break;
+                        }
+                        /* The attempt was successful. Update lengths and stats */
+                        else 
+                        {
+                            atomic_fetch_add(&(class->log_pl_len), 1);
+                            atomic_fetch_add(&(class->phys_pl_len), 1);
+
+                            done = TRUE;
+                            str_cmp_done = TRUE;
+
+                            /* update stats */
+                            /* num_insert_prop_class_success */
+                        }
+                        
+                    } /* end if ( new_prop->create_version > curr_prop->create_version ) */
+                    else
+                    {
+                        /* Property is already in the LFSLL, update stats and exit */
+                        if ( new_prop->create_version == curr_prop->create_version )
+                        {
+                            /* update stats */
+                            /* num_insert_prop_class_alread_in_LFSLL */
+                            
+                            done = TRUE;
+                            str_cmp_done = TRUE;
+
+                            break;
+                        }
+                        
+                        atomic_store(&(next_prop), curr_prop->next.ptr);
+
+                        assert(next_prop->chksum >= curr_prop->chksum);
+
+                        if ( new_prop->chksum != next_prop->chksum )
+                        {
+                            /* Prep new_prop to be inserted between curr_prop and next_prop */
+                            atomic_store(&(new_prop->next.ptr), next_prop);
+
+                            /** Attempt to atomically insert new_prop 
+                             * 
+                             * NOTE: If this fails, another thread modified the LFSLL and we must 
+                             * update stats and restart to ensure new_prop is correctly inserted.
+                            */
+                            if ( !atomic_compare_exchange_strong(&(curr_prop->next.ptr), 
+                                                                &next_prop, new_prop) )
+                            {
+                                /* update stats */
+                                /* num_insert_prop_class_success */
+
+                                break;
+
+                            }
+                            /* The attempt was successful. Update lengths and stats */
+                            else
+                            {
+                                atomic_fetch_add(&(class->log_pl_len), 1);
+                                atomic_fetch_add(&(class->phys_pl_len), 1);
+
+                                done = TRUE;
+                                str_cmp_done = TRUE;
+
+                                /* update stats */
+                                /* num_insert_prop_class_success */
+                            }
+                        } /* end if ( new_prop->chksum != next_prop->chksum ) */
+
+                    } /* end else */
+
+                } /* end else ( cmp_results == 0 ) */ 
+
+                /** 
+                 * Must update prev_prop and curr_prop to compare next_prop
+                 * with new_prop to find the correct insert location.
+                 */
+                atomic_store(&(prev_prop), curr_prop);
+                atomic_store(&(curr_prop), next_prop);
+
+
+            } /* end while ( ! str_cmp_done ) */
+            
+
+        } /* end else if ( curr_prop->chksum == new_prop->chksum ) */
+    
+    } /* end while (!done) */
+
+}
+
+
+
+void
+find_mod_point(H5P_mt_class_t *class, H5P_mt_prop_t **first_ptr_ptr, 
+               H5P_mt_prop_t **second_ptr_ptr, int32_t *deletes_comp, 
+               int32_t *nodes_visited, int32_t *thrd_cols, 
+               int64_t target_chksum)
+{
+    bool done = FALSE;
+    bool retry = FALSE;
+    int32_t cols = 0;
+    int32_t delets = 0;
+    int32_t nodes_visited = 0;
+    H5P_mt_prop_t * first_prop;
+    H5P_mt_prop_t * second_prop;
+    H5P_mt_prop_t * next_prop;
+
+
+    assert(class);
+    assert(class->tag == H5P_MT_CLASS_TAG);
+    assert(!class->ref_count.deleted);
+    assert(first_ptr_ptr);
+    assert(NULL == *first_ptr_ptr);
+    assert(second_ptr_ptr);
+    assert(NULL == *second_ptr_ptr);
+    assert(deletes_comp);
+    assert(nodes_visited);
+    assert(thrd_cols);
+    assert(target_chksum > LLONG_MIN && target_chksum < LLONG_MAX);
+
+    /* update stats */
+    /* H5P__insert_prop_class__num_calls */
+
+
+    /** 
+     * Iterates through the LFSLL of H5P_mt_prop_t (properites), to find the correct
+     * location to insert the new property. chksum is used to determine insert location
+     * by increasing value. 
+     * 
+     * If there is a chksum collision then property names in lexicographical order. 
+     * 
+     * If there again is a collision with names, then version number is used in 
+     * decreasing order (newest version (higher number) first, oldest version last).
+     */
+    do
+    {
+        assert(!done);
+
+        retry = FALSE;
+
+        first_prop = class->pl_head;
+        assert(first_prop->sentinel);
+        assert(first_prop->tag == H5P_MT_PROP_TAG);
+                
+        second_prop = atomic_load(&(first_prop->next.ptr));
+        assert(first_prop != second_prop);
+        assert(second_prop->tag == H5P_MT_PROP_TAG);
+
+        do 
+        {
+            while (second_prop->next.deleted)
+            {
+                if ( second_prop->ref_count != 0 )
+                {
+                    uint64_t version;
+
+                    version = atomic_load(&(class->curr_version));
+                    version--;
+                    atomic_store(&(second_prop->delete_version), version);
+                }
+                else /* second_prop->ref_count == 0 */
+                {
+
+                    assert(first_prop->next.ptr == second_prop);
+                    assert(second_prop->next.ptr != NULL);
+
+                    next_prop = atomic_load(&(second_prop->next.ptr));
+                    assert(next_prop->tag == H5P_MT_PROP_TAG);
+
+                    if ( ! atomic_compare_exchange_strong(&(first_prop->next.ptr), 
+                                                            &second_prop, next_prop) )
+                    {
+                        thrd_cols++;
+                        retry = TRUE;
+                        break;
+                    }
+                    else 
+                    {
+                        atomic_fetch_sub(&(class->phys_pl_len), 1);
+                        deletes_comp++;
+                        nodes_visited++;
+
+                        second_prop = next_prop;
+                        next_prop = atomic_load(&(second_prop->next.ptr));
+
+                        assert(first_prop);
+                        assert(first_prop->tag == H5P_MT_PROP_TAG);
+                        assert(second_prop);
+                        assert(second_prop->tag == H5P_MT_PROP_TAG);
+                    }
+                } /* end else ( second_prop->ref_count == 0 ) */
+
+            } /* end while ( second_prop->next.deleted ) */
+
+            
+        
+        } while ( ( ! done ) && ( ! retry ) ); 
+
+
+
+        if ( second_prop->chksum > target_chksum )
+        {
+
+
+#if 0
+            /* prep new_prop to be inserted between prev_prop and curr_prop */
+            atomic_store(&(new_prop->next.ptr), curr_prop);
+            
+            /** Attempt to atomically insert new_prop 
+             * 
+             * NOTE: If this fails, another thread modified the LFSLL and we must 
+             * update stats and restart to ensure new_prop is correctly inserted.
+             */
+            if ( !atomic_compare_exchange_strong(&(prev_prop->next.ptr), 
+                                                 &curr_prop, new_prop) )
+            {
+                /* update stats */
+                /* num_insert_prop_class_cols */
+
+                continue;
+            }
+            /* The attempt was successful. Update lengths and stats */
+            else
+            {
+                atomic_fetch_add(&(class->log_pl_len), 1);
+                atomic_fetch_add(&(class->phys_pl_len), 1);
+
+                done = TRUE;
+
+                /* update stats */
+                /* num_insert_prop_class_success */
+            }
+#endif
+        }
+        else if ( curr_prop->chksum == new_prop->chksum )
+        {
+            int32_t        cmp_result;
+            H5P_mt_prop_t *next_prop;
+            bool           str_cmp_done = FALSE;
+
+            while ( ! str_cmp_done )
+            { 
+                /* update stats */
+                /* num_insert_prop_class_chksum_cols */
+
+                cmp_result = strcmp(curr_prop->name, new_prop->name);
+
+                /* new_prop is less than curr_prop lexicographically */
+                if ( cmp_result > 0 )
+                {
+                    /* prep new_prop to insert between prev_prop and curr_prop */
+                    atomic_store(&(new_prop->next.ptr), curr_prop);
+
+                    /** Attempt to atomically insert new_prop 
+                     * 
+                     * NOTE: If this fails, another thread modified the LFSLL and we must 
+                     * update stats and restart to ensure new_prop is correctly inserted.
+                    */
+                    if ( !atomic_compare_exchange_strong(&(prev_prop->next.ptr), 
+                                                         &curr_prop, new_prop) )
+                    {
+                        /* update stats */
+                        /* num_insert_prop_class_cols */
+
+                        break;
+
+                    }
+                    /* The attempt was successful. Update lengths and stats */
+                    else 
+                    {
+                        atomic_fetch_add(&(class->log_pl_len), 1);
+                        atomic_fetch_add(&(class->phys_pl_len), 1);
+
+                        done = TRUE;
+                        str_cmp_done = TRUE;
+
+                        /* update stats */
+                        /* num_insert_prop_class_success */
+                    }
+                }
+                else if ( cmp_result < 0 )
+                {
+
+                    atomic_store(&(next_prop), curr_prop->next.ptr);
+
+                    assert(next_prop->chksum >= curr_prop->chksum);
+
+                    /** 
+                     * If the next property in the LFSLL doesn't have the same chksum,
+                     * then new_prop gets inserted between curr_prop and new_prop since
+                     * chksum is used to sort first.
+                     */
+                    if ( next_prop->chksum != curr_prop->chksum )
+                    {
+                        /* Prep new_prop to be inserted between curr_prop and next_prop */
+                        atomic_store(&(new_prop->next.ptr), next_prop);
+
+                        /** Attempt to atomically insert new_prop 
+                         * 
+                         * NOTE: If this fails, another thread modified the LFSLL and we must 
+                         * update stats and restart to ensure new_prop is correctly inserted.
+                        */
+                        if ( !atomic_compare_exchange_strong(&(curr_prop->next.ptr), 
+                                                            &next_prop, new_prop) )
+                        {
+                            /* update stats */
+                            /* num_insert_prop_class_success */
+
+                            break;
+
+                        }
+                        /* The attempt was successful. Update lengths and stats */
+                        else
+                        {
+                            atomic_fetch_add(&(class->log_pl_len), 1);
+                            atomic_fetch_add(&(class->phys_pl_len), 1);
+
+                            done = TRUE;
+                            str_cmp_done = TRUE;
+
+                            /* update stats */
+                            /* num_insert_prop_class_success */
+                        }
+                    } /* end if ( next_prop->chksum != curr_prop->chksum ) */
+  
+                } 
+                else /* cmp_results == 0 */
+                {
+                    /* update stats */
+                    /* num_insert_prop_class_string_cols */
+
+                    /**
+                     * If the name's of curr_prop and new_prop are the same, we must
+                     * move on to using version number to determine insert location.
+                     */
+                    if ( new_prop->create_version > curr_prop->create_version )
+                    {
+                        atomic_store(&(new_prop->next.ptr), curr_prop);
+
+                        if ( !atomic_compare_exchange_strong(&(prev_prop->next.ptr), 
+                                                             &curr_prop, new_prop) )
+                        {
+                            /* update stats */
+                            /* num_insert_prop_class_cols */
+
+                            break;
+                        }
+                        /* The attempt was successful. Update lengths and stats */
+                        else 
+                        {
+                            atomic_fetch_add(&(class->log_pl_len), 1);
+                            atomic_fetch_add(&(class->phys_pl_len), 1);
+
+                            done = TRUE;
+                            str_cmp_done = TRUE;
+
+                            /* update stats */
+                            /* num_insert_prop_class_success */
+                        }
+                        
+                    } /* end if ( new_prop->create_version > curr_prop->create_version ) */
+                    else
+                    {
+                        /* Property is already in the LFSLL, update stats and exit */
+                        if ( new_prop->create_version == curr_prop->create_version )
+                        {
+                            /* update stats */
+                            /* num_insert_prop_class_alread_in_LFSLL */
+                            
+                            done = TRUE;
+                            str_cmp_done = TRUE;
+
+                            break;
+                        }
+                        
+                        atomic_store(&(next_prop), curr_prop->next.ptr);
+
+                        assert(next_prop->chksum >= curr_prop->chksum);
+
+                        if ( new_prop->chksum != next_prop->chksum )
+                        {
+                            /* Prep new_prop to be inserted between curr_prop and next_prop */
+                            atomic_store(&(new_prop->next.ptr), next_prop);
+
+                            /** Attempt to atomically insert new_prop 
+                             * 
+                             * NOTE: If this fails, another thread modified the LFSLL and we must 
+                             * update stats and restart to ensure new_prop is correctly inserted.
+                            */
+                            if ( !atomic_compare_exchange_strong(&(curr_prop->next.ptr), 
+                                                                &next_prop, new_prop) )
+                            {
+                                /* update stats */
+                                /* num_insert_prop_class_success */
+
+                                break;
+
+                            }
+                            /* The attempt was successful. Update lengths and stats */
+                            else
+                            {
+                                atomic_fetch_add(&(class->log_pl_len), 1);
+                                atomic_fetch_add(&(class->phys_pl_len), 1);
+
+                                done = TRUE;
+                                str_cmp_done = TRUE;
+
+                                /* update stats */
+                                /* num_insert_prop_class_success */
+                            }
+                        } /* end if ( new_prop->chksum != next_prop->chksum ) */
+
+                    } /* end else */
+
+                } /* end else ( cmp_results == 0 ) */ 
+
+                /** 
+                 * Must update prev_prop and curr_prop to compare next_prop
+                 * with new_prop to find the correct insert location.
+                 */
+                atomic_store(&(prev_prop), curr_prop);
+                atomic_store(&(curr_prop), next_prop);
+
+
+            } /* end while ( ! str_cmp_done ) */
+            
+
+        } /* end else if ( curr_prop->chksum == new_prop->chksum ) */
+    
+    } /* end while (!done) */
+}
+
+
+
+
+
+#endif

--- a/src/H5Ppkg_mt.h
+++ b/src/H5Ppkg_mt.h
@@ -1,0 +1,1219 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*
+ * Purpose: This file contains declarations which are visible only within
+ *          the H5P package.  Source files outside the H5P package should
+ *          include H5Pprivate.h instead.
+ */
+
+
+#include <assert.h>
+#include <stddef.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <stdatomic.h>
+
+#ifndef H5Ppkg_mt_H
+#define H5Ppkg_mt_H
+
+
+/* Get package's private header */
+#include "H5Pprivate.h"
+
+/* Other private headers needed by this file */
+#include "H5SLprivate.h" /* Skip lists				*/
+
+
+/**************************/
+/* Package Private Macros */
+/**************************/
+
+/****************************/
+/* Package Private Typedefs */
+/****************************/
+
+
+/* Structures for Properties */
+
+typedef struct H5P_mt_prop_t H5I_mt_prop_t; /* Forward declaration */
+
+/****************************************************************************************
+ *
+ * Structure:   H5P_mt_prop_aptr_t
+ *
+ * Description:
+ *
+ * Struct H5P_mt_prop_aptr_t is a structure designed to contain a pointer to an instance
+ * of H5P_mt_prop_t and a deleted flag in a single atomic structure. This is necessary,
+ * as instances of H5P_mt_prop_t will typically appear in lock free singly linked lists.
+ *
+ * For correct operation, these lists require the next pointer and the deleted flag to
+ * be accessed and modified in a single atomic operations.
+ *
+ * With padding, this structure is 128 bits, which allows true atomic operation on
+ * many (most?) modern CPUs. However, it this becomes a problem, we can obtain the
+ * same effect by stealing the low order bit of the pointer for a deleted bit -- which
+ * works on all CPU / C compiler combinations I have tried.
+ *
+ * Fields:
+ * 
+ * ptr (struct H5P_mt_prop_t):
+ *      Pointer to an instance of H5P_mt_prop_t, or NULL.
+ * 
+ * deleted (bool):
+ *      Boolean flag.  If this instance of H5P_mt_prop_aptr_t appears as a field
+ *      in an instance of H5P_mt_prop_t and this flag is TRUE, the instance of 
+ *      H5P_mt_prop_t is logically deleted, and not if the flag is FALSE.
+ * 
+ * dummy_bool_1:
+ * dummy_bool_2:
+ * dummy_bool_3: The dummy_bool fields exist to pad H5P_mt_prop_aptr_t out to 128 bits  
+ *
+ ****************************************************************************************
+ */
+typedef struct H5P_mt_prop_aptr_t 
+{
+    H5P_mt_prop_t       * ptr;
+
+    bool                  deleted;
+
+    bool                  dummy_bool_1;
+    bool                  dummy_bool_2;
+    bool                  dummy_bool_3;
+
+} H5P_mt_prop_aptr_t;
+
+
+
+/****************************************************************************************
+ * 
+ * Structure: H5P_mt_value_t
+ * 
+ * Description:
+ * 
+ * Properties in a property list consist of a void pointer and a size.  To avoid race 
+ * conditions, the size and poitner must be set atomically.  This structure exits to
+ * facilitate this.
+ * 
+ * Fields:
+ * 
+ * ptr (void *):
+ *      Void pointer to the value, or NULL if the value is undefined.
+ * 
+ * size (size_t):
+ *      size_t containing the size of the buffer pointed to by the ptr field, or zero
+ *      if ptr is NULL.
+ * 
+ * Note: The above fields will usually have a total size of 128 bits. However, since
+ * the size of size_t is not fixed across all 64 bit compilers, there is the potential
+ * for occult failures in atomic_compare_exchange_strong() when garbage gets into
+ * the un-used space in the structure. (recall that the sum of the sizes of the fields
+ * of a structure need not equal the allocation size of the structure.)
+ *
+ * For now, it should be sufficient to assert that sizeof(size_t) = 8.
+ * However, we will have to deal with the issue eventually. For example, I have read
+ * that size_t is a 32 bit value on at least some compilers targeting Windows.
+ * 
+ ****************************************************************************************
+ */
+typedef struct H5P_mt_prop_value_t
+{
+    void * ptr;
+    size_t size;
+
+} H5P_mt_prop_value_t;
+
+
+
+/****************************************************************************************
+ * 
+ * Structure: H5P_mt_prop_t
+ * 
+ * Description:
+ * 
+ * Struct H5P_mt_prop_t is a revised version of H5_genprop_t designed for use in a
+ * multi-thread safe version of H5P. The data structures supporting property lists
+ * are lock free to the extent practical, and thus instances of H5P_mt_prop_t will
+ * typically appear in lock free singly linked list.
+ *
+ * Further, to support versioning in property list classes,instances of H5P_mt_prop_t
+ * in property list classes maintain reference counts of the number of property lists
+ * that refer to them for default values, the revision number at which they inserted
+ * into the containing property list class or property list, and (if deleted) the
+ * revision number at which which the deletion took place.
+ *
+ * Fields:
+ *
+ * tag (uint32_t): 
+ *      Integer value set to H5P_MT_PROP_TAG when an instance of H5P_mt_prop_t
+ *      is allocated from the heap, and to H5P_MT_PROP_INVALID_TAG just before
+ *      it is released back to the heap. The field is used to validate pointers
+ *      to instances of H5P_mt_prop_t,
+ *
+ *
+ * next (_Atomic H5P_mt_prop_aptr_t): 
+ *      Atomic instance of H5P_mt_prop_aptr_t, which combines a pointer to the
+ *      next element of the lock free singly linked list with a deleted flag.
+ *      If there is no next element, or if the instance of H5P_mt_prop_t is
+ *      not in a LFSLL, this field should be set to {NULL, false}.
+ *
+ * sentinel (bool): 
+ *      Boolean flag. When set, this instance of H5P_mt_prop_t is a sentinel
+ *      node in the lock free singly linked list -- and therefore does not
+ *      represent a property.
+ *
+ * in_prop_class (bool): 
+ *      Boolean flag that is set to TRUE if this instance of H5P_mt_prop_t
+ *      resides in a property list class, and false otherwise. Note that
+ *      the ref_count field is un-used if this field is false.
+ *
+ * ref_count (_Atomic uint64_t): 
+ *      Atomic integer used to track the number of property list properties
+ *      that point to this instance of H5P_mt_prop_t. This field must be
+ *      zero if in_prop_class is false.
+ *
+ *      Note that this ref_count is only increased when a new property list
+ *      is created, and is decremented when the property list is discarded.
+ *
+ *      Thus this instance of H5P_mt_prop_t can be safely deleted if:
+ *
+ *      1) the ref count drops to zero, and
+ *
+ *      2) this property has been either deleted or superseded
+ *      in the property list class.
+ *
+ *
+ * Property Chksum, Name & Value:
+ * 
+ * Instances of H5P_mt_prop_t will typically appear in lock free singly linked lists,
+ * which must be sorted by property name, and then by decreasing create_version (i.e.
+ * highest create_version first).
+ *
+ * The lock free singly linked list used to store most instances of H5P_mt_prop_t
+ * requires sentinels at the beginning and end of the list with values (conceptually)
+ * of negative and positive infinity respectively. This is a bit awkward with strings,
+ * so for this reason, the (name, creation_version) key is augmented with a 32 bit
+ * checksum on the name, converting the key to a (chksum, name, creation_version)
+ * triplet. Note that the check sum is a 32 bit unsigned value, which is stored
+ * in an int64_t. Thus we can use LLONG_MIN and LLONG_MAX as our negative and
+ * positive infinity respectively.
+ *
+ * The addition of the chksum changes the sorting order to checksum, name, and
+ * then decreasing create_version. This ordering, along with the delete_version
+ * field, allows us to operate on specific versions of a property list classes and
+ * property lists -- thus allowing concurrent operations without introducing
+ * corruption.
+ *
+ * Fields:
+ * 
+ * chksum (int64_t): 
+ *      int64_t containing a 32 bit checksum computed on the name field
+ *      below, or LLONG_MIN or LLONG_MAX if either the head or tail
+ *      sentinel in the lock free SLL respectively.
+ *
+ *      Since this field is constant for the life of the instance of
+ *      H5P_mt_prop_t, and is set before the instance is visible to more
+ *      than one thread, it need not be atomic.
+ *
+ * name (char *): 
+ *      Pointer to a dynamically allocated string containing the name of the
+ *      property. This field is not atomic, as the string should be allocated,
+ *      and initialized, and the name field set before the instance of
+ *      H5P_mt_prop_t is visible to more than one thread. Since the name
+ *      is constant for the life of the instance of H5P_mt_prop_t, this should
+ *      be sufficient for thread safety.
+ * 
+ * value (_Atomic H5P_mt_prop_value_t): 
+ *      Atomic structure containing the pointer to the buffer containing the
+ *      value of the property, and its size.
+ *
+ * create_version (_Atomic uint64_t): 
+ *      Atomic integer which is set to the version of the containing
+ *      property list class or property list in which this property was
+ *      inserted.
+ *
+ * delete_version (_Atomic uint64_t):  
+ *      Atomic integer which is set to the version of the containing
+ *      property list class or property list in which the property was
+ *      deleted. If the property has not been deleted, this field contains
+ *      zero.
+ * 
+ * Property Callback Functions:
+ *
+ * These fields are currently left out to keep the structure more simple for early 
+ * testing.
+ * 
+ ****************************************************************************************
+ */
+
+#define H5P_MT_PROP_TAG         0x1010 /* 4112 */
+#define H5P_MT_PROP_INVALID_TAG 0x2020 /* 8224 */
+
+typedef struct H5P_mt_prop_t
+{
+    uint32_t                    tag;
+    
+    _Atomic H5P_mt_prop_aptr_t  next;
+
+    bool                        sentinel;
+
+    bool                        in_prop_class;
+    _Atomic uint64_t            ref_count;
+
+    int64_t                     chksum;
+    char                      * name;
+    _Atomic H5P_mt_prop_value_t value;
+    
+    _Atomic uint64_t            create_version;
+    _Atomic uint64_t            delete_version;
+
+    /* Callbacks are currently left out for early testing */
+
+} H5P_mt_prop_t;
+
+
+
+
+/* Structures for Property List Classes  */
+
+
+/****************************************************************************************
+ * 
+ * Structure: H5P_mt_active_thread_count_t
+ * 
+ * Description:
+ *
+ * Struct H5P_mt_active_thread_count_t is structure designed to contain a counter of the
+ * number of threads currently active in the host structure and opening and closing flags
+ * in a single atomic structure. The objectives are to prevent access to the containing
+ * structure during setup, and to provide a mechanism for delaying the discard of the
+ * containing structure until all threads currently active in the structure have exited.
+ *
+ * The possibility of access to a property list class or property list that is in the
+ * process of being set stems from two points.
+ *
+ * First, some callbacks that must be called during setup require the ID of the host
+ * property list. This requires that the property list be inserted into the index,
+ * which in turn makes the incomplete property list accessible to other threads.
+ *
+ * Even in the absence of these callbacks, both property list classes and property lists
+ * must be inserted into the index before they are completely set up. While it is
+ * improbable, this makes them accessible to other threads via iterations on the host
+ * indexes.
+ *
+ * To prevent this, the opening flag in the contained instance of
+ * H5P_mt_active_thread_count_t is initialized to TRUE, and not set to FALSE until setup
+ * completes. Any thread that wants to access the host property list much check this flag
+ * on entry, and fail if it is TRUE.
+ *
+ * In principle, it should be impossible for any thread to access a property list class
+ * or property list that is in the process of being taken down. However, it seems prudent
+ * to have a mechanism to detect the case where it does, and to manage it gracefully. 
+ * Note that in debug builds we should throw an assertion failure whenever a circumstance
+ * thatis forbidden occurs. One could argue that in production builds we should log the 
+ * issue and handle it gracefully – I am not sure I agree, but this is a discussion for 
+ * another time.
+ *
+ * In the typical case of a thread that reads or modifies the host data structure, it 
+ * must first do an atomic fetch on the associated instance of 
+ * H5P_mt_active_thread_count_t and fail if either the opening or closing flag is set. If
+ * neither flag is set, it must increment the thread counter in the local copy, and 
+ * attempt to overwrite the shared copy with the local copy using a call to 
+ * atomic_compare_exchange_strong(). If this fails, it must repeat the procedure until 
+ * successful, or until the closing flag is set. When the thread is done with host data 
+ * structure, it must again load the associated instance of H5P_mt_active_thread_count_t,
+ * decrement the thread count in the local copy, and attempt to overwrite the shared copy
+ * with the local copy with another call to atomic_compare_exchange_strong() – repeating 
+ * the procedure until successful. Note that the flags are ignored in this case.
+ *
+ * Similarly, a thread that is about to discard the host structure must first do an 
+ * atomic fetch on the associated instance of H5P_mt_active_thread_count_t and fail 
+ * either the opening or closing flag is set – preferably with an assertion failure. If 
+ * the closing flag is not set, it must set it in the local copy, and attempt to 
+ * overwrite the shared copy with the local copy using a call to 
+ * atomic_compare_exchange_strong(). If this fails, it must repeat the procedure until 
+ * successful. Once the closing flag is set, it must verify that no threads are active in
+ * the host structure – either throwing an error or waiting until the thread count drops 
+ * to zero as appropriate.
+ * 
+ * Fields:
+ * 
+ * count (uint64_t):
+ *      Number of threads currently active in the host structure.
+ * 
+ * opening (bool):
+ *      Boolean flag that is set to TRUE while the host property list class or property
+ *      list is in the process of being setup. It must be set to FALSE once setup is 
+ *      complete.
+ * 
+ * closing (bool):
+ *      Boolean flag that is set to TRUE iff the host structure is about to be discarded.
+ * 
+ ****************************************************************************************
+ */
+typedef struct H5P_mt_active_thread_count_t
+{
+    uint64_t    count;
+    bool        opening;
+    bool        closing;
+
+} H5P_mt_active_thread_count_t;
+
+
+
+/****************************************************************************************
+ * 
+ * Structure: H5P_mt_class_ref_counts_t
+ * 
+ * Description:
+ *
+ * Property list classes (instances on H5P_mt_class_t in the new implementation) need to
+ * maintain reference counts on the number of derived property list classes, the number
+ * derived property lists, and whether the property list class still exists in the index.
+ *
+ * One can argue that these three ref counts should be combined into a single reference
+ * count. For now, at least, I am inclined to retain this design feature for the
+ * following reasons:
+ *
+ * First, maintaining these reference counts separately seems likely to have some
+ * debugging benefits, in that it provides more information about the current derivatives
+ * of the property list class than a single reference count.
+ *
+ * Second, given that we must replicate the behavior of the current implementation quite
+ * closely in the single thread case, it seems to me that gratuitous design changes
+ * should be avoided.
+ *
+ * This, however raises the issue of how to keep the different reference counts
+ * synchronized, and in particular, how to avoid the case in which the combined
+ * reference counts drop to zero, discard is initialized, and another thread comes
+ * in and tries to increment one of the reference counts.
+ *
+ * This is solved by combining the various reference counts into a single atomic 
+ * structure, and not allowing any reference count to be incremented once all the 
+ * reference counts have dropped to zero.
+ *
+ * This structure is intended to fulfill this role. The individual fields are discussed
+ * below. Observe that the size of the structure is less that 128 bits, which should
+ * allow true atomic operation on most modern machines. 
+ * 
+ * Fields:
+ * 
+ * pl (uint64_t):
+ *      Number of property lists immediately derived from this property list class, and 
+ *      still extant.
+ * 
+ * plc (uint32_t):
+ *      Number of property list classes immediately derived from this property list 
+ *      class, and still extant.
+ * 
+ * deleted (bool):
+ *      Boolean flag indicating whether this property list class has been deleted from 
+ *      the index. This field is set to FALSE on creation, and set to TRUE when the 
+ *      reference count on the property list class in the index drops to zero.
+ * 
+ ****************************************************************************************
+ */
+typedef struct H5P_mt_class_ref_counts_t
+{
+    uint64_t pl;
+    uint32_t plc;
+    bool     deleted;
+
+} H5P_mt_class_ref_counts_t;
+
+
+
+/****************************************************************************************
+ * 
+ * Structure: H5P_mt_class_sptr_t
+ * 
+ * Description:
+ * 
+ * The H5P_mt_class_sptr_t combines a pointer to H5P_mt_class_t with a serial number
+ * in a 128 bit package. It is intended to allow instances of H5P_mt_class_t to be
+ * linked together in a singly linked list – specifically in a free list.
+ *
+ * This combination of a pointer and a serial number is needed to prevent ABA
+ * bugs.
+ * 
+ * Fields:
+ * 
+ * ptr (H5P_mt_class_t *):
+ *      Pointer to an instance of H5P_mt_class_t.
+ * 
+ * sn (uint64_t):
+ *      Serial number that should be incremented by 1 each time a new value is assigned
+ *      to ptr.
+ * 
+ ****************************************************************************************
+ */
+typedef struct H5P_mt_class_t H5P_mt_class_t; /* Forward declaration */
+
+typedef struct H5P_mt_class_sptr_t
+{
+    H5P_mt_class_t * ptr;
+    uint64_t         sn;
+
+} H5P_mt_class_sptr_t;
+
+
+
+/****************************************************************************************
+ * 
+ * Structure: H5P_mt_class_t
+ * 
+ * Description:
+ * 
+ * Revised version of H5P_genclass_t designed for use in a multi-thread safe version
+ * of the HDF5 property list module (H5P).
+ *
+ * At the conceptual level, a property list class is simply a template for constructing
+ * a default version of a member of a class of property lists, with the default 
+ * properties, each with that property's default value.
+ *
+ * This simple concept is complicated by the requirement that modifications to property
+ * list classes not effect preexisting derived property lists or property list classes.
+ *
+ * The single thread version of H5P addressed this problem by duplicating property list
+ * classes with derived property lists and/or property list classes whenever they are
+ * modified. The modification is applied to the duplicate, and the duplicate replaces
+ * the base version in the index. This approach has a number of problems, not the
+ * least being that it makes it possible for multiple versions of the property list
+ * class to exist in the index, and thus be visible to the user.
+ *
+ * Instead, the multi-thread version of property list classes maintains back versions
+ * of all properties tagged with the property list class version in which they were
+ * created (and possibly deleted). All properties are ref counted with the number of
+ * properties in derived property lists that refer to them for default values. Since
+ * the ref count on a version of a property can only be incremented when that property
+ * version appears in the current version of the property list class, this means that
+ * back versions of properties may be safely discarded once their ref counts drop to zero.
+ *
+ * Note that this no longer need be the case if we allow back version of property list
+ * classes to be visible outside of H5P. Note also that this is a semantic change in
+ * the H5P API from the single thread version, albeit an obscure one, and to my thinking,
+ * very much in the right direction.
+ *
+ * More importantly, if all operations on a property list address a specific version,
+ * and all modifications are effectively atomic, concurrent operations can occur without
+ * the potential for data corruption as long as all modifications trigger an increment
+ * of the property list class version number.
+ *
+ * Making modifications to a property list class effectively atomic is slightly tricky,
+ * as to give an obvious example, inserting a new property and incrementing the
+ * version number can't be made atomic without heroic measures. However, by
+ * targeting every operation at a specific version, we can make changes in progress
+ * effectively invisible since new or modified properties are represented by new
+ * instances of H5P_mt_prop_t with creation property list class versions higher than
+ * the current version, and thus don't become visible until the property list class
+ * version is incremented to the point that they become visible.
+ *
+ * However, if multiple modifications to the property list class are in progress
+ * simultaneously, there is a race condition between the issue of a new version
+ * number to be used to tag a modification, and the increment of the property list
+ * class version number when the modification completes.
+ *
+ * Conceptually, this can be handled by waiting to increment the version number until
+ * the current version number is one less than the issued version number. Use of a
+ * condition variable is the obvious solution here -- but we will sleep and try again
+ * until we settle on a threading package.
+ *
+ * There is also a potential race condition if a delete and either a modify or an
+ * insert on a single property is in progress at the same time. In this case, the
+ * operations must proceed in target version issue order.
+ *
+ * A second fundamental difference between the single thread and the multi-thread
+ * implementations of the property list class, is that properties are stored on a
+ * lock free singly linked list (LFSLL) instead of a skip list. This LFSLL list is
+ * sorted first by a hash on the property name, second by property name (to allow for
+ * hash collisions), and finally by creation version in decreasing order.
+ *
+ * Given that property lists are typically short (less that 25 properties), and that
+ * the LFSLL will be searched only on property insert, delete, or modification, the
+ * LFSLL should be near optimal for this application. However, if the number of
+ * properties (or back versions of same) balloon and cause performance issues, it
+ * will be easy enough to replace the LFSLL with a lock free hash table.
+ * 
+ * Finally, for code simplicity, properties inherited from the parent property list
+ * class are copied into the LFSLL of properties in the derived property list class.
+ * There is nothing magic about this, and we can revert to the old system if there
+ * is some reason to do so.
+ *
+ * Note, however, that it is still necessary for property list classes to maintain
+ * pointers to their parent property list classes due to the requirement that
+ * all close functions in ancestor property list classes be called on close.
+ *
+ * With this outline of H5P_mt_class_t in hand, we now address individual fields.
+ *
+ *                                                          JRM -- 5/22/24
+ * 
+ * Fields:
+ * 
+ * tag (uint32_t):
+ *      Integer value set to H5P_MT_CLASS_TAG when an instance of H5P_mt_class_t is
+ *      allocated from the heap, and to H5P_MT_CLASS_INVALID_TAG just before it is 
+ *      released back to the heap. The field is used to validate pointers to instances
+ *      of H5P_mt_class_t.
+ * 
+ * parent_id (hid_t):
+ *      ID assigned to the immediate parent property list class in the index. As the 
+ *      parent cannot be deleted until its ref_counts drop to zero, it must exist at
+ *      least as long as this property list class.
+ * 
+ *      This field is not atomic, as it is set before this property list class is 
+ *      inserted in the index, thus before it's visible to other threads, and doesn't
+ *      change for the life of this instance.
+ * 
+ * parent_ptr (H5P_mt_class_t *):
+ *      Pointer to the instance of H5P_mt_class_t that represents the immediate parent
+ *      property list class in the index. As the parent cannot be deleted until its
+ *      ref_counts drop to zero, it must exist and this pointer must be valid at least
+ *      as long as this property list class exists.
+ * 
+ *      This field is not atomic, as it is set before this property list class is 
+ *      inserted in the index, thus before it's visible to other threads, and doesn't
+ *      change for the life of this instance.
+ * 
+ * perent_version (uint64_t):
+ *      Version of the parent property list class from which this property list class
+ *      is derived.
+ * 
+ *      This field is not atomic, as it is set before this property list class is 
+ *      inserted in the index, thus before it's visible to other threads, and doesn't
+ *      change for the life of this instance.
+ * 
+ * name (char *):
+ *      Pointer to a string containing the name of this property list class.
+ * 
+ *      This field is not atomic, as it is set before this property list class is 
+ *      inserted in the index, thus before it's visible to other threads, and doesn't
+ *      change for the life of this instance.
+ * 
+ * id (_Atomic hid_t *):
+ *      Atomic instance of hid_t used to store the id assigned to this property list
+ *      class in the index. This field is atomic, as it can't be set until after the
+ *      instance of H5P_mt_class_t is registered, and thus visible to other threads.
+ *      That said, once set, this field will not change for the life of the property 
+ *      list class.
+ * 
+ * type (H5P_plist_type_t):
+ *      Type of the property list class. 
+ * 
+ *      This field is not atomic, as it is set before this property list class is 
+ *      inserted in the index, thus before it's visible to other threads, and doesn't
+ *      change for the life of this instance.
+ * 
+ * curr_version (_Atomic uint64_t):
+ *      Atomic uint64_t containing the current version of the property list class. This
+ *      version number is incremented each time a modification to the property list class
+ *      is completed.
+ * 
+ *      A uint64_t is used, as at present there is no provision for a roll over. Given
+ *      the relative infrequency of modifications to propety list classes, 64 bits is
+ *      probably sufficient for all reasonable cases. However, a roll over must never
+ *      occur, and an error should be flagged if it does.
+ * 
+ *      To allow an undefined deletion version, the curr_version must be no less than 1.
+ * 
+ * next_version (_Atomic uint64_t):
+ *      Atomic uint64_t containing the version number to be assigned to the next 
+ *      modification of the property list class. When no modifications to the property 
+ *      list class are in propgress next_version should be one greater than curr_version.
+ * 
+ *      When a modification to a property list class begins, it does a fetch and 
+ *      increment on next_version, preforms its changes and tags them with the returned
+ *      version, and finally increments the curr_version.
+ * 
+ *      NOTE: To avoid exposure of partial modifications, increments to curr_version must
+ *      be executed in next_version issue order. Thus, a thread that modifies the propety
+ *      list class, must not increment curr_version until its value is one less than the
+ *      version number it obtained when it started.
+ * 
+ *      Further, if a modify or insert and a delete on the same property are active at
+ *      the same time, they must be executed in issue_order.
+ * 
+ * pl_head (H5P_mt_prop_t *):
+ *      Atomic pointer to the head of the LFSLL containing the list of properties (i.e.
+ *      instances of H5P_mt_prop_t) associated with the property list class. Other than 
+ *      during setup, this field will always point to the first node in teh list whose
+ *      value will be negative infinity.
+ * 
+ *      Entries in this list are sorted first by a hash on the property name, second by
+ *      property name (to allow for hash collisions), and finally by creation version in
+ *      decreasing order. Other than during setup, the first and last entries in the list
+ *      will be sentry nodes with hash values (conceptually) of negative and positive 
+ *      infinity respectively.
+ * 
+ * log_pl_len (_Atomic uint32_t):
+ *      Number of properties defined in the property list class at the current version. 
+ *      
+ *      NOTE: This value will not be correct for all versions of the property list class,
+ *      and will be briefly incorrect even for the current version during property 
+ *      insertions and deletions. Thus when an exact value is required, the property list
+ *      class must be scanned for the correct value for the desired version.
+ * 
+ * phys_pl_len (_Atomic uint32_t):
+ *      Number of instances of H5P_mt_prop_t in the property list class. This number 
+ *      includes sentinel nodes, and both current and superseded instances of 
+ *      H5P_mt_prop_t. 
+ *      
+ *      NOTE: This value will be briefly incorrect during property insertions, deletions,
+ *      and modifications. Modification of a property cause this value to change, and a
+ *      new instance of H5P_mt_prop_t is inserted with the desired changes and a new
+ *      creation version.
+ * 
+ * ref_count (_Atomic H5P_mt_class_ref_counts_t):
+ *      Atomic instance of H5P_mt_class_ref_counts_t which combines:
+ * 
+ *          1) The number of property lists immediately derived from this property list
+ *             class, and still extant (ref_count.pl),
+ *          2) The number of property list classes immediately derived from this property
+ *             list class, and still extant (ref_count.plc),
+ *          3) A boolean flag indicating whether this property list class has been
+ *             deleted from the index (ref_count.deleted).
+ * 
+ *      into a single atomic structure - thus ensuring sychronization between these three
+ *      different values.
+ * 
+ *      Once ref_count.pl and ref_count.plc have dropped to zero, and deleted is set to
+ *      TRUE, the property list class may be discarded. Further, neither ref_count.pl or
+ *      ref_count.plc may be incremented once this condition obtains.
+ * 
+ *      Further, observe that once this condition holds, the reference counts on all 
+ *      versions of all properties in the property list class must be zero.
+ * 
+ * 
+ * 
+ * Callbacks are currently left out for early testing
+ * 
+ * 
+ * Free list and shutdown management fields:
+ * 
+ * thrd (_Atomic H5P_mt_active_thread_count_t):
+ *      This field is a structure used to verify that no threads are active in an 
+ *      instance of H5P_mt_class_t during setup or takedown of the structure prior to 
+ *      discard. See the header comment on H5P_mt_active_thread_count_t for a detailed 
+ *      discription of how its fields must be maintained whena thread wants to access the 
+ *      host instance of H5P_mt_class_t.
+ * 
+ * fl_next (_Atomic_H5P_mt_class_sptr_t):
+ *      This field is a structure used to contain a pointer to the next instance of 
+ *      H5P_mt_class_t in the free list. It is augmented with a serial number to avoid
+ *      ABA bugs. This field is included to support a free list of instances of 
+ *      H5P_mt_class_t.
+ * 
+ * 
+ * Statistics Fields:
+ *  
+ ****************************************************************************************
+ */
+#define H5P_MT_CLASS_TAG            0x1011 /* 4113 */
+#define H5P_MT_CLASS_INVALID_TAG    0x2021 /* 8225 */
+
+typedef struct H5P_mt_class_t
+{
+    uint32_t           tag;
+
+    /* fields related to the parent class */
+    hid_t              parent_id;
+    H5P_mt_class_t   * parent_ptr;
+    uint64_t           parent_version;
+
+    /* Fields related to this class */
+    char             * name;
+    _Atomic hid_t    * id;
+    H5P_plist_type_t   type;
+    _Atomic uint64_t   curr_version;
+    _Atomic uint64_t   next_version;
+
+    /* List of properties, and related fields */
+    H5P_mt_prop_t    * pl_head;
+    _Atomic uint32_t   log_pl_len;
+    _Atomic uint32_t   phys_pl_len;
+
+    /* reference counts */
+    _Atomic H5P_mt_class_ref_counts_t ref_count;
+
+    /* Callback function pointers and info */
+    /* Currently left out for simple testing */
+
+    /* Shutdown and free list management fields */
+    _Atomic H5P_mt_active_thread_count_t thrd;
+    _Atomic H5P_mt_class_sptr_t          fl_next;
+
+    /* Stats */
+
+} H5P_mt_class_t;
+
+
+
+
+/* Structures for Property Lists */
+
+
+
+
+/****************************************************************************************
+ * 
+ * Structure: H5P_mt_list_sptr_t
+ * 
+ * Description:
+ * 
+ * The H5P_mt_list_sptr_t combines a pointer to H5P_mt_list_t with a serial number
+ * in a 128 bit package. It is intended to allow instances of H5P_mt_list_t to be
+ * linked together in a singly linked list – specifically in a free list.
+ *
+ * This combination of a pointer and a serial number is needed to prevent ABA
+ * bugs.
+ * 
+ * Fields:
+ * 
+ * ptr (H5P_mt_list_t *):
+ *      Pointer to an instance of H5P_mt_list_t.
+ * 
+ * sn (uint64_t):
+ *      Serial number that should be incremented by 1 each time a new value is assigned
+ *      to ptr.
+ * 
+ ****************************************************************************************
+ */
+typedef struct H5P_mt_list_t H5P_mt_list_t; /* Forward declaration */
+
+typedef struct H5P_mt_list_sptr_t
+{
+    H5P_mt_list_t * ptr;
+    uint64_t        sn;
+
+} H5P_mt_list_sptr_t;
+
+
+
+/****************************************************************************************
+ * 
+ * Structure: H5P_mt_list_prop_ref_t
+ * 
+ * Description:
+ * 
+ * H5P_mt_list_prop_ref_t is a structure designed to contain a pointer to an instance of 
+ * H5P_mt_prop_t and a version number in a single atomic structure. This is necessary, as 
+ * when an entry in the H5P_mt_list_table_entry_t is updated, we need to update both the 
+ * pointer to the instance of H5P_mt_prop_t and the version number in a single atomic 
+ * operation.
+ *
+ * This structure is 128 bits, which allows true atomic operation on many (most?) modern
+ * CPUs.
+ *
+ * The structure is used in two contexts:
+ *
+ * First to point to the instance of H5P_mt_prop_t in the property list class from
+ * which the host property list was derived. In this case, version number should be
+ * the initial version of the host property list class.
+ *
+ * Second, if the default value of the property has been overwritten, to point to an
+ * instance of H5P_mt_prop_t in the host property list class's LFSLL of modified or
+ * added properties. In this case, the ver field must match the create_version field
+ * of the instance of H5P_mt_prop_t pointed to by ptr.
+ * 
+ * Fields:
+ * 
+ * ptr (H5P_mt_prop_t *):
+ *      Pointer to an instance of H5P_mt_prop_t.
+ * 
+ * ver (uint64_t):
+ *      Version number of the host property list class at which this pointer was set.
+ * 
+ ****************************************************************************************
+ */
+typedef struct H5P_mt_list_prop_ref_t
+{
+    H5P_mt_prop_t * ptr;
+    uint64_t        ver;
+
+} H5P_mt_list_prop_ref_t;
+
+
+
+/****************************************************************************************
+ * 
+ * Structure: H5P_mt_list_table_entry_t
+ * 
+ * Description:
+ * 
+ * An array of instances of H5P_mt_list_table_entry_t is used to create a look up table
+ * for properties inherited from the parent property list class.
+ * 
+ * Fields:
+ * 
+ * chksum (int64_t):
+ *      int64_t containing a 32-bit checksum coputed on the name field below.
+ * 
+ * name (char *):
+ *      Pointer to a dynamically allocated string containing the name of the property. 
+ * 
+ *      This field is not atomic, as it is set before this instance of H5P_mt_prop_t is 
+ *      visible to other threads, and doesn't change for the life of this instance.
+ * 
+ * base (_Atomic H5P_mt_list_prop_ref_t):
+ *      Atomic structure of H5P_mt_list_prop_ref_t with it's ptr field pointing to the
+ *      instance of H5P_mt_prop_t in the parent property list class, and the ver field
+ *      should contain the initial version number of the property list.
+ * 
+ *      NOTE: If the instance of H5P_mt_prop_t in the parent property list class has a 
+ *      create callback, we must copy the property into the new property list, and not
+ *      use the property in the parent property list class as the initial value of the
+ *      property. In this case, base.ptr is set to NULL, and base.ver set to 0, the copy
+ *      is inserted into the lock free slignly linked list, and curr.ptr points to the
+ *      copy of the property until such time as the value of the property is modified. In 
+ *      this case, curr.ver is initialized to the initial version of the property list.
+ * 
+ * base_delete_version (_Atomic uint64_t):
+ *      Property lists derived from a property list class must not modify properties in
+ *      the parent property list class. Thus they must maintain their own create and 
+ *      delete version. The create version is simply the initial version of the property
+ *      list, and is stored in the base.ver field. However, if the property is deleted
+ *      from the property list, we must have a delete version to indicate the property 
+ *      list version at which this took place.
+ * 
+ *      The atomic uint64_t base_delete_version exists to serve this purpose. If the base
+ *      version of the property has not been deleted, this field will be 0. Once set to
+ *      a non-zero value, it will never change for the life of the property list.
+ * 
+ * curr (_Atomic H5P_mt_list_prop_ref_t):
+ *      Atomic instance of H5P_mt_list_prop_ref_t whose ptr and ver fields must be 
+ *      initialized to NULL and 0 respectively.
+ * 
+ *      If the value of the inherited property is modified, a new instance of 
+ *      H5P_mt_prop_t is allocated, copying the tag, sentinel, chksum, name, and 
+ *      callback fields from the most recent version of the property pointed to by 
+ *      either base.ptr or curr.ptr.
+ * 
+ *      The in_prop_class, and ref_count fields are set to zero, and not used in 
+ *      property lists. The create_version is set to the version of the property list in 
+ *      which the modified version is set, and the delete_version is set to 0. The value
+ *      field is set to point to the new value of the property, and the new instance of 
+ *      H5P_mt_prop_t is inserted intot he LFSLL of new / modified properties associated 
+ *      with the host property list.
+ * 
+ *      Next, curr.ptr is set to point to the new instance, and curr.ver is set to its
+ *      create_version. Recall that both of these fields are set in a single atomic
+ *      operation. 
+ * 
+ *      Finally, the version of the host property list is incremented to make these 
+ *      chagnes visible.
+ * 
+ ****************************************************************************************
+ */
+typedef struct H5P_mt_list_table_entry_t
+{
+    int64_t                         chksum;
+    char                          * name;
+    _Atomic H5P_mt_list_prop_ref_t  base;
+    _Atomic uint64_t                base_delete_version;
+    _Atomic H5P_mt_list_prop_ref_t  curr;
+
+} H5P_mt_list_table_entry_t;
+
+
+
+/****************************************************************************************
+ * 
+ * Structure: H5P_mt_list_t
+ * 
+ * Description:
+ * 
+ * Revised version of H5P_genlist_t designed for use in a multi-thread safe version of 
+ * the HDF5 property list module (H5P).
+ * 
+ * At the conceptual level, a property list class is simply a list of properties -- i.e.
+ * name value pairs.
+ * 
+ * When a property list is created, it incorporates a list of properties with default 
+ * values from its parent property list class at the version at which the creation of the 
+ * property list was started. At this time, the number of properties in the property list
+ * class is detemined and stored in the nprops_inherited field.
+ * 
+ * This done, an array of H5P_mt_list_table_entry_t of length nprops_inherited is 
+ * allocated, with base.ptr field pointing to the associated instance of H5P_mt_prop_t
+ * in the parent property list class's lock free singly linked list (LFSLL) of 
+ * properties, and the base.ver field set to the initial version of the property list. 
+ * After this array is initialized, it is sorted by chksum and then name, and the 
+ * lkup_table field is set to point to the array of H5P_mt_list_table_entry_t instances. 
+ * Observe that this table allows a log n lookup of properties inherited from the parent 
+ * property list class.
+ * 
+ * If the value of any inherited property is modified, a new instance of H5P_mt_prop_t
+ * is created with the modified value and new creation version, and is inserted into the
+ * property list's LFSLL of properties. The curr.ptr field of the appropriate entry
+ * in the lookup table is set to point to it, and the curr.ver field is set to the new
+ * version of the property. Finally, the property list's curr_version field is 
+ * incremented to make this modification visible.
+ *
+ * If a new property is added to the property list, it is simply inserted into the
+ * property list's LFSLL of instances of H5P_mt_prop_t, and the nprops_added field is
+ * incremented. On searches, the lookup table is searched first, with the LFSLL being
+ * searched only if this first search fails, and nprops_added is positive.
+ *
+ * As with the multi-thread version of the property list classes, property lists
+ * maintain back versions of all properties tagged with the property list version
+ * in which they were created (and possibly deleted). Unlike property list classes,
+ * the properties are not reference counted.
+ *
+ * All operations on a property list must address a specific version, which must be no
+ * greater than the current version at the start of the operation. As shall be seen,
+ * this allows us to make all modifications effectively atomic, which in turn allows
+ * concurrent operations to occur without the potential for data corruption.
+ *
+ * As with property list classes, making modifications to a property list effectively
+ * atomic is slightly tricky, but can be handled in much the same way. Since every
+ * operation on a property list is targeted at a specific version, we can make changes in
+ * progress effectively invisible since new or modified properties are represented by
+ * new instances of H5P_mt_prop_t with creation property list versions higher
+ * than the current version, and thus don't become visible until the property list
+ * version is incremented to the point that they become visible..
+ *
+ * However, as with property list classes, if multiple modifications to the property list
+ * are in progress simultaneously, there is a race condition between the issue of a new
+ * version number to be used to tag a modification, and the increment of the property list
+ * version number when the modification completes.
+ * 
+ * As with property list classes, this can be usually be handled by waiting to increment
+ * the version number until the current version number is one less than the issued
+ * version number. However, if a modify or insert and a delete on the same property are
+ * active at the same time, they must be executed in issue order.
+ *
+ * Also, as per property list classes, modified / new properties are stored on a LFSLL 
+ * instead of a skip list. This LFSLL list is sorted first by a hash on the property 
+ * name, second by property name (to allow for hash collisions), and finally by creation 
+ * version in decreasing order.
+ *
+ * Since only new / modified properties are stored on this list, it should be shorter
+ * than the similar list in property list classes. More importantly, the latest
+ * version of each inherited property is pointed to by the appropriate entry in the
+ * lookup table. Added properties still require a linear search through the LFSLL.
+ * If this proves to be a performance issue, we can either keep added entries in a
+ * different list, or allow the lookup table to be extended when new entries are added.
+ *
+ * Property lists are stored in the index, and should only be accessed via their IDs.
+ * Within HDF5, the reference count on the property list ID should be incremented before
+ * its pointer is looked up in the index, and should not be decremented until the code
+ * in question is done with the property list. If this rule is followed religiously, it 
+ * should be impossible for a property list to be deleted out from under a thread, or
+ * for any thread to access a property list after its reference count drops to zero and
+ * it is removed from the index and discarded.
+ *
+ * However, since any failure of this mechanism will be hard to diagnose, an instance
+ * of H5P_mt_active_thread_count_t is included in H5P_mt_list_t, and must be maintained.
+ * The protocol for doing this is discussed in the header comment for
+ * H5P_mt_active_thread_count_t. In the context of H5P_mt_list_t, a positive thread
+ * count on discard is an error and should trigger an assertion failure.
+ *
+ * Similarly, H5P_mt_list_t contains an instance of H5P_mt_list_sptr_t to support a
+ * free list that shouldn’t be necessary, but which is probably prudent for much the
+ * same reason.
+ * 
+ * Fields:
+ * 
+ * tag (uint32_t):
+ *      Integer value set to H5P_MT_LIST_TAG when an instance of H5P_mt_list_t is 
+ *      allocated from the heap, and set to H5P_MT_LIST_INVALID_TAG just before it is
+ *      released back to the heap. The field is used to validate pointers to instances
+ *      of H5P_mt_list_t.
+ * 
+ * pclass_id (hid_t):
+ *      ID of the instance of H5P_mt_class_t from which the property list was derived.
+ * 
+ *      This field is not atomic, as it is set before this property list is inserted in
+ *      the index, thus before it's visible to other threads, and doesn't change for the
+ *      life of this instance.
+ * 
+ * pclass_ptr (H5P_mt_class_t *):
+ *      Pointer to the instance of H5P_mt_class_t from which the property list was 
+ *      derived.
+ * 
+ *      This field is not atomic, as it is set before this property list is inserted in
+ *      the index, thus before it's visible to other threads, and doesn't change for the
+ *      life of this instance.
+ * 
+ * pclass_version (uint64_t):
+ *      Version of the parent property list class from which this property list was 
+ *      derived.
+ * 
+ * plist_id (hid_t):
+ *      ID assigned to this property list. This field must be atomic, because the 
+ *      instance of H5P_mt_list_t becomes visible to other threads before this field can 
+ *      be set. That said, once it is set, it should not change for the life of the
+ *      property list.
+ * 
+ * curr_version (_Atomic uint64_t):
+ *      Atomic uint64_t containing the current version of the propety list. This version
+ *      number is incremented each time a modification to the property list is completed.
+ *      
+ *      A uint64_t is used, as at present there is no provision for a roll over. Given
+ *      the relative infrequency of modifications to property lists, 64-bits is probably
+ *      sufficient for all reasonable cases. However, a roll over must never occur, and
+ *      an error should be flagged if it does.
+ * 
+ *      To allow an undefined deletion version, the curr_version must be no less than 1.
+ * 
+ * next_version (_Atomic uint64_t):
+ *      Atomic uint64_t containing the version number to be assigned to the next 
+ *      modification of the property list.
+ * 
+ *      When no modificaitons to the property list are in progress, next_version should
+ *      be one greater than curr_version.
+ * 
+ *      When a modification to a property list begins, it does a fetch and increment on
+ *      next_version, preforms its changes and tags them with the returned version, and
+ *      finally increments the curr_version.
+ * 
+ *      NOTE: To avoid exposure of partial modifications, increments to curr_version must
+ *      be executed in next_version issue order. Thus, a thread that modifies the propery
+ *      list, must not increment curr_version until its value is one less than the 
+ *      version number it obtained when it started.
+ * 
+ * lkup_tbl (H5P_mt_list_table_entry_t *):
+ *      Pointer to an array of H5P_mt_list_table_entry_t that permits fast lookup of
+ *      properties inherited from the parent property list class.
+ * 
+ *      See the header comment for H5P_mt_list_table_entry_t for further details.
+ * 
+ * nprops_inherited (uint32_t):
+ *      The number of properties inherited from the parent property list class, and also
+ *      the number of entries in the lookup table (lkup_tbl) above. 
+ * 
+ *      NOTE: Any or all of these properties may be deleted in an arbitrary version of
+ *      the property list.
+ * 
+ * nprops_added (_Atomic uint32_t):
+ *      The number of properties added to the property list after its creation. 
+ *      
+ *      NOTE: These properties do not appear in the lkup_tbl, and thus if a search for
+ *      a property fails in lkup_tbl and nprops_added is positive, the LFSLL pointed to
+ *      by pl_head (below) must also be searched.
+ * 
+ * nprops (_Atomic uint32_t):
+ *      Number of properties defined in the current version of the property list.
+ *      
+ *      NOTE: This value may be briefly incorrect during property additions or deletions
+ *      -- if an accurate value is required, the LFSLL pointed to by pl_head must be 
+ *      scanned for the target property list version.
+ * 
+ * pl_head (_Atomic H5P_mt_prop_t *):
+ *      Atomic pointer to the head of the LFSLL containing the list of modified or 
+ *      inserted properties (i.e. instances of H5P_mt_prop_t) associated with the 
+ *      property list. Other than during setup, this field will always point to the first
+ *      node in the list whose value will be negative infinity (conceptually).
+ * 
+ *      Entries in this list are sorted first by a hash on the property name, second by
+ *      property name (to allow for collisions), and finally by creation version in 
+ *      decreasing order. Other than during setup, the first and last entries in the list
+ *      will be sentinel entries with hash values (conceptually) of negative and positive
+ *      infinity respectively.
+ * 
+ * log_pl_len (_Atomic uint32_t): 
+ *      Number of properties defined in the property list at the current version. 
+ * 
+ *      NOTE: This value will not be correct for all versions of the property list, and
+ *      will be briefly incorrect even for the current version during property 
+ *      insertions and deletions. Thus when an exact value is required, the property list
+ *      must be scanned for the correct value for the desired version.
+ * 
+ * phys_pl_len (_Atomic uint32_t):
+ *      Number of instances of H5P_mt_prop_t in the property list. This number includes
+ *      sentinel nodes, and both current and superseded instanced of H5P_mt_prop_t. 
+ *  
+ *      NOTE: This value will be briefly incorrect during property insertions, deletions,
+ *      and modifications. Modifications of a property cause this value to change, and a
+ *      new instance of H5P_mt_prop_t is inserted with the desired changed and a new
+ *      creation version.
+ * 
+ * class_init (_Atomic bool): 
+ *      True iff the class initialization callback finished successfully.
+ * 
+ * 
+ * Free list and shutdown management fields:
+ * 
+ * thrd (_Atomic H5P_mt_active_thread_count_t):
+ *      This field is a structure used to verify that no threads are active in an 
+ *      instance of H5P_mt_class_t during setup or takedown of the structure prior to 
+ *      discard. See the header comment on H5P_mt_active_thread_count_t for a detailed 
+ *      discription of how its fields must be maintained whena thread wants to access the 
+ *      host instance of H5P_mt_list_t.
+ * 
+ * fl_next (_Atomic H5P_mt_list_sptr_t):
+ *      This field is a structure used to contain a pointer to the next instance of
+ *      H5P_mt_list_t in the free list. It is augmented with a serial number to avoid
+ *      ABA bugs. This field is included to support a free list of instances of
+ *      H5P_mt_list_t.
+ * 
+ * 
+ * Statistics Fields     
+ * 
+ ****************************************************************************************
+ */
+#define H5P_MT_LIST_TAG         0x1012 /* 4114 */
+#define H5P_MT_LIST_INVALID_TAG 0x2022 /* 8226 */
+
+typedef struct H5P_mt_list_t
+{
+    uint32_t                    tag;
+
+    /* Fields related to the parent class*/
+    hid_t                       pclass_id;
+    H5P_mt_class_t            * pclass_ptr;
+    uint64_t                    pclass_version;
+
+    /* Fields related to this class */
+    _Atomic hid_t               plist_id;
+    _Atomic uint64_t            curr_version;
+    _Atomic uint64_t            next_version;
+
+    H5P_mt_list_table_entry_t * lkup_tbl;
+
+    /* Fields related to number of properties */
+    uint32_t                    nprops_inherited;
+    _Atomic uint32_t            nprops_added;
+    _Atomic uint32_t            nprops;
+
+    /* List of properties in the LFSLL, and related fields */
+    H5P_mt_prop_t             * pl_head;
+    _Atomic uint32_t            log_pl_len;
+    _Atomic uint32_t            phys_pl_len;
+
+    _Atomic bool                class_init;
+
+    /* Shutdown and free list management fields */
+    _Atomic H5P_mt_active_thread_count_t thrd;
+    _Atomic H5P_mt_list_sptr_t           fl_next;
+
+    /* stats */
+
+} H5P_mt_list_t;
+
+
+
+/*****************************/
+/* Package Private Variables */
+/*****************************/
+
+
+/*****************************/
+/* Package Private Variables */
+/*****************************/
+
+
+
+#endif /* H5Ppkg_mt_H */

--- a/test/mt_id_test.c
+++ b/test/mt_id_test.c
@@ -6309,14 +6309,13 @@ void serial_test_1(void)
     assert( 0 == (atomic_load(&(H5I_mt_g.num_id_serial_num_resets)) -
                   atomic_load(&(H5I_mt_g.num_id_info_structs_alloced_from_fl)) -
                   atomic_load(&(H5I_mt_g.num_id_info_structs_freed))));
-#if 1
+
     assert( 0 == (atomic_load(&(H5I_mt_g.num_type_next_sn_assigned)) - 
                   atomic_load(&(H5I_mt_g.num_type_info_structs_added_to_fl))));
 
     assert( 0 == (atomic_load(&(H5I_mt_g.num_type_serial_num_resets)) -
                   atomic_load(&(H5I_mt_g.num_type_info_structs_alloced_from_fl)) -
                   atomic_load(&(H5I_mt_g.num_type_info_structs_freed))));
-#endif
 
     if ( H5close() < 0 ) {
 
@@ -7948,14 +7947,13 @@ void mt_test_fcn_1_serial_test(void)
     assert( 0 == (atomic_load(&(H5I_mt_g.num_id_serial_num_resets)) -
                   atomic_load(&(H5I_mt_g.num_id_info_structs_alloced_from_fl)) -
                   atomic_load(&(H5I_mt_g.num_id_info_structs_freed))));
-#if 1
+
     assert( 0 == (atomic_load(&(H5I_mt_g.num_type_next_sn_assigned)) - 
                   atomic_load(&(H5I_mt_g.num_type_info_structs_added_to_fl))));
 
     assert( 0 == (atomic_load(&(H5I_mt_g.num_type_serial_num_resets)) -
                   atomic_load(&(H5I_mt_g.num_type_info_structs_alloced_from_fl)) -
                   atomic_load(&(H5I_mt_g.num_type_info_structs_freed))));
-#endif
 
 
     if ( H5close() < 0 ) {
@@ -8137,14 +8135,12 @@ void mt_test_1(int num_threads)
                   atomic_load(&(H5I_mt_g.num_id_info_structs_alloced_from_fl)) -
                   atomic_load(&(H5I_mt_g.num_id_info_structs_freed))));
 
-#if 1
     assert( 0 == (atomic_load(&(H5I_mt_g.num_type_next_sn_assigned)) - 
                   atomic_load(&(H5I_mt_g.num_type_info_structs_added_to_fl))));
 
     assert( 0 == (atomic_load(&(H5I_mt_g.num_type_serial_num_resets)) -
                   atomic_load(&(H5I_mt_g.num_type_info_structs_alloced_from_fl)) -
                   atomic_load(&(H5I_mt_g.num_type_info_structs_freed))));
-#endif
 
 
     if ( H5close() < 0 ) {
@@ -8413,15 +8409,12 @@ void mt_test_2(int num_threads)
                   atomic_load(&(H5I_mt_g.num_id_info_structs_alloced_from_fl)) -
                   atomic_load(&(H5I_mt_g.num_id_info_structs_freed))));
 
-#if 1
     assert( 0 == (atomic_load(&(H5I_mt_g.num_type_next_sn_assigned)) - 
                   atomic_load(&(H5I_mt_g.num_type_info_structs_added_to_fl))));
 
     assert( 0 == (atomic_load(&(H5I_mt_g.num_type_serial_num_resets)) -
                   atomic_load(&(H5I_mt_g.num_type_info_structs_alloced_from_fl)) -
                   atomic_load(&(H5I_mt_g.num_type_info_structs_freed))));
-#endif
-
 
     if ( H5close() < 0 ) {
 


### PR DESCRIPTION
Changed the H5I id and type free lists from using the length of the free list to determine number of reallocable entries to using serial numbers entries get upon entry to the free list. A maximum allocable serial number in the global struct H5I_mt_g is used as the barrier to prevent entry serial numbers above that maximum to not be re-allocatable. 

Stats variables in H5Ipkg.h that used the number reallocable were removed and serial number tracking stats were added. 

In mt_id_test.c asserts that checked number reallocable adjustments were removed and asserts that checked serial number adjustments were added.

