### PR TITLE
Cherry-pick user-defined callback wrapper

### DIFF
--- a/src/H5.c
+++ b/src/H5.c
@@ -32,6 +32,7 @@
 #include "H5PLprivate.h" /* Plugins                                  */
 #include "H5SLprivate.h" /* Skip lists                               */
 #include "H5Tprivate.h"  /* Datatypes                                */
+#include "H5TSprivate.h" /* Threadsafety                             */
 
 #include "H5FDsec2.h" /* for H5FD_sec2_init() */
 
@@ -1328,3 +1329,54 @@ DllMain(_In_ HINSTANCE hinstDLL, _In_ DWORD fdwReason, _In_ LPVOID lpvReserved)
     return fOkay;
 }
 #endif /* H5_HAVE_WIN32_API && H5_BUILT_AS_DYNAMIC_LIB && H5_HAVE_WIN_THREADS && H5_HAVE_THREADSAFE*/
+/*-------------------------------------------------------------------------
+ * Function:    H5_user_cb_prepare
+ *
+ * Purpose:     Prepares library before a user callback
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5_user_cb_prepare(void)
+{
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+#if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
+    /* Prepare H5TS package for user callback */
+    if (H5TS_user_cb_prepare() < 0)
+        HGOTO_ERROR(H5E_LIB, H5E_CANTSET, FAIL, "unable to prepare H5TS package for user callback");
+#endif /* H5_HAVE_THREADSAFE or H5_HAVE_MULTITHREAD */
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5_user_cb_prepare() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5_user_cb_restore
+ *
+ * Purpose:     Restores library after a user callback
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5_user_cb_restore(void)
+{
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+#if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
+    /* Restore H5TS package after user callback */
+    if (H5TS_user_cb_restore() < 0)
+        HGOTO_ERROR(H5E_LIB, H5E_CANTRESTORE, FAIL, "unable to restore H5TS package after user callback");
+#endif /* H5_HAVE_THREADSAFE or H5_HAVE_MULTITHREAD */
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5_user_cb_restore() */

--- a/src/H5Adense.c
+++ b/src/H5Adense.c
@@ -1047,17 +1047,21 @@ H5A__dense_iterate_bt2_cb(const void *_record, void *_bt2_udata)
                 if (H5A__get_info(fh_udata.attr, &ainfo) < 0)
                     HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, H5_ITER_ERROR, "unable to get attribute info");
 
-                /* Make the application callback */
-                ret_value = (bt2_udata->attr_op->u.app_op2)(bt2_udata->loc_id, fh_udata.attr->shared->name,
-                                                            &ainfo, bt2_udata->op_data);
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(H5_ITER_ERROR) {
+                    /* Make the application callback */
+                    ret_value = (bt2_udata->attr_op->u.app_op2)(bt2_udata->loc_id, fh_udata.attr->shared->name, &ainfo, bt2_udata->op_data);
+                } H5_AFTER_USER_CB(H5_ITER_ERROR)
                 break;
             }
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
             case H5A_ATTR_OP_APP:
-                /* Make the application callback */
-                ret_value = (bt2_udata->attr_op->u.app_op)(bt2_udata->loc_id, fh_udata.attr->shared->name,
-                                                           bt2_udata->op_data);
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(H5_ITER_ERROR) {
+                    /* Make the application callback */
+                    ret_value = (bt2_udata->attr_op->u.app_op)(bt2_udata->loc_id, fh_udata.attr->shared->name, bt2_udata->op_data);
+                } H5_AFTER_USER_CB(H5_ITER_ERROR)
                 break;
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -1866,15 +1866,21 @@ H5A__attr_iterate_table(const H5A_attr_table_t *atable, hsize_t skip, hsize_t *l
                 if (H5A__get_info(atable->attrs[u], &ainfo) < 0)
                     HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, H5_ITER_ERROR, "unable to get attribute info");
 
-                /* Make the application callback */
-                ret_value = (attr_op->u.app_op2)(loc_id, ((atable->attrs[u])->shared)->name, &ainfo, op_data);
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(H5_ITER_ERROR) {
+                    /* Make the application callback */
+                    ret_value = (attr_op->u.app_op2)(loc_id, ((atable->attrs[u])->shared)->name, &ainfo, op_data);
+                } H5_AFTER_USER_CB(H5_ITER_ERROR)
                 break;
             }
 
 #ifndef H5_NO_DEPRECATED_SYMBOLS
             case H5A_ATTR_OP_APP:
-                /* Make the application callback */
-                ret_value = (attr_op->u.app_op)(loc_id, ((atable->attrs[u])->shared)->name, op_data);
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(H5_ITER_ERROR) {
+                    /* Make the application callback */
+                    ret_value = (attr_op->u.app_op)(loc_id, ((atable->attrs[u])->shared)->name, op_data);
+                } H5_AFTER_USER_CB(H5_ITER_ERROR)
                 break;
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -1612,8 +1612,12 @@ H5Dscatter(H5D_scatter_func_t op, void *op_data, hid_t type_id, hid_t dst_space_
 
     /* Loop until all data has been scattered */
     while (nelmts > 0) {
-        /* Make callback to retrieve data */
-        if (op(&src_buf, &src_buf_nbytes, op_data) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            /* Make callback to retrieve data */
+            ret_value = op(&src_buf, &src_buf_nbytes, op_data);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CALLBACK, FAIL, "callback operator returned failure");
 
         /* Calculate number of elements */
@@ -1719,14 +1723,19 @@ H5Dgather(hid_t src_space_id, const void *src_buf, hid_t type_id, size_t dst_buf
     /* Loop until all data has been scattered */
     while (nelmts > 0) {
         /* Gather data */
-        if (0 ==
-            (nelmts_gathered = H5D__gather_mem(src_buf, iter, MIN(dst_buf_nelmts, (size_t)nelmts), dst_buf)))
+        if (0 == (nelmts_gathered = H5D__gather_mem(src_buf, iter, MIN(dst_buf_nelmts, (size_t)nelmts), dst_buf)))
             HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "gather failed");
         assert(nelmts_gathered == MIN(dst_buf_nelmts, (size_t)nelmts));
 
         /* Make callback to process dst_buf */
-        if (op && op(dst_buf, nelmts_gathered * type_size, op_data) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CALLBACK, FAIL, "callback operator returned failure");
+        if (op) {
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                ret_value = op(dst_buf, nelmts_gathered * type_size, op_data);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
+                HGOTO_ERROR(H5E_DATASET, H5E_CALLBACK, FAIL, "callback operator returned failure");
+        }
 
         nelmts -= (hssize_t)nelmts_gathered;
         assert(op || (nelmts == 0));

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -1401,7 +1401,11 @@ H5D__chunk_mem_xfree(void *chk, const void *pline)
 void
 H5D__chunk_mem_free(void *chk, void *pline)
 {
+    FUNC_ENTER_NOAPI_NAMECHECK_ONLY
+
     (void)H5D__chunk_mem_xfree(chk, pline);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
 }
 
 /*-------------------------------------------------------------------------
@@ -8145,15 +8149,19 @@ H5D__chunk_iter_cb(const H5D_chunk_rec_t *chunk_rec, void *udata)
     hsize_t                    offset[H5O_LAYOUT_NDIMS];
     unsigned                   ii; /* Match H5O_layout_chunk_t.ndims */
 
+    FUNC_ENTER_PACKAGE_NOERR
+
     /* Similar to H5D__get_chunk_info */
     for (ii = 0; ii < chunk->ndims; ii++)
         offset[ii] = chunk_rec->scaled[ii] * chunk->dim[ii];
 
-    FUNC_ENTER_PACKAGE_NOERR
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB_NOERR(FAIL) {
+        ret_value = (data->op)(offset, (unsigned)chunk_rec->filter_mask, chunk_rec->chunk_addr, (hsize_t)chunk_rec->nbytes, data->op_data);
+    } H5_AFTER_USER_CB_NOERR(FAIL)
 
     /* Check for callback failure and pass along return value */
-    if ((ret_value = (data->op)(offset, (unsigned)chunk_rec->filter_mask, chunk_rec->chunk_addr,
-                                (hsize_t)chunk_rec->nbytes, data->op_data)) < 0)
+    if (ret_value < 0)
         HERROR(H5E_DATASET, H5E_CANTNEXT, "iteration operator failed");
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Dfill.c
+++ b/src/H5Dfill.c
@@ -367,12 +367,16 @@ H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocat
                 fb_info->use_caller_fill_buf = TRUE;
             } /* end if */
             else {
-                if (alloc_func)
-                    fb_info->fill_buf = alloc_func(fb_info->fill_buf_size, alloc_info);
+                if (alloc_func) {
+                    /* Prepare & restore library for user callback */
+                    H5_BEFORE_USER_CB(FAIL) {
+                        fb_info->fill_buf = alloc_func(fb_info->fill_buf_size, alloc_info);
+                    } H5_AFTER_USER_CB(FAIL)
+                }
                 else
                     fb_info->fill_buf = H5FL_BLK_MALLOC(non_zero_fill, fb_info->fill_buf_size);
                 if (NULL == fb_info->fill_buf)
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for fill buffer");
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "memory allocation failed for fill buffer");
             } /* end else */
 
             /* Get the datatype conversion path for this operation */
@@ -420,12 +424,16 @@ H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocat
                 fb_info->use_caller_fill_buf = TRUE;
             } /* end if */
             else {
-                if (alloc_func)
-                    fb_info->fill_buf = alloc_func(fb_info->fill_buf_size, alloc_info);
+                if (alloc_func) {
+                    /* Prepare & restore library for user callback */
+                    H5_BEFORE_USER_CB(FAIL) {
+                        fb_info->fill_buf = alloc_func(fb_info->fill_buf_size, alloc_info);
+                    } H5_AFTER_USER_CB(FAIL)
+                }
                 else
                     fb_info->fill_buf = H5FL_BLK_MALLOC(non_zero_fill, fb_info->fill_buf_size);
                 if (NULL == fb_info->fill_buf)
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for fill buffer");
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "memory allocation failed for fill buffer");
             } /* end else */
 
             /* Replicate the fill value into the cached buffer */
@@ -456,14 +464,17 @@ H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocat
         } /* end if */
         else {
             if (alloc_func) {
-                fb_info->fill_buf = alloc_func(fb_info->fill_buf_size, alloc_info);
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(FAIL) {
+                    fb_info->fill_buf = alloc_func(fb_info->fill_buf_size, alloc_info);
+                } H5_AFTER_USER_CB(FAIL)
+                if (NULL == fb_info->fill_buf)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "memory allocation failed for fill buffer");
 
                 memset(fb_info->fill_buf, 0, fb_info->fill_buf_size);
             } /* end if */
             else {
-                htri_t buf_avail = H5FL_BLK_AVAIL(
-                    zero_fill,
-                    fb_info->fill_buf_size); /* Check if there is an already zeroed out buffer available */
+                htri_t buf_avail = H5FL_BLK_AVAIL( zero_fill, fb_info->fill_buf_size); /* Check if there is an already zeroed out buffer available */
                 assert(buf_avail != FAIL);
 
                 /* Allocate temporary buffer (zeroing it if no buffer is available) */
@@ -530,8 +541,12 @@ H5D__fill_refill_vl(H5D_fill_buf_info_t *fb_info, size_t nelmts)
         memset(fb_info->bkg_buf, 0, fb_info->bkg_buf_size);
 
     /* Make a copy of the fill buffer so we can free dynamic elements after conversion */
-    if (fb_info->fill_alloc_func)
-        buf = fb_info->fill_alloc_func(fb_info->fill_buf_size, fb_info->fill_alloc_info);
+    if (fb_info->fill_alloc_func) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            buf = fb_info->fill_alloc_func(fb_info->fill_buf_size, fb_info->fill_alloc_info);
+        } H5_AFTER_USER_CB(FAIL)
+    }
     else
         buf = H5FL_BLK_MALLOC(non_zero_fill, fb_info->fill_buf_size);
     if (!buf)
@@ -557,8 +572,12 @@ done:
         } /* end else */
 
         /* Free temporary fill buffer */
-        if (fb_info->fill_free_func)
-            fb_info->fill_free_func(buf, fb_info->fill_free_info);
+        if (fb_info->fill_free_func) {
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB_NOERR(FAIL) {
+                fb_info->fill_free_func(buf, fb_info->fill_free_info);
+            } H5_AFTER_USER_CB_NOERR(FAIL)
+        }
         else
             buf = H5FL_BLK_FREE(non_zero_fill, buf);
     } /* end if */
@@ -578,6 +597,8 @@ done:
 static herr_t
 H5D__fill_release(H5D_fill_buf_info_t *fb_info)
 {
+    herr_t          ret_value = SUCCEED;             /* Return value */
+
     FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
@@ -586,8 +607,12 @@ H5D__fill_release(H5D_fill_buf_info_t *fb_info)
 
     /* Free the buffer for fill values */
     if (!fb_info->use_caller_fill_buf && fb_info->fill_buf) {
-        if (fb_info->fill_free_func)
-            fb_info->fill_free_func(fb_info->fill_buf, fb_info->fill_free_info);
+        if (fb_info->fill_free_func) {
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB_NOERR(FAIL) {
+                fb_info->fill_free_func(fb_info->fill_buf, fb_info->fill_free_info);
+            } H5_AFTER_USER_CB_NOERR(FAIL)
+        }
         else {
             if (fb_info->fill->buf)
                 fb_info->fill_buf = H5FL_BLK_FREE(non_zero_fill, fb_info->fill_buf);
@@ -597,7 +622,7 @@ H5D__fill_release(H5D_fill_buf_info_t *fb_info)
         fb_info->fill_buf = NULL;
     } /* end if */
 
-    FUNC_LEAVE_NOAPI(SUCCEED)
+    FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__fill_release() */
 
 /*-------------------------------------------------------------------------

--- a/src/H5ESint.c
+++ b/src/H5ESint.c
@@ -286,9 +286,16 @@ H5ES__insert(H5ES_t *es, H5VL_t *connector, void *request_token, const char *app
     ev_inserted = TRUE;
 
     /* Invoke the event set's 'insert' callback, if present */
-    if (es->ins_func)
-        if ((es->ins_func)(&ev->op_info, es->ins_ctx) < 0)
+    if (es->ins_func) {
+        int status = -1;
+
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            status = (es->ins_func)(&ev->op_info, es->ins_ctx);
+        } H5_AFTER_USER_CB(FAIL)
+        if (status < 0)
             HGOTO_ERROR(H5E_EVENTSET, H5E_CALLBACK, FAIL, "'insert' callback for event set failed");
+    }
 
 done:
     /* Release resources on error */
@@ -542,6 +549,7 @@ H5ES__op_complete(H5ES_t *es, H5ES_event_t *ev, H5VL_request_status_t ev_status)
         /* Invoke the event set's 'complete' callback, if present */
         if (es->comp_func) {
             H5ES_status_t op_status; /* Status for complete callback */
+            int status = -1;
 
             /* Set appropriate info for callback */
             if (H5VL_REQUEST_STATUS_SUCCEED == ev_status) {
@@ -562,7 +570,11 @@ H5ES__op_complete(H5ES_t *es, H5ES_event_t *ev, H5VL_request_status_t ev_status)
                 /* Translate status */
                 op_status = H5ES_STATUS_CANCELED;
 
-            if ((es->comp_func)(&ev->op_info, op_status, H5I_INVALID_HID, es->comp_ctx) < 0)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                status = (es->comp_func)(&ev->op_info, op_status, H5I_INVALID_HID, es->comp_ctx);
+            } H5_AFTER_USER_CB(FAIL)
+            if (status < 0)
                 HGOTO_ERROR(H5E_EVENTSET, H5E_CALLBACK, FAIL, "'complete' callback for event set failed");
         } /* end if */
 
@@ -576,6 +588,7 @@ H5ES__op_complete(H5ES_t *es, H5ES_event_t *ev, H5VL_request_status_t ev_status)
             /* Set up VOL callback arguments */
             vol_cb_args.op_type                         = H5VL_REQUEST_GET_ERR_STACK;
             vol_cb_args.args.get_err_stack.err_stack_id = H5I_INVALID_HID;
+            int status = -1;
 
             /* Retrieve the error stack for the operation */
             if (H5VL_request_specific(ev->request, &vol_cb_args) < 0)
@@ -584,7 +597,11 @@ H5ES__op_complete(H5ES_t *es, H5ES_event_t *ev, H5VL_request_status_t ev_status)
             /* Set values */
             err_stack_id = vol_cb_args.args.get_err_stack.err_stack_id;
 
-            if ((es->comp_func)(&ev->op_info, H5ES_STATUS_FAIL, err_stack_id, es->comp_ctx) < 0)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                status = (es->comp_func)(&ev->op_info, H5ES_STATUS_FAIL, err_stack_id, es->comp_ctx);
+            } H5_AFTER_USER_CB(FAIL)
+            if (status < 0)
                 HGOTO_ERROR(H5E_EVENTSET, H5E_CALLBACK, FAIL, "'complete' callback for event set failed");
         } /* end if */
 

--- a/src/H5Eint.c
+++ b/src/H5Eint.c
@@ -498,7 +498,10 @@ H5E__walk(const H5E_t *estack, H5E_direction_t direction, const H5E_walk_op_t *o
                     old_err.desc      = estack->slot[i].desc;
                     old_err.line      = estack->slot[i].line;
 
-                    ret_value = (op->u.func1)(i, &old_err, client_data);
+                    /* Prepare & restore library for user callback */
+                    H5_BEFORE_USER_CB_NOERR(H5_ITER_ERROR) {
+                        ret_value = (op->u.func1)(i, &old_err, client_data);
+                    } H5_AFTER_USER_CB_NOERR(H5_ITER_ERROR)
                 } /* end for */
             }     /* end if */
             else {
@@ -512,7 +515,10 @@ H5E__walk(const H5E_t *estack, H5E_direction_t direction, const H5E_walk_op_t *o
                     old_err.desc      = estack->slot[i].desc;
                     old_err.line      = estack->slot[i].line;
 
-                    ret_value = (op->u.func1)((int)(estack->nused - (size_t)(i + 1)), &old_err, client_data);
+                    /* Prepare & restore library for user callback */
+                    H5_BEFORE_USER_CB_NOERR(H5_ITER_ERROR) {
+                        ret_value = (op->u.func1)((int)(estack->nused - (size_t)(i + 1)), &old_err, client_data);
+                    } H5_AFTER_USER_CB_NOERR(H5_ITER_ERROR)
                 } /* end for */
             }     /* end else */
 
@@ -529,13 +535,19 @@ H5E__walk(const H5E_t *estack, H5E_direction_t direction, const H5E_walk_op_t *o
             ret_value = SUCCEED;
             if (H5E_WALK_UPWARD == direction) {
                 for (i = 0; i < (int)estack->nused && ret_value == H5_ITER_CONT; i++)
-                    ret_value = (op->u.func2)((unsigned)i, estack->slot + i, client_data);
+                    /* Prepare & restore library for user callback */
+                    H5_BEFORE_USER_CB_NOERR(H5_ITER_ERROR) {
+                        ret_value = (op->u.func2)((unsigned)i, estack->slot + i, client_data);
+                    } H5_AFTER_USER_CB_NOERR(H5_ITER_ERROR)
             } /* end if */
             else {
                 H5_CHECK_OVERFLOW(estack->nused - 1, size_t, int);
                 for (i = (int)(estack->nused - 1); i >= 0 && ret_value == H5_ITER_CONT; i--)
+                    /* Prepare & restore library for user callback */
+                    H5_BEFORE_USER_CB_NOERR(H5_ITER_ERROR) {
                     ret_value = (op->u.func2)((unsigned)(estack->nused - (size_t)(i + 1)), estack->slot + i,
                                               client_data);
+                    } H5_AFTER_USER_CB_NOERR(H5_ITER_ERROR)
             } /* end else */
 
             if (ret_value < 0)
@@ -976,17 +988,26 @@ H5E_dump_api_stack(hbool_t is_api)
         assert(estack);
 
 #ifdef H5_NO_DEPRECATED_SYMBOLS
-        if (estack->auto_op.func2)
+    if (estack->auto_op.func2)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB_NOERR(H5_ITER_ERROR) {
             (void)((estack->auto_op.func2)(H5E_DEFAULT, estack->auto_data));
+        } H5_AFTER_USER_CB_NOERR(H5_ITER_ERROR)
 #else  /* H5_NO_DEPRECATED_SYMBOLS */
-        if (estack->auto_op.vers == 1) {
-            if (estack->auto_op.func1)
+    if (estack->auto_op.vers == 1) {
+        if (estack->auto_op.func1)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB_NOERR(H5_ITER_ERROR) {
                 (void)((estack->auto_op.func1)(estack->auto_data));
-        } /* end if */
-        else {
-            if (estack->auto_op.func2)
+            } H5_AFTER_USER_CB_NOERR(H5_ITER_ERROR)
+    } /* end if */
+    else {
+        if (estack->auto_op.func2)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB_NOERR(H5_ITER_ERROR) {
                 (void)((estack->auto_op.func2)(H5E_DEFAULT, estack->auto_data));
-        } /* end else */
+            } H5_AFTER_USER_CB_NOERR(H5_ITER_ERROR)
+    } /* end else */
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
     }  /* end if */
 

--- a/src/H5FD.c
+++ b/src/H5FD.c
@@ -175,9 +175,14 @@ H5FD__free_cls(H5FD_class_t *cls, void H5_ATTR_UNUSED **request)
      * driver a chance to free singletons or other resources which will become
      * invalid once the class structure is freed.
      */
-    if (cls->terminate && cls->terminate() < 0)
-        HGOTO_ERROR(H5E_VFL, H5E_CANTCLOSEOBJ, FAIL, "virtual file driver '%s' did not terminate cleanly",
-                    cls->name);
+    if (cls->terminate) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = cls->terminate();
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTCLOSEOBJ, FAIL, "virtual file driver '%s' did not terminate cleanly", cls->name);
+    }
 
     H5MM_xfree(cls);
 
@@ -453,8 +458,12 @@ H5FD_sb_size(H5FD_t *file)
     assert(file->cls);
 
     /* Dispatch to driver */
-    if (file->cls->sb_size)
-        ret_value = (file->cls->sb_size)(file);
+    if (file->cls->sb_size) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB_NOERR(0) {
+            ret_value = (file->cls->sb_size)(file);
+        } H5_AFTER_USER_CB_NOERR(0)
+    }
 
     FUNC_LEAVE_NOAPI(ret_value)
 }
@@ -485,8 +494,14 @@ H5FD_sb_encode(H5FD_t *file, char *name /*out*/, uint8_t *buf)
     assert(file->cls);
 
     /* Dispatch to driver */
-    if (file->cls->sb_encode && (file->cls->sb_encode)(file, name /*out*/, buf /*out*/) < 0)
-        HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver sb_encode request failed");
+    if (file->cls->sb_encode) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->sb_encode)(file, name /*out*/, buf /*out*/);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver sb_encode request failed");
+    }
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -513,8 +528,14 @@ H5FD__sb_decode(H5FD_t *file, const char *name, const uint8_t *buf)
     assert(file->cls);
 
     /* Dispatch to driver */
-    if (file->cls->sb_decode && (file->cls->sb_decode)(file, name, buf) < 0)
-        HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver sb_decode request failed");
+    if (file->cls->sb_decode) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->sb_decode)(file, name, buf);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver sb_decode request failed");
+    }
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -590,8 +611,12 @@ H5FD_fapl_get(H5FD_t *file)
     assert(file->cls);
 
     /* Dispatch to driver */
-    if (file->cls->fapl_get)
-        ret_value = (file->cls->fapl_get)(file);
+    if (file->cls->fapl_get) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB_NOERR(NULL) {
+            ret_value = (file->cls->fapl_get)(file);
+        } H5_AFTER_USER_CB_NOERR(NULL)
+    }
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5FD_fapl_get() */
@@ -951,8 +976,11 @@ H5FD_cmp(const H5FD_t *f1, const H5FD_t *f2)
         HGOTO_DONE(0);
     }
 
-    /* Dispatch to driver */
-    ret_value = (f1->cls->cmp)(f1, f2);
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB_NOCHECK {
+        /* Dispatch to driver */
+        ret_value = (f1->cls->cmp)(f1, f2);
+    } H5_AFTER_USER_CB_NOCHECK
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1015,7 +1043,11 @@ H5FD__query(const H5FD_t *file, unsigned long *flags /*out*/)
 
     /* Dispatch to driver (if available) */
     if (file->cls->query) {
-        if ((file->cls->query)(file, flags) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->query)(file, flags);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "unable to query feature flags");
     }
     else
@@ -1371,8 +1403,12 @@ H5FD_get_fs_type_map(const H5FD_t *file, H5FD_mem_t *type_map)
 
     /* Check for VFD class providing a type map retrieval routine */
     if (file->cls->get_type_map) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->get_type_map)(file, type_map);
+        } H5_AFTER_USER_CB(FAIL)
         /* Retrieve type mapping for this file */
-        if ((file->cls->get_type_map)(file, type_map) < 0)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "driver get type map failed");
     } /* end if */
     else
@@ -2283,8 +2319,14 @@ H5FD_flush(H5FD_t *file, hbool_t closing)
     assert(file->cls);
 
     /* Dispatch to driver */
-    if (file->cls->flush && (file->cls->flush)(file, H5CX_get_dxpl(), closing) < 0)
-        HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver flush request failed");
+    if (file->cls->flush) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->flush)(file, H5CX_get_dxpl(), closing);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver flush request failed");
+    }
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -2349,8 +2391,14 @@ H5FD_truncate(H5FD_t *file, hbool_t closing)
     assert(file->cls);
 
     /* Dispatch to driver */
-    if (file->cls->truncate && (file->cls->truncate)(file, H5CX_get_dxpl(), closing) < 0)
-        HGOTO_ERROR(H5E_VFL, H5E_CANTUPDATE, FAIL, "driver truncate request failed");
+    if (file->cls->truncate) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->truncate)(file, H5CX_get_dxpl(), closing);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTUPDATE, FAIL, "driver truncate request failed");
+    }
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -2408,8 +2456,14 @@ H5FD_lock(H5FD_t *file, hbool_t rw)
     assert(file->cls);
 
     /* Dispatch to driver */
-    if (file->cls->lock && (file->cls->lock)(file, rw) < 0)
-        HGOTO_ERROR(H5E_VFL, H5E_CANTLOCKFILE, FAIL, "driver lock request failed");
+    if (file->cls->lock) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->lock)(file, rw);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTLOCKFILE, FAIL, "driver lock request failed");
+    }
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -2467,8 +2521,14 @@ H5FD_unlock(H5FD_t *file)
     assert(file->cls);
 
     /* Dispatch to driver */
-    if (file->cls->unlock && (file->cls->unlock)(file) < 0)
-        HGOTO_ERROR(H5E_VFL, H5E_CANTUNLOCKFILE, FAIL, "driver unlock request failed");
+    if (file->cls->unlock) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->unlock)(file);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTUNLOCKFILE, FAIL, "driver unlock request failed");
+    }
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -2558,16 +2618,16 @@ H5FD_ctl(H5FD_t *file, uint64_t op_code, uint64_t flags, const void *input, void
      * Otherwise, report success.
      */
     if (file->cls->ctl) {
-
-        if ((file->cls->ctl)(file, op_code, flags, input, output) < 0)
-
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->ctl)(file, op_code, flags, input, output);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VFL, H5E_FCNTL, FAIL, "VFD ctl request failed");
     }
-    else if (flags & H5FD_CTL_FAIL_IF_UNKNOWN_FLAG) {
-
-        HGOTO_ERROR(H5E_VFL, H5E_FCNTL, FAIL,
-                    "VFD ctl request failed (no ctl callback and fail if unknown flag is set)");
-    }
+    else
+        if (flags & H5FD_CTL_FAIL_IF_UNKNOWN_FLAG)
+            HGOTO_ERROR(H5E_VFL, H5E_FCNTL, FAIL, "VFD ctl request failed (no ctl callback and fail if unknown flag is set)");
 
 done:
 
@@ -2666,7 +2726,12 @@ H5FD_get_vfd_handle(H5FD_t *file, hid_t fapl_id, void **file_handle)
     /* Dispatch to driver */
     if (NULL == file->cls->get_handle)
         HGOTO_ERROR(H5E_VFL, H5E_UNSUPPORTED, FAIL, "file driver has no `get_vfd_handle' method");
-    if ((file->cls->get_handle)(file, fapl_id, file_handle) < 0)
+
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        ret_value = (file->cls->get_handle)(file, fapl_id, file_handle);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't get file handle for file driver");
 
 done:

--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -840,13 +840,18 @@ H5FD__core_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
         if (size) {
             /* Allocate memory for the file's data, using the file image callback if available. */
             if (file->fi_callbacks.image_malloc) {
-                if (NULL == (file->mem = (unsigned char *)file->fi_callbacks.image_malloc(
-                                 size, H5FD_FILE_IMAGE_OP_FILE_OPEN, file->fi_callbacks.udata)))
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, NULL, "image malloc callback failed");
+                /* Prepare & restore library for user callback */
+
+                H5_BEFORE_USER_CB(NULL) {
+                    file->mem = file->fi_callbacks.image_malloc(
+                        size, H5FD_FILE_IMAGE_OP_FILE_OPEN, file->fi_callbacks.udata);
+                } H5_AFTER_USER_CB(NULL)
+                if (NULL == file->mem)
+                    HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "image malloc callback failed");
             } /* end if */
             else {
-                if (NULL == (file->mem = (unsigned char *)H5MM_malloc(size)))
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, NULL, "unable to allocate memory block");
+                if (NULL == (file->mem = H5MM_malloc(size)))
+                    HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate memory block");
             } /* end else */
 
             /* Set up data structures */
@@ -855,10 +860,16 @@ H5FD__core_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
             /* If there is an initial file image, copy it, using the callback if possible */
             if (file_image_info.buffer && file_image_info.size > 0) {
                 if (file->fi_callbacks.image_memcpy) {
-                    if (file->mem != file->fi_callbacks.image_memcpy(file->mem, file_image_info.buffer, size,
-                                                                     H5FD_FILE_IMAGE_OP_FILE_OPEN,
-                                                                     file->fi_callbacks.udata))
-                        HGOTO_ERROR(H5E_FILE, H5E_CANTCOPY, NULL, "image_memcpy callback failed");
+                    void *tmp = NULL;
+
+                    /* Prepare & restore library for user callback */
+                    H5_BEFORE_USER_CB(NULL) {
+                        tmp = file->fi_callbacks.image_memcpy(file->mem, file_image_info.buffer, size,
+                                                              H5FD_FILE_IMAGE_OP_FILE_OPEN, file->fi_callbacks.udata);
+                    } H5_AFTER_USER_CB(NULL)
+
+                    if (file->mem != tmp)
+                        HGOTO_ERROR(H5E_VFL, H5E_CANTCOPY, NULL, "image_memcpy callback failed");
                 } /* end if */
                 else
                     H5MM_memcpy(file->mem, file_image_info.buffer, size);
@@ -993,9 +1004,13 @@ H5FD__core_close(H5FD_t *_file)
     if (file->mem) {
         /* Use image callback if available */
         if (file->fi_callbacks.image_free) {
-            if (file->fi_callbacks.image_free(file->mem, H5FD_FILE_IMAGE_OP_FILE_CLOSE,
-                                              file->fi_callbacks.udata) < 0)
-                HGOTO_ERROR(H5E_FILE, H5E_CANTFREE, FAIL, "image_free callback failed");
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                ret_value = file->fi_callbacks.image_free(file->mem, H5FD_FILE_IMAGE_OP_FILE_CLOSE,
+                                                  file->fi_callbacks.udata);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
+                HGOTO_ERROR(H5E_VFL, H5E_CANTFREE, FAIL, "image_free callback failed");
         } /* end if */
         else
             H5MM_xfree(file->mem);
@@ -1362,15 +1377,20 @@ H5FD__core_write(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UN
 
         /* (Re)allocate memory for the file buffer, using callbacks if available */
         if (file->fi_callbacks.image_realloc) {
-            if (NULL == (x = (unsigned char *)file->fi_callbacks.image_realloc(
-                             file->mem, new_eof, H5FD_FILE_IMAGE_OP_FILE_RESIZE, file->fi_callbacks.udata)))
-                HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL,
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                x = file->fi_callbacks.image_realloc(
+                    file->mem, new_eof, H5FD_FILE_IMAGE_OP_FILE_RESIZE, file->fi_callbacks.udata);
+            } H5_AFTER_USER_CB(FAIL)
+
+            if (NULL == x)
+                HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL,
                             "unable to allocate memory block of %llu bytes with callback",
                             (unsigned long long)new_eof);
         } /* end if */
         else {
-            if (NULL == (x = (unsigned char *)H5MM_realloc(file->mem, new_eof)))
-                HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL,
+            if (NULL == (x = H5MM_realloc(file->mem, new_eof)))
+                HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL,
                             "unable to allocate memory block of %llu bytes", (unsigned long long)new_eof);
         } /* end else */
 
@@ -1520,15 +1540,19 @@ H5FD__core_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t closing
 
             /* (Re)allocate memory for the file buffer, using callback if available */
             if (file->fi_callbacks.image_realloc) {
-                if (NULL ==
-                    (x = (unsigned char *)file->fi_callbacks.image_realloc(
-                         file->mem, new_eof, H5FD_FILE_IMAGE_OP_FILE_RESIZE, file->fi_callbacks.udata)))
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL,
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(FAIL) {
+                    x = (unsigned char *)file->fi_callbacks.image_realloc(
+                        file->mem, new_eof, H5FD_FILE_IMAGE_OP_FILE_RESIZE, file->fi_callbacks.udata);
+                } H5_AFTER_USER_CB(FAIL)
+
+                if (NULL == x)
+                    HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL,
                                 "unable to allocate memory block with callback");
             } /* end if */
             else {
                 if (NULL == (x = (unsigned char *)H5MM_realloc(file->mem, new_eof)))
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "unable to allocate memory block");
+                    HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, "unable to allocate memory block");
             } /* end else */
 
             if (file->eof < new_eof)

--- a/src/H5FDint.c
+++ b/src/H5FDint.c
@@ -244,7 +244,11 @@ H5FD_read(H5FD_t *file, H5FD_mem_t type, haddr_t addr, size_t size, void *buf /*
     if (!(file->access_flags & H5F_ACC_SWMR_READ)) {
         haddr_t eoa;
 
-        if (HADDR_UNDEF == (eoa = (file->cls->get_eoa)(file, type)))
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            eoa = (file->cls->get_eoa)(file, type);
+        } H5_AFTER_USER_CB(FAIL)
+        if (!H5_addr_defined(eoa))
             HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver get_eoa request failed");
 
         if ((addr + file->base_addr + size) > eoa)
@@ -253,8 +257,12 @@ H5FD_read(H5FD_t *file, H5FD_mem_t type, haddr_t addr, size_t size, void *buf /*
                         (unsigned long long)eoa);
     }
 
-    /* Dispatch to driver */
-    if ((file->cls->read)(file, type, dxpl_id, addr + file->base_addr, size, buf) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Dispatch to driver */
+        ret_value = (file->cls->read)(file, type, dxpl_id, addr + file->base_addr, size, buf);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "driver read request failed");
 
 done:
@@ -297,15 +305,23 @@ H5FD_write(H5FD_t *file, H5FD_mem_t type, haddr_t addr, size_t size, const void 
         HGOTO_DONE(SUCCEED);
 #endif /* H5_HAVE_PARALLEL */
 
-    if (HADDR_UNDEF == (eoa = (file->cls->get_eoa)(file, type)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        eoa = (file->cls->get_eoa)(file, type);
+    } H5_AFTER_USER_CB(FAIL)
+    if (!H5_addr_defined(eoa))
         HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver get_eoa request failed");
     if ((addr + file->base_addr + size) > eoa)
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu, size=%llu, eoa=%llu",
                     (unsigned long long)(addr + file->base_addr), (unsigned long long)size,
                     (unsigned long long)eoa);
 
-    /* Dispatch to driver */
-    if ((file->cls->write)(file, type, dxpl_id, addr + file->base_addr, size, buf) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Dispatch to driver */
+        ret_value = (file->cls->write)(file, type, dxpl_id, addr + file->base_addr, size, buf);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, "driver write request failed");
 
 done:
@@ -387,21 +403,17 @@ H5FD_read_vector(H5FD_t *file, uint32_t count, H5FD_mem_t types[], haddr_t addrs
      * Do not return early for Parallel mode since the I/O could be a
      * collective transfer.
      */
-    if (0 == count) {
+    if (0 == count)
         HGOTO_DONE(SUCCEED);
-    }
 #endif /* H5_HAVE_PARALLEL */
 
     if (file->base_addr > 0) {
-
         /* apply the base_addr offset to the addrs array.  Must undo before
          * we return.
          */
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             addrs[i] += file->base_addr;
-        }
-        addrs_cooked = TRUE;
+        addrs_cooked = true;
     }
 
     /* If the file is open for SWMR read access, allow access to data past
@@ -417,54 +429,48 @@ H5FD_read_vector(H5FD_t *file, uint32_t count, H5FD_mem_t types[], haddr_t addrs
         extend_types = FALSE;
 
         for (i = 0; i < count; i++) {
-
             if (!extend_sizes) {
-
                 if (sizes[i] == 0) {
-
-                    extend_sizes = TRUE;
+                    extend_sizes = true;
                     size         = sizes[i - 1];
                 }
-                else {
-
+                else
                     size = sizes[i];
-                }
             }
 
             if (!extend_types) {
-
                 if (types[i] == H5FD_MEM_NOLIST) {
-
-                    extend_types = TRUE;
+                    extend_types = true;
                     type         = types[i - 1];
                 }
                 else {
-
                     type = types[i];
                 }
             }
 
-            if (HADDR_UNDEF == (eoa = (file->cls->get_eoa)(file, type)))
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                eoa = (file->cls->get_eoa)(file, type);
+            } H5_AFTER_USER_CB(FAIL)
+            if (!H5_addr_defined(eoa))
                 HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver get_eoa request failed");
 
             if ((addrs[i] + size) > eoa)
-
-                HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL,
-                            "addr overflow, addrs[%d] = %llu, sizes[%d] = %llu, eoa = %llu", (int)i,
-                            (unsigned long long)(addrs[i]), (int)i, (unsigned long long)size,
-                            (unsigned long long)eoa);
+                HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addrs[%d] = %llu, sizes[%d] = %llu, eoa = %llu", (int)i,
+                            (unsigned long long)(addrs[i]), (int)i, (unsigned long long)size, (unsigned long long)eoa);
         }
     }
 
     /* if the underlying VFD supports vector read, make the call */
     if (file->cls->read_vector) {
-
-        if ((file->cls->read_vector)(file, dxpl_id, count, types, addrs, sizes, bufs) < 0)
-
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->read_vector)(file, dxpl_id, count, types, addrs, sizes, bufs);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "driver read vector request failed");
     }
     else {
-
         /* otherwise, implement the vector read as a sequence of regular
          * read calls.
          */
@@ -473,38 +479,32 @@ H5FD_read_vector(H5FD_t *file, uint32_t count, H5FD_mem_t types[], haddr_t addrs
         uint32_t no_selection_io_cause;
 
         for (i = 0; i < count; i++) {
-
             /* we have already verified that sizes[0] != 0 and
              * types[0] != H5FD_MEM_NOLIST
              */
-
             if (!extend_sizes) {
-
                 if (sizes[i] == 0) {
-
-                    extend_sizes = TRUE;
+                    extend_sizes = true;
                     size         = sizes[i - 1];
                 }
-                else {
-
+                else
                     size = sizes[i];
-                }
             }
 
             if (!extend_types) {
-
                 if (types[i] == H5FD_MEM_NOLIST) {
-
-                    extend_types = TRUE;
+                    extend_types = true;
                     type         = types[i - 1];
                 }
-                else {
-
+                else
                     type = types[i];
-                }
             }
 
-            if ((file->cls->read)(file, type, dxpl_id, addrs[i], size, bufs[i]) < 0)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                ret_value = (file->cls->read)(file, type, dxpl_id, addrs[i], size, bufs[i]);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
                 HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "driver read request failed");
         }
 
@@ -517,14 +517,11 @@ H5FD_read_vector(H5FD_t *file, uint32_t count, H5FD_mem_t types[], haddr_t addrs
 done:
     /* undo the base addr offset to the addrs array if necessary */
     if (addrs_cooked) {
-
         assert(file->base_addr > 0);
-
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             addrs[i] -= file->base_addr;
-        }
     }
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5FD_read_vector() */
 
@@ -607,65 +604,56 @@ H5FD_write_vector(H5FD_t *file, uint32_t count, H5FD_mem_t types[], haddr_t addr
 #endif /* H5_HAVE_PARALLEL */
 
     if (file->base_addr > 0) {
-
         /* apply the base_addr offset to the addrs array.  Must undo before
          * we return.
          */
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             addrs[i] += file->base_addr;
-        }
-        addrs_cooked = TRUE;
+        addrs_cooked = true;
     }
 
     extend_sizes = FALSE;
     extend_types = FALSE;
 
     for (i = 0; i < count; i++) {
-
         if (!extend_sizes) {
-
             if (sizes[i] == 0) {
-
-                extend_sizes = TRUE;
+                extend_sizes = true;
                 size         = sizes[i - 1];
             }
-            else {
-
+            else
                 size = sizes[i];
-            }
         }
 
         if (!extend_types) {
-
             if (types[i] == H5FD_MEM_NOLIST) {
-
-                extend_types = TRUE;
+                extend_types = true;
                 type         = types[i - 1];
             }
             else {
-
                 type = types[i];
             }
         }
 
-        if (HADDR_UNDEF == (eoa = (file->cls->get_eoa)(file, type)))
-
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            eoa = (file->cls->get_eoa)(file, type);
+        } H5_AFTER_USER_CB(FAIL)
+        if (!H5_addr_defined(eoa))
             HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver get_eoa request failed");
 
         if ((addrs[i] + size) > eoa)
-
-            HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addrs[%d] = %llu, sizes[%d] = %llu, \
-                        eoa = %llu",
-                        (int)i, (unsigned long long)(addrs[i]), (int)i, (unsigned long long)size,
-                        (unsigned long long)eoa);
+            HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addrs[%d] = %llu, sizes[%d] = %llu, eoa = %llu",
+                        (int)i, (unsigned long long)(addrs[i]), (int)i, (unsigned long long)size, (unsigned long long)eoa);
     }
 
     /* if the underlying VFD supports vector write, make the call */
     if (file->cls->write_vector) {
-
-        if ((file->cls->write_vector)(file, dxpl_id, count, types, addrs, sizes, bufs) < 0)
-
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->write_vector)(file, dxpl_id, count, types, addrs, sizes, bufs);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, "driver write vector request failed");
     }
     else {
@@ -677,38 +665,32 @@ H5FD_write_vector(H5FD_t *file, uint32_t count, H5FD_mem_t types[], haddr_t addr
         uint32_t no_selection_io_cause;
 
         for (i = 0; i < count; i++) {
-
             /* we have already verified that sizes[0] != 0 and
              * types[0] != H5FD_MEM_NOLIST
              */
-
             if (!extend_sizes) {
-
                 if (sizes[i] == 0) {
-
-                    extend_sizes = TRUE;
+                    extend_sizes = true;
                     size         = sizes[i - 1];
                 }
-                else {
-
+                else
                     size = sizes[i];
-                }
             }
 
             if (!extend_types) {
-
                 if (types[i] == H5FD_MEM_NOLIST) {
-
-                    extend_types = TRUE;
+                    extend_types = true;
                     type         = types[i - 1];
                 }
-                else {
-
+                else
                     type = types[i];
-                }
             }
 
-            if ((file->cls->write)(file, type, dxpl_id, addrs[i], size, bufs[i]) < 0)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                ret_value = (file->cls->write)(file, type, dxpl_id, addrs[i], size, bufs[i]);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
                 HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "driver write request failed");
         }
 
@@ -721,14 +703,11 @@ H5FD_write_vector(H5FD_t *file, uint32_t count, H5FD_mem_t types[], haddr_t addr
 done:
     /* undo the base addr offset to the addrs array if necessary */
     if (addrs_cooked) {
-
         assert(file->base_addr > 0);
-
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             addrs[i] -= file->base_addr;
-        }
     }
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5FD_write_vector() */
 
@@ -957,11 +936,15 @@ H5FD__read_selection_translate(uint32_t skip_vector_cb, H5FD_t *file, H5FD_mem_t
                 vec_bufs[vec_arr_nused] = (void *)((uint8_t *)buf + mem_off[mem_seq_i]);
                 vec_arr_nused++;
             }
-            else
-                /* Issue scalar read call */
-                if ((file->cls->read)(file, type, dxpl_id, offsets[i] + file_off[file_seq_i], io_len,
-                                      (void *)((uint8_t *)buf + mem_off[mem_seq_i])) < 0)
+            else {
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(FAIL) {
+                    /* Issue scalar read call */
+                    ret_value = (file->cls->read)(file, type, dxpl_id, offsets[i] + file_off[file_seq_i], io_len, (void *)((uint8_t *)buf + mem_off[mem_seq_i]));
+                } H5_AFTER_USER_CB(FAIL)
+                if (ret_value < 0)
                     HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "driver read request failed");
+            }
 
             /* Update file sequence */
             if (io_len == file_len[file_seq_i])
@@ -997,8 +980,11 @@ H5FD__read_selection_translate(uint32_t skip_vector_cb, H5FD_t *file, H5FD_mem_t
     /* Issue vector read call if appropriate */
     if (use_vector) {
         H5_CHECK_OVERFLOW(vec_arr_nused, size_t, uint32_t);
-        if ((file->cls->read_vector)(file, dxpl_id, (uint32_t)vec_arr_nused, types, addrs, sizes, vec_bufs) <
-            0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->read_vector)(file, dxpl_id, (uint32_t)vec_arr_nused, types, addrs, sizes, vec_bufs);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "driver read vector request failed");
     }
     else {
@@ -1117,21 +1103,17 @@ H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_s
      * Do not return early for Parallel mode since the I/O could be a
      * collective transfer.
      */
-    if (0 == count) {
+    if (0 == count)
         HGOTO_DONE(SUCCEED);
-    }
 #endif /* H5_HAVE_PARALLEL */
 
     if (file->base_addr > 0) {
-
         /* apply the base_addr offset to the offsets array.  Must undo before
          * we return.
          */
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             offsets[i] += file->base_addr;
-        }
-        offsets_cooked = TRUE;
+        offsets_cooked = true;
     }
 
     /* If the file is open for SWMR read access, allow access to data past
@@ -1147,16 +1129,16 @@ H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_s
     if (!(file->access_flags & H5F_ACC_SWMR_READ)) {
         haddr_t eoa;
 
-        if (HADDR_UNDEF == (eoa = (file->cls->get_eoa)(file, type)))
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            eoa = (file->cls->get_eoa)(file, type);
+        } H5_AFTER_USER_CB(FAIL)
+        if (!H5_addr_defined(eoa))
             HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver get_eoa request failed");
 
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             if ((offsets[i]) > eoa)
-
-                HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, offsets[%d] = %llu, eoa = %llu",
-                            (int)i, (unsigned long long)(offsets[i]), (unsigned long long)eoa);
-        }
+                HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, offsets[%d] = %llu, eoa = %llu", (int)i, (unsigned long long)(offsets[i]), (unsigned long long)eoa);
     }
 
     /* if the underlying VFD supports selection read, make the call */
@@ -1183,8 +1165,11 @@ H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_s
             }
         }
 
-        if ((file->cls->read_selection)(file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets,
-                                        element_sizes, bufs) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->read_selection)(file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets, element_sizes, bufs);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "driver read selection request failed");
     }
     else
@@ -1198,13 +1183,9 @@ H5FD_read_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_s
 done:
     /* undo the base addr offset to the offsets array if necessary */
     if (offsets_cooked) {
-
         assert(file->base_addr > 0);
-
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             offsets[i] -= file->base_addr;
-        }
     }
 
     /* Cleanup dataspace arrays.  Use H5I_remove() so we only close the IDs and
@@ -1290,24 +1271,20 @@ H5FD_read_selection_id(uint32_t skip_cb, H5FD_t *file, H5FD_mem_t type, uint32_t
      * Do not return early for Parallel mode since the I/O could be a
      * collective transfer.
      */
-    if (0 == count) {
+    if (0 == count)
         HGOTO_DONE(SUCCEED);
-    }
 #endif /* H5_HAVE_PARALLEL */
 
     skip_selection_cb = skip_cb & SKIP_SELECTION_CB;
     skip_vector_cb    = skip_cb & SKIP_VECTOR_CB;
 
     if (file->base_addr > 0) {
-
         /* apply the base_addr offset to the offsets array.  Must undo before
          * we return.
          */
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             offsets[i] += file->base_addr;
-        }
-        offsets_cooked = TRUE;
+        offsets_cooked = true;
     }
 
     /* If the file is open for SWMR read access, allow access to data past
@@ -1323,22 +1300,27 @@ H5FD_read_selection_id(uint32_t skip_cb, H5FD_t *file, H5FD_mem_t type, uint32_t
     if (!(file->access_flags & H5F_ACC_SWMR_READ)) {
         haddr_t eoa;
 
-        if (HADDR_UNDEF == (eoa = (file->cls->get_eoa)(file, type)))
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            eoa = (file->cls->get_eoa)(file, type);
+        } H5_AFTER_USER_CB(FAIL)
+        if (!H5_addr_defined(eoa))
             HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver get_eoa request failed");
 
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             if ((offsets[i]) > eoa)
-
-                HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, offsets[%d] = %llu, eoa = %llu",
-                            (int)i, (unsigned long long)(offsets[i]), (unsigned long long)eoa);
-        }
+                HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, offsets[%d] = %llu, eoa = %llu", (int)i, (unsigned long long)(offsets[i]), (unsigned long long)eoa);
     }
 
     /* if the underlying VFD supports selection read, make the call */
     if (!skip_selection_cb && file->cls->read_selection) {
-        if ((file->cls->read_selection)(file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets,
-                                        element_sizes, bufs) < 0)
+        uint32_t actual_selection_io_mode;
+
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->read_selection)(file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets, element_sizes, bufs);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "driver read selection request failed");
     }
     else {
@@ -1373,13 +1355,9 @@ H5FD_read_selection_id(uint32_t skip_cb, H5FD_t *file, H5FD_mem_t type, uint32_t
 done:
     /* undo the base addr offset to the offsets array if necessary */
     if (offsets_cooked) {
-
         assert(file->base_addr > 0);
-
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             offsets[i] -= file->base_addr;
-        }
     }
 
     /* Cleanup dataspace arrays */
@@ -1473,34 +1451,24 @@ H5FD__write_selection_translate(uint32_t skip_vector_cb, H5FD_t *file, H5FD_mem_
 
     /* Loop over dataspaces */
     for (i = 0; i < count; i++) {
-
         /* we have already verified that element_sizes[0] != 0 and bufs[0]
          * != NULL */
-
         if (!extend_sizes) {
-
             if (element_sizes[i] == 0) {
-
-                extend_sizes = TRUE;
+                extend_sizes = true;
                 element_size = element_sizes[i - 1];
             }
-            else {
-
+            else
                 element_size = element_sizes[i];
-            }
         }
 
         if (!extend_bufs) {
-
             if (bufs[i] == NULL) {
-
-                extend_bufs = TRUE;
+                extend_bufs = true;
                 buf         = bufs[i - 1];
             }
-            else {
-
+            else
                 buf = bufs[i];
-            }
         }
 
         /* Initialize sequence lists for memory and file spaces */
@@ -1614,11 +1582,15 @@ H5FD__write_selection_translate(uint32_t skip_vector_cb, H5FD_t *file, H5FD_mem_
                 vec_bufs[vec_arr_nused] = (const void *)((const uint8_t *)buf + mem_off[mem_seq_i]);
                 vec_arr_nused++;
             }
-            else
-                /* Issue scalar write call */
-                if ((file->cls->write)(file, type, dxpl_id, offsets[i] + file_off[file_seq_i], io_len,
-                                       (const void *)((const uint8_t *)buf + mem_off[mem_seq_i])) < 0)
+            else {
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(FAIL) {
+                    /* Issue scalar write call */
+                    ret_value = (file->cls->write)(file, type, dxpl_id, offsets[i] + file_off[file_seq_i], io_len, (const void *)((const uint8_t *)buf + mem_off[mem_seq_i]));
+                } H5_AFTER_USER_CB(FAIL)
+                if (ret_value < 0)
                     HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, "driver write request failed");
+            }
 
             /* Update file sequence */
             if (io_len == file_len[file_seq_i])
@@ -1654,8 +1626,11 @@ H5FD__write_selection_translate(uint32_t skip_vector_cb, H5FD_t *file, H5FD_mem_
     /* Issue vector write call if appropriate */
     if (use_vector) {
         H5_CHECK_OVERFLOW(vec_arr_nused, size_t, uint32_t);
-        if ((file->cls->write_vector)(file, dxpl_id, (uint32_t)vec_arr_nused, types, addrs, sizes, vec_bufs) <
-            0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->write_vector)(file, dxpl_id, (uint32_t)vec_arr_nused, types, addrs, sizes, vec_bufs);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, "driver write vector request failed");
     }
     else {
@@ -1742,6 +1717,7 @@ H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_
     hid_t   *mem_space_ids = mem_space_ids_local;
     hid_t    file_space_ids_local[H5FD_LOCAL_SEL_ARR_LEN];
     hid_t   *file_space_ids = file_space_ids_local;
+    haddr_t eoa;
     uint32_t num_spaces     = 0;
     hid_t    dxpl_id        = H5I_INVALID_HID; /* DXPL for operation */
     uint32_t i;
@@ -1772,41 +1748,34 @@ H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_
      * Do not return early for Parallel mode since the I/O could be a
      * collective transfer.
      */
-    if (0 == count) {
+    if (0 == count)
         HGOTO_DONE(SUCCEED);
-    }
 #endif /* H5_HAVE_PARALLEL */
 
     if (file->base_addr > 0) {
-
         /* apply the base_addr offset to the offsets array.  Must undo before
          * we return.
          */
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             offsets[i] += file->base_addr;
-        }
-        offsets_cooked = TRUE;
+        offsets_cooked = true;
     }
 
     /* For now at least, only check that the offset is not past the eoa, since
      * looking into the highest offset in the selection (different from the
      * bounds) is potentially expensive.
      */
-    {
-        haddr_t eoa;
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        eoa = (file->cls->get_eoa)(file, type);
+    } H5_AFTER_USER_CB(FAIL)
+    if (!H5_addr_defined(eoa))
+        HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver get_eoa request failed");
 
-        if (HADDR_UNDEF == (eoa = (file->cls->get_eoa)(file, type)))
-            HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver get_eoa request failed");
-
-        for (i = 0; i < count; i++) {
-
-            if ((offsets[i]) > eoa)
-
-                HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, offsets[%d] = %llu, eoa = %llu",
-                            (int)i, (unsigned long long)(offsets[i]), (unsigned long long)eoa);
-        }
-    }
+    for (i = 0; i < count; i++)
+        if ((offsets[i]) > eoa)
+            HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, offsets[%d] = %llu, eoa = %llu",
+                        (int)i, (unsigned long long)(offsets[i]), (unsigned long long)eoa);
 
     /* if the underlying VFD supports selection write, make the call */
     if (file->cls->write_selection) {
@@ -1824,16 +1793,18 @@ H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_
             if ((mem_space_ids[num_spaces] = H5I_register(H5I_DATASPACE, mem_spaces[num_spaces], TRUE)) < 0)
                 HGOTO_ERROR(H5E_VFL, H5E_CANTREGISTER, FAIL, "unable to register dataspace ID");
 
-            if ((file_space_ids[num_spaces] = H5I_register(H5I_DATASPACE, file_spaces[num_spaces], TRUE)) <
-                0) {
+            if ((file_space_ids[num_spaces] = H5I_register(H5I_DATASPACE, file_spaces[num_spaces], true)) < 0) {
                 if (NULL == H5I_remove(mem_space_ids[num_spaces]))
                     HDONE_ERROR(H5E_VFL, H5E_CANTREMOVE, FAIL, "problem removing id");
                 HGOTO_ERROR(H5E_VFL, H5E_CANTREGISTER, FAIL, "unable to register dataspace ID");
             }
         }
 
-        if ((file->cls->write_selection)(file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets,
-                                         element_sizes, bufs) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->write_selection)(file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets, element_sizes, bufs);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, "driver write selection request failed");
     }
     else
@@ -1848,13 +1819,9 @@ H5FD_write_selection(H5FD_t *file, H5FD_mem_t type, uint32_t count, H5S_t **mem_
 done:
     /* undo the base addr offset to the offsets array if necessary */
     if (offsets_cooked) {
-
         assert(file->base_addr > 0);
-
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             offsets[i] -= file->base_addr;
-        }
     }
 
     /* Cleanup dataspace arrays.  Use H5I_remove() so we only close the IDs and
@@ -1907,6 +1874,7 @@ H5FD_write_selection_id(uint32_t skip_cb, H5FD_t *file, H5FD_mem_t type, uint32_
     H5S_t  **mem_spaces = mem_spaces_local;
     H5S_t   *file_spaces_local[H5FD_LOCAL_SEL_ARR_LEN];
     H5S_t  **file_spaces = file_spaces_local;
+    haddr_t eoa;
     hid_t    dxpl_id     = H5I_INVALID_HID; /* DXPL for operation */
     uint32_t i;
     uint32_t skip_selection_cb;
@@ -1938,49 +1906,47 @@ H5FD_write_selection_id(uint32_t skip_cb, H5FD_t *file, H5FD_mem_t type, uint32_
      * Do not return early for Parallel mode since the I/O could be a
      * collective transfer.
      */
-    if (0 == count) {
+    if (0 == count)
         HGOTO_DONE(SUCCEED);
-    }
 #endif /* H5_HAVE_PARALLEL */
 
     skip_selection_cb = skip_cb & SKIP_SELECTION_CB;
     skip_vector_cb    = skip_cb & SKIP_VECTOR_CB;
 
     if (file->base_addr > 0) {
-
         /* apply the base_addr offset to the offsets array.  Must undo before
          * we return.
          */
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             offsets[i] += file->base_addr;
-        }
-        offsets_cooked = TRUE;
+        offsets_cooked = true;
     }
 
     /* For now at least, only check that the offset is not past the eoa, since
      * looking into the highest offset in the selection (different from the
      * bounds) is potentially expensive.
      */
-    {
-        haddr_t eoa;
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        eoa = (file->cls->get_eoa)(file, type);
+    } H5_AFTER_USER_CB(FAIL)
+    if (!H5_addr_defined(eoa))
+        HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver get_eoa request failed");
 
-        if (HADDR_UNDEF == (eoa = (file->cls->get_eoa)(file, type)))
-            HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver get_eoa request failed");
-
-        for (i = 0; i < count; i++) {
-
-            if ((offsets[i]) > eoa)
-
-                HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, offsets[%d] = %llu, eoa = %llu",
-                            (int)i, (unsigned long long)(offsets[i]), (unsigned long long)eoa);
-        }
-    }
+    for (i = 0; i < count; i++)
+        if ((offsets[i]) > eoa)
+            HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, offsets[%d] = %llu, eoa = %llu",
+                        (int)i, (unsigned long long)(offsets[i]), (unsigned long long)eoa);
 
     /* if the underlying VFD supports selection write, make the call */
     if (!skip_selection_cb && file->cls->write_selection) {
-        if ((file->cls->write_selection)(file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets,
-                                         element_sizes, bufs) < 0)
+        uint32_t actual_selection_io_mode;
+
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (file->cls->write_selection)(file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets, element_sizes, bufs);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, "driver write selection request failed");
     }
     else {
@@ -2006,7 +1972,6 @@ H5FD_write_selection_id(uint32_t skip_cb, H5FD_t *file, H5FD_mem_t type, uint32_
         }
 
         /* Translate to vector or scalar I/O */
-
         if (H5FD__write_selection_translate(skip_vector_cb, file, type, dxpl_id, count, mem_spaces,
                                             file_spaces, offsets, element_sizes, bufs) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, "translation to vector or scalar write failed");
@@ -2015,13 +1980,9 @@ H5FD_write_selection_id(uint32_t skip_cb, H5FD_t *file, H5FD_mem_t type, uint32_
 done:
     /* undo the base addr offset to the offsets array if necessary */
     if (offsets_cooked) {
-
         assert(file->base_addr > 0);
-
-        for (i = 0; i < count; i++) {
-
+        for (i = 0; i < count; i++)
             offsets[i] -= file->base_addr;
-        }
     }
 
     /* Cleanup dataspace arrays */
@@ -2260,8 +2221,12 @@ H5FD_set_eoa(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
     assert(file && file->cls);
     assert(H5_addr_defined(addr) && addr <= file->maxaddr);
 
-    /* Dispatch to driver, convert to absolute address */
-    if ((file->cls->set_eoa)(file, type, addr + file->base_addr) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Dispatch to driver, convert to absolute address */
+        ret_value = (file->cls->set_eoa)(file, type, addr + file->base_addr);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, FAIL, "driver set_eoa request failed");
 
 done:
@@ -2293,8 +2258,12 @@ H5FD_get_eoa(const H5FD_t *file, H5FD_mem_t type)
 
     assert(file && file->cls);
 
-    /* Dispatch to driver */
-    if (HADDR_UNDEF == (ret_value = (file->cls->get_eoa)(file, type)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(HADDR_UNDEF) {
+        /* Dispatch to driver */
+        ret_value = (file->cls->get_eoa)(file, type);
+    } H5_AFTER_USER_CB(HADDR_UNDEF)
+    if (!H5_addr_defined(ret_value))
         HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, HADDR_UNDEF, "driver get_eoa request failed");
 
     /* Adjust for base address in file (convert to relative address) */
@@ -2331,7 +2300,11 @@ H5FD_get_eof(const H5FD_t *file, H5FD_mem_t type)
 
     /* Dispatch to driver */
     if (file->cls->get_eof) {
-        if (HADDR_UNDEF == (ret_value = (file->cls->get_eof)(file, type)))
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(HADDR_UNDEF) {
+            ret_value = (file->cls->get_eof)(file, type);
+        } H5_AFTER_USER_CB(HADDR_UNDEF)
+        if (!H5_addr_defined(ret_value))
             HGOTO_ERROR(H5E_VFL, H5E_CANTGET, HADDR_UNDEF, "driver get_eof request failed");
     }
     else

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -3376,9 +3376,14 @@ H5F_object_flush_cb(H5F_t *f, hid_t obj_id)
     assert(f->shared);
 
     /* Invoke object flush callback if there is one */
-    if (f->shared->object_flush.func &&
-        f->shared->object_flush.func(obj_id, f->shared->object_flush.udata) < 0)
-        HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "object flush callback returns error");
+    if (f->shared->object_flush.func) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = f->shared->object_flush.func(obj_id, f->shared->object_flush.udata);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "object flush callback returns error");
+    }
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Gint.c
+++ b/src/H5Gint.c
@@ -799,8 +799,11 @@ H5G__iterate_cb(const H5O_link_t *lnk, void *_udata)
     switch (udata->lnk_op.op_type) {
 #ifndef H5_NO_DEPRECATED_SYMBOLS
         case H5G_LINK_OP_OLD:
-            /* Make the old-type application callback */
-            ret_value = (udata->lnk_op.op_func.op_old)(udata->gid, lnk->name, udata->op_data);
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(H5_ITER_ERROR) {
+                /* Make the old-type application callback */
+                ret_value = (udata->lnk_op.op_func.op_old)(udata->gid, lnk->name, udata->op_data);
+            } H5_AFTER_USER_CB(H5_ITER_ERROR)
             break;
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
@@ -811,8 +814,11 @@ H5G__iterate_cb(const H5O_link_t *lnk, void *_udata)
             if (H5G_link_to_info(udata->link_loc, lnk, &info) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_CANTGET, H5_ITER_ERROR, "unable to get info for link");
 
-            /* Make the application callback */
-            ret_value = (udata->lnk_op.op_func.op_new)(udata->gid, lnk->name, &info, udata->op_data);
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(H5_ITER_ERROR) {
+                /* Make the application callback */
+                ret_value = (udata->lnk_op.op_func.op_new)(udata->gid, lnk->name, &info, udata->op_data);
+            } H5_AFTER_USER_CB(H5_ITER_ERROR)
         } break;
 
         default:
@@ -952,8 +958,11 @@ H5G__visit_cb(const H5O_link_t *lnk, void *_udata)
     if (H5G_link_to_info(udata->curr_loc->oloc, lnk, &info) < 0)
         HGOTO_ERROR(H5E_SYM, H5E_CANTGET, H5_ITER_ERROR, "unable to get info for link");
 
-    /* Make the application callback */
-    ret_value = (udata->op)(udata->gid, udata->path, &info, udata->op_data);
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(H5_ITER_ERROR) {
+        /* Make the application callback */
+        ret_value = (udata->op)(udata->gid, udata->path, &info, udata->op_data);
+    } H5_AFTER_USER_CB(H5_ITER_ERROR)
 
     /* Check for doing more work */
     if (ret_value == H5_ITER_CONT && lnk->type == H5L_TYPE_HARD) {

--- a/src/H5Glink.c
+++ b/src/H5Glink.c
@@ -298,13 +298,14 @@ H5G_link_to_info(const H5O_loc_t *link_loc, const H5O_link_t *lnk, H5L_info2_t *
                 if (link_class != NULL && link_class->query_func != NULL) {
                     ssize_t cb_ret; /* Return value from UD callback */
 
-                    /* Call the link's query routine to retrieve the user-defined link's value size */
-                    /* (in case the query routine packs/unpacks the link value in some way that changes its
-                     * size) */
-                    if ((cb_ret = (link_class->query_func)(lnk->name, lnk->u.ud.udata, lnk->u.ud.size, NULL,
-                                                           (size_t)0)) < 0)
-                        HGOTO_ERROR(H5E_LINK, H5E_CALLBACK, FAIL,
-                                    "query buffer size callback returned failure");
+                    /* Prepare & restore library for user callback */
+                    H5_BEFORE_USER_CB(FAIL) {
+                        /* Call the link's query routine to retrieve the user-defined link's value size */
+                        /* (in case the query routine packs/unpacks the link value in some way that changes its size) */
+                        cb_ret = (link_class->query_func)(lnk->name, lnk->u.ud.udata, lnk->u.ud.size, NULL, (size_t)0);
+                    } H5_AFTER_USER_CB(FAIL)
+                    if (cb_ret < 0)
+                        HGOTO_ERROR(H5E_LINK, H5E_CALLBACK, FAIL, "query buffer size callback returned failure");
 
                     info->u.val_size = (size_t)cb_ret;
                 } /* end if */

--- a/src/H5Gtraverse.c
+++ b/src/H5Gtraverse.c
@@ -183,15 +183,23 @@ H5G__traverse_ud(const H5G_loc_t *grp_loc /*in,out*/, const H5O_link_t *lnk, H5G
         /* User-defined callback function */
 #ifndef H5_NO_DEPRECATED_SYMBOLS
     /* (Backwardly compatible with v0 H5L_class_t traversal callback) */
-    if (link_class->version == H5L_LINK_CLASS_T_VERS_0)
-        cb_return = (((const H5L_class_0_t *)link_class)->trav_func)(lnk->name, cur_grp, lnk->u.ud.udata,
-                                                                     lnk->u.ud.size, H5CX_get_lapl());
-    else
-        cb_return = (link_class->trav_func)(lnk->name, cur_grp, lnk->u.ud.udata, lnk->u.ud.size,
-                                            H5CX_get_lapl(), H5CX_get_dxpl());
+    if (link_class->version == H5L_LINK_CLASS_T_VERS_0) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            cb_return = (((const H5L_class_0_t *)link_class)->trav_func)(lnk->name, cur_grp, lnk->u.ud.udata, lnk->u.ud.size, H5CX_get_lapl());
+        } H5_AFTER_USER_CB(FAIL)
+    }
+    else {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            cb_return = (link_class->trav_func)(lnk->name, cur_grp, lnk->u.ud.udata, lnk->u.ud.size, H5CX_get_lapl(), H5CX_get_dxpl());
+        } H5_AFTER_USER_CB(FAIL)
+    }
 #else  /* H5_NO_DEPRECATED_SYMBOLS */
-    cb_return = (link_class->trav_func)(lnk->name, cur_grp, lnk->u.ud.udata, lnk->u.ud.size, H5CX_get_lapl(),
-                                        H5CX_get_dxpl());
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        cb_return = (link_class->trav_func)(lnk->name, cur_grp, lnk->u.ud.udata, lnk->u.ud.size, H5CX_get_lapl(), H5CX_get_dxpl());
+    } H5_AFTER_USER_CB(FAIL)
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
     /* Check for failing to locate the object */

--- a/src/H5I.c
+++ b/src/H5I.c
@@ -1614,7 +1614,9 @@ H5I__search_cb(void *obj, hid_t id, void *_udata)
 
     FUNC_ENTER_PACKAGE_NOERR
 
+    H5_BEFORE_USER_CB_NOERR(FAIL) {
     cb_ret_val = (*udata->app_cb)(obj, id, udata->app_key);
+    } H5_AFTER_USER_CB_NOERR(FAIL)
 
     /* Set the return value based on the callback's return value */
     if (cb_ret_val > 0) {
@@ -1720,7 +1722,9 @@ H5I__iterate_pub_cb(void H5_ATTR_UNUSED *obj, hid_t id, void *_udata)
     FUNC_ENTER_PACKAGE_NOERR
 
     /* Invoke the callback */
+    H5_BEFORE_USER_CB_NOERR(FAIL) {
     cb_ret_val = (*udata->op)(id, udata->op_data);
+    } H5_AFTER_USER_CB_NOERR(FAIL)
 
     /* Set the return value based on the callback's return value */
     if (cb_ret_val > 0)

--- a/src/H5Lexternal.c
+++ b/src/H5Lexternal.c
@@ -195,9 +195,11 @@ H5L__extern_traverse(const char H5_ATTR_UNUSED *link_name, hid_t cur_group, cons
         if (H5G_get_name(&loc, parent_group_name, group_name_len, NULL, NULL) < 0)
             HGOTO_ERROR(H5E_LINK, H5E_CANTGET, H5I_INVALID_HID, "unable to retrieve group name");
 
-        /* Make callback */
-        if ((cb_info.func)(parent_file_name, parent_group_name, file_name, obj_name, &intent, fapl_id,
-                           cb_info.user_data) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (cb_info.func)(parent_file_name, parent_group_name, file_name, obj_name, &intent, fapl_id, cb_info.user_data);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_LINK, H5E_CALLBACK, H5I_INVALID_HID, "traversal operator failed");
 
         /* Check access flags */

--- a/src/H5Lint.c
+++ b/src/H5Lint.c
@@ -611,9 +611,12 @@ H5L__link_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t H5_AT
             if ((grp_id = H5VL_wrap_register(H5I_GROUP, grp, TRUE)) < 0)
                 HGOTO_ERROR(H5E_LINK, H5E_CANTREGISTER, FAIL, "unable to register ID for group");
 
-            /* Make callback */
-            if ((link_class->create_func)(name, grp_id, udata->lnk->u.ud.udata, udata->lnk->u.ud.size,
-                                          H5P_DEFAULT) < 0)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                /* Make callback */
+                ret_value = (link_class->create_func)(name, grp_id, udata->lnk->u.ud.udata, udata->lnk->u.ud.size, H5P_DEFAULT);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
                 HGOTO_ERROR(H5E_LINK, H5E_CALLBACK, FAIL, "link creation callback failed");
         } /* end if */
     }     /* end if */
@@ -941,7 +944,13 @@ H5L__get_val_real(const H5O_link_t *lnk, void *buf, size_t size)
         link_class = H5L_find_class(lnk->type);
 
         if (link_class != NULL && link_class->query_func != NULL) {
-            if ((link_class->query_func)(lnk->name, lnk->u.ud.udata, lnk->u.ud.size, buf, size) < 0)
+            ssize_t len;
+
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                len = (link_class->query_func)(lnk->name, lnk->u.ud.udata, lnk->u.ud.size, buf, size);
+            } H5_AFTER_USER_CB(FAIL)
+            if (len < 0)
                 HGOTO_ERROR(H5E_LINK, H5E_CALLBACK, FAIL, "query callback returned failure");
         } /* end if */
         else if (buf && size > 0)
@@ -1345,13 +1354,19 @@ H5L__move_dest_cb(H5G_loc_t *grp_loc /*in*/, const char *name, const H5O_link_t 
                 HGOTO_ERROR(H5E_LINK, H5E_CANTREGISTER, FAIL, "unable to register group ID");
 
             if (udata->copy) {
-                if ((link_class->copy_func)(udata->lnk->name, grp_id, udata->lnk->u.ud.udata,
-                                            udata->lnk->u.ud.size) < 0)
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(FAIL) {
+                    ret_value = (link_class->copy_func)(udata->lnk->name, grp_id, udata->lnk->u.ud.udata, udata->lnk->u.ud.size);
+                } H5_AFTER_USER_CB(FAIL)
+                if (ret_value < 0)
                     HGOTO_ERROR(H5E_LINK, H5E_CALLBACK, FAIL, "UD copy callback returned error");
             } /* end if */
             else {
-                if ((link_class->move_func)(udata->lnk->name, grp_id, udata->lnk->u.ud.udata,
-                                            udata->lnk->u.ud.size) < 0)
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(FAIL) {
+                    ret_value = (link_class->move_func)(udata->lnk->name, grp_id, udata->lnk->u.ud.udata, udata->lnk->u.ud.size);
+                } H5_AFTER_USER_CB(FAIL)
+                if (ret_value < 0)
                     HGOTO_ERROR(H5E_LINK, H5E_CALLBACK, FAIL, "UD move callback returned error");
             } /* end else */
         }     /* end if */

--- a/src/H5Ocopy.c
+++ b/src/H5Ocopy.c
@@ -1496,9 +1496,14 @@ H5O__copy_search_comm_dt(H5F_t *file_src, H5O_t *oh_src, H5O_loc_t *oloc_dst /*i
             H5O_mcdt_search_ret_t search_cb_ret = H5O_MCDT_SEARCH_CONT;
 
             /* Make callback to see if we should search destination file */
-            if (cpy_info->mcdt_cb)
-                if ((search_cb_ret = cpy_info->mcdt_cb(cpy_info->mcdt_ud)) == H5O_MCDT_SEARCH_ERROR)
+            if (cpy_info->mcdt_cb) {
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(FAIL) {
+                    search_cb_ret = cpy_info->mcdt_cb(cpy_info->mcdt_ud);
+                } H5_AFTER_USER_CB(FAIL)
+                if (H5O_MCDT_SEARCH_ERROR ==search_cb_ret)
                     HGOTO_ERROR(H5E_OHDR, H5E_CALLBACK, FAIL, "callback returned error");
+            }
 
             if (search_cb_ret == H5O_MCDT_SEARCH_CONT) {
                 /* Build the complete dst dt list */

--- a/src/H5Oint.c
+++ b/src/H5Oint.c
@@ -2541,8 +2541,11 @@ H5O__visit_cb(hid_t H5_ATTR_UNUSED group, const char *name, const H5L_info2_t *l
             if (H5O_get_info(&obj_oloc, &oinfo, udata->fields) < 0)
                 HGOTO_ERROR(H5E_OHDR, H5E_CANTGET, H5_ITER_ERROR, "unable to get object info");
 
-            /* Make the application callback */
-            ret_value = (udata->op)(udata->obj_id, name, &oinfo, udata->op_data);
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                /* Make the application callback */
+                ret_value = (udata->op)(udata->obj_id, name, &oinfo, udata->op_data);
+            } H5_AFTER_USER_CB(FAIL)
 
             /* Check for continuing to visit objects */
             if (ret_value == H5_ITER_CONT) {

--- a/src/H5Olink.c
+++ b/src/H5Olink.c
@@ -636,8 +636,12 @@ H5O_link_delete(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, void *_mesg)
             if ((file_id = H5F_get_id(f)) < 0)
                 HGOTO_ERROR(H5E_OHDR, H5E_CANTGET, FAIL, "unable to get file ID");
 
-            /* Call user-defined link's 'delete' callback */
-            if ((link_class->del_func)(lnk->name, file_id, lnk->u.ud.udata, lnk->u.ud.size) < 0)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                /* Call user-defined link's 'delete' callback */
+                ret_value = (link_class->del_func)(lnk->name, file_id, lnk->u.ud.udata, lnk->u.ud.size);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
                 HGOTO_ERROR(H5E_OHDR, H5E_CALLBACK, FAIL, "link deletion callback returned failure");
         } /* end if */
     }     /* end if */

--- a/src/H5Pencdec.c
+++ b/src/H5Pencdec.c
@@ -318,9 +318,13 @@ H5P__encode_cb(H5P_genprop_t *prop, void *_udata)
         } /* end if */
         *(udata->enc_size_ptr) += prop_name_len;
 
-        /* Encode (or not, if *(udata->pp) is NULL) the property value */
-        prop_value_len = 0;
-        if ((prop->encode)(prop->value, udata->pp, &prop_value_len) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(H5_ITER_ERROR) {
+            /* Encode (or not, if *(udata->pp) is NULL) the property value */
+            prop_value_len = 0;
+            ret_value = (prop->encode)(prop->value, udata->pp, &prop_value_len);
+        } H5_AFTER_USER_CB(H5_ITER_ERROR)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTENCODE, H5_ITER_ERROR, "property encoding routine failed");
         *(udata->enc_size_ptr) += prop_value_len;
     } /* end if */
@@ -698,9 +702,12 @@ H5P__decode(const void *buf)
 
         /* Decode serialized value */
         if (prop->decode) {
-            if ((prop->decode)((const void **)&p, value_buf) < 0)
-                HGOTO_ERROR(H5E_PLIST, H5E_CANTDECODE, FAIL,
-                            "property decoding routine failed, property: '%s'", name);
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                ret_value = (prop->decode)((const void **)&p, value_buf);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
+                HGOTO_ERROR(H5E_PLIST, H5E_CANTDECODE, FAIL, "property decoding routine failed, property: '%s'", name);
         } /* end if */
         else
             HGOTO_ERROR(H5E_PLIST, H5E_NOTFOUND, FAIL, "no decode callback for property: '%s'", name);

--- a/src/H5Pfapl.c
+++ b/src/H5Pfapl.c
@@ -2997,6 +2997,7 @@ H5Pset_file_image(hid_t fapl_id, void *buf_ptr, size_t buf_len)
     H5P_genplist_t        *fapl;                /* Property list pointer */
     H5FD_file_image_info_t image_info;          /* File image info */
     herr_t                 ret_value = SUCCEED; /* Return value */
+    herr_t                 cb_ret_val = FAIL;
 
     FUNC_ENTER_API(FAIL)
     H5TRACE3("e", "i*xz", fapl_id, buf_ptr, buf_len);
@@ -3007,7 +3008,7 @@ H5Pset_file_image(hid_t fapl_id, void *buf_ptr, size_t buf_len)
 
     /* Get the plist structure */
     if (NULL == (fapl = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
-        HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
+        HGOTO_ERROR(H5E_PLIST, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get old image info */
     if (H5P_peek(fapl, H5F_ACS_FILE_IMAGE_INFO_NAME, &image_info) < 0)
@@ -3016,10 +3017,13 @@ H5Pset_file_image(hid_t fapl_id, void *buf_ptr, size_t buf_len)
     /* Release previous buffer, if it exists */
     if (image_info.buffer != NULL) {
         if (image_info.callbacks.image_free) {
-            if (SUCCEED != image_info.callbacks.image_free(image_info.buffer,
+            H5_BEFORE_USER_CB(FAIL) {
+                cb_ret_val = image_info.callbacks.image_free(image_info.buffer,
                                                            H5FD_FILE_IMAGE_OP_PROPERTY_LIST_SET,
-                                                           image_info.callbacks.udata))
-                HGOTO_ERROR(H5E_RESOURCE, H5E_CANTFREE, FAIL, "image_free callback failed");
+                                                           image_info.callbacks.udata);
+            } H5_AFTER_USER_CB(FAIL)
+            if (SUCCEED != cb_ret_val)
+                HGOTO_ERROR(H5E_PLIST, H5E_CANTFREE, FAIL, "image_free callback failed");
         } /* end if */
         else
             H5MM_xfree(image_info.buffer);
@@ -3029,19 +3033,29 @@ H5Pset_file_image(hid_t fapl_id, void *buf_ptr, size_t buf_len)
     if (buf_ptr) {
         /* Allocate memory */
         if (image_info.callbacks.image_malloc) {
-            if (NULL == (image_info.buffer = image_info.callbacks.image_malloc(
-                             buf_len, H5FD_FILE_IMAGE_OP_PROPERTY_LIST_SET, image_info.callbacks.udata)))
-                HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "image malloc callback failed");
+            H5_BEFORE_USER_CB(FAIL) {
+                image_info.buffer = image_info.callbacks.image_malloc(
+                             buf_len, H5FD_FILE_IMAGE_OP_PROPERTY_LIST_SET, image_info.callbacks.udata);
+            } H5_AFTER_USER_CB(FAIL)
+
+            if (NULL == image_info.buffer)
+                HGOTO_ERROR(H5E_PLIST, H5E_NOSPACE, FAIL, "image malloc callback failed");
         } /* end if */
         else if (NULL == (image_info.buffer = H5MM_malloc(buf_len)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "unable to allocate memory block");
 
         /* Copy data */
         if (image_info.callbacks.image_memcpy) {
-            if (image_info.buffer != image_info.callbacks.image_memcpy(image_info.buffer, buf_ptr, buf_len,
-                                                                       H5FD_FILE_IMAGE_OP_PROPERTY_LIST_SET,
-                                                                       image_info.callbacks.udata))
-                HGOTO_ERROR(H5E_RESOURCE, H5E_CANTCOPY, FAIL, "image_memcpy callback failed");
+            void *tmp = NULL;
+
+            H5_BEFORE_USER_CB(FAIL) {
+                tmp = image_info.callbacks.image_memcpy(image_info.buffer, buf_ptr, buf_len,
+                                                        H5FD_FILE_IMAGE_OP_PROPERTY_LIST_SET,
+                                                        image_info.callbacks.udata);
+            } H5_AFTER_USER_CB(FAIL)
+
+            if (image_info.buffer != tmp)
+                HGOTO_ERROR(H5E_PLIST, H5E_CANTCOPY, FAIL, "image_memcpy callback failed");
         } /* end if */
         else
             H5MM_memcpy(image_info.buffer, buf_ptr, buf_len);
@@ -3097,7 +3111,7 @@ H5Pget_file_image(hid_t fapl_id, void **buf /*out*/, size_t *buf_len /*out*/)
 
     /* Get the plist structure */
     if (NULL == (fapl = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
-        HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
+        HGOTO_ERROR(H5E_PLIST, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get values */
     if (H5P_peek(fapl, H5F_ACS_FILE_IMAGE_INFO_NAME, &image_info) < 0)
@@ -3118,19 +3132,26 @@ H5Pget_file_image(hid_t fapl_id, void **buf /*out*/, size_t *buf_len /*out*/)
         if (image_info.buffer != NULL) {
             /* Allocate memory */
             if (image_info.callbacks.image_malloc) {
-                if (NULL ==
-                    (copy_ptr = image_info.callbacks.image_malloc(
-                         image_info.size, H5FD_FILE_IMAGE_OP_PROPERTY_LIST_GET, image_info.callbacks.udata)))
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "image malloc callback failed");
+                H5_BEFORE_USER_CB(FAIL) {
+                    copy_ptr = image_info.callbacks.image_malloc(
+                        image_info.size, H5FD_FILE_IMAGE_OP_PROPERTY_LIST_GET, image_info.callbacks.udata);
+                } H5_AFTER_USER_CB(FAIL)
+                if (NULL == copy_ptr)
+                    HGOTO_ERROR(H5E_PLIST, H5E_NOSPACE, FAIL, "image malloc callback failed");
             } /* end if */
             else if (NULL == (copy_ptr = H5MM_malloc(image_info.size)))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "unable to allocate copy");
 
             /* Copy data */
             if (image_info.callbacks.image_memcpy) {
-                if (copy_ptr != image_info.callbacks.image_memcpy(
-                                    copy_ptr, image_info.buffer, image_info.size,
-                                    H5FD_FILE_IMAGE_OP_PROPERTY_LIST_GET, image_info.callbacks.udata))
+                void *tmp = NULL;
+                H5_BEFORE_USER_CB(FAIL) {
+                    tmp = image_info.callbacks.image_memcpy(copy_ptr, image_info.buffer, image_info.size,
+                                                            H5FD_FILE_IMAGE_OP_PROPERTY_LIST_GET,
+                                                            image_info.callbacks.udata);
+                } H5_AFTER_USER_CB(FAIL)
+
+                if (copy_ptr != tmp)
                     HGOTO_ERROR(H5E_RESOURCE, H5E_CANTCOPY, FAIL, "image_memcpy callback failed");
             } /* end if */
             else
@@ -3169,7 +3190,7 @@ H5Pset_file_image_callbacks(hid_t fapl_id, H5FD_file_image_callbacks_t *callback
 
     /* Get the plist structure */
     if (NULL == (fapl = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
-        HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
+        HGOTO_ERROR(H5E_PLIST, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get old info */
     if (H5P_peek(fapl, H5F_ACS_FILE_IMAGE_INFO_NAME, &info) < 0)
@@ -3196,7 +3217,10 @@ H5Pset_file_image_callbacks(hid_t fapl_id, H5FD_file_image_callbacks_t *callback
     /* Release old udata if it exists */
     if (info.callbacks.udata != NULL) {
         assert(info.callbacks.udata_free);
-        if (info.callbacks.udata_free(info.callbacks.udata) < 0)
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = info.callbacks.udata_free(info.callbacks.udata);
+        } H5_AFTER_USER_CB(FAIL) 
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTFREE, FAIL, "udata_free callback failed");
     } /* end if */
 
@@ -3206,7 +3230,11 @@ H5Pset_file_image_callbacks(hid_t fapl_id, H5FD_file_image_callbacks_t *callback
     if (callbacks_ptr->udata) {
         assert(callbacks_ptr->udata_copy);
         assert(callbacks_ptr->udata_free);
-        if ((info.callbacks.udata = callbacks_ptr->udata_copy(callbacks_ptr->udata)) == NULL)
+
+        H5_BEFORE_USER_CB(FAIL) {
+            info.callbacks.udata = callbacks_ptr->udata_copy(callbacks_ptr->udata);
+        } H5_AFTER_USER_CB(FAIL)
+        if (NULL == info.callbacks.udata)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "can't copy the supplied udata");
     } /* end if */
 
@@ -3242,7 +3270,7 @@ H5Pget_file_image_callbacks(hid_t fapl_id, H5FD_file_image_callbacks_t *callback
 
     /* Get the plist structure */
     if (NULL == (fapl = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
-        HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
+        HGOTO_ERROR(H5E_PLIST, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get old info */
     if (H5P_peek(fapl, H5F_ACS_FILE_IMAGE_INFO_NAME, &info) < 0)
@@ -3261,7 +3289,10 @@ H5Pget_file_image_callbacks(hid_t fapl_id, H5FD_file_image_callbacks_t *callback
     /* Copy udata if it exists */
     if (info.callbacks.udata != NULL) {
         assert(info.callbacks.udata_copy);
-        if ((callbacks->udata = info.callbacks.udata_copy(info.callbacks.udata)) == 0)
+        H5_BEFORE_USER_CB(FAIL) {
+            callbacks->udata = info.callbacks.udata_copy(info.callbacks.udata);
+        } H5_AFTER_USER_CB(FAIL)
+        if (NULL == callbacks->udata)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "can't copy udata");
     } /* end if */
 
@@ -3308,20 +3339,29 @@ H5P__file_image_info_copy(void *value)
 
             /* Allocate new buffer */
             if (info->callbacks.image_malloc) {
-                if (NULL == (info->buffer = info->callbacks.image_malloc(
-                                 info->size, H5FD_FILE_IMAGE_OP_PROPERTY_LIST_COPY, info->callbacks.udata)))
+                H5_BEFORE_USER_CB(FAIL) {
+                    info->buffer = info->callbacks.image_malloc(info->size, H5FD_FILE_IMAGE_OP_PROPERTY_LIST_COPY,
+                                                               info->callbacks.udata);
+                } H5_AFTER_USER_CB(FAIL)
+
+                if (NULL == info->buffer)
                     HGOTO_ERROR(H5E_PLIST, H5E_CANTALLOC, FAIL, "image malloc callback failed");
             } /* end if */
-            else {
+            else
                 if (NULL == (info->buffer = H5MM_malloc(info->size)))
                     HGOTO_ERROR(H5E_PLIST, H5E_CANTALLOC, FAIL, "unable to allocate memory block");
-            } /* end else */
 
             /* Copy data to new buffer */
             if (info->callbacks.image_memcpy) {
-                if (info->buffer != info->callbacks.image_memcpy(info->buffer, old_buffer, info->size,
-                                                                 H5FD_FILE_IMAGE_OP_PROPERTY_LIST_COPY,
-                                                                 info->callbacks.udata))
+                void *tmp = NULL;
+
+                H5_BEFORE_USER_CB(FAIL) {
+                    tmp = info->callbacks.image_memcpy(info->buffer, old_buffer, info->size,
+                                                             H5FD_FILE_IMAGE_OP_PROPERTY_LIST_COPY,
+                                                             info->callbacks.udata);
+                } H5_AFTER_USER_CB(FAIL)
+
+                if (info->buffer != tmp)
                     HGOTO_ERROR(H5E_PLIST, H5E_CANTCOPY, FAIL, "image_memcpy callback failed");
             } /* end if */
             else
@@ -3335,7 +3375,9 @@ H5P__file_image_info_copy(void *value)
             if (NULL == info->callbacks.udata_copy)
                 HGOTO_ERROR(H5E_PLIST, H5E_BADVALUE, FAIL, "udata_copy not defined");
 
+            H5_BEFORE_USER_CB(FAIL) {
             info->callbacks.udata = info->callbacks.udata_copy(old_udata);
+            } H5_AFTER_USER_CB(FAIL)
         } /* end if */
     }     /* end if */
 
@@ -3373,8 +3415,12 @@ H5P__file_image_info_free(void *value)
         /* Free buffer */
         if (info->buffer != NULL && info->size > 0) {
             if (info->callbacks.image_free) {
-                if ((*info->callbacks.image_free)(info->buffer, H5FD_FILE_IMAGE_OP_PROPERTY_LIST_CLOSE,
-                                                  info->callbacks.udata) < 0)
+
+                H5_BEFORE_USER_CB(FAIL) {
+                    ret_value = (*info->callbacks.image_free)(info->buffer, H5FD_FILE_IMAGE_OP_PROPERTY_LIST_CLOSE,
+                                                  info->callbacks.udata);
+                } H5_AFTER_USER_CB(FAIL)
+                if (ret_value < 0)
                     HGOTO_ERROR(H5E_PLIST, H5E_CANTFREE, FAIL, "image_free callback failed");
             } /* end if */
             else
@@ -3385,7 +3431,11 @@ H5P__file_image_info_free(void *value)
         if (info->callbacks.udata) {
             if (NULL == info->callbacks.udata_free)
                 HGOTO_ERROR(H5E_PLIST, H5E_BADVALUE, FAIL, "udata_free not defined");
-            if ((*info->callbacks.udata_free)(info->callbacks.udata) < 0)
+
+            H5_BEFORE_USER_CB(FAIL) {
+                ret_value = (*info->callbacks.udata_free)(info->callbacks.udata);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
                 HGOTO_ERROR(H5E_PLIST, H5E_CANTFREE, FAIL, "udata_free callback failed");
         } /* end if */
     }     /* end if */

--- a/src/H5Pint.c
+++ b/src/H5Pint.c
@@ -4192,8 +4192,11 @@ H5P__iterate_plist_cb(void *_item, void *_key, void *_udata)
 
     /* Check if we've found the correctly indexed property */
     if (*udata->curr_idx_ptr >= udata->prev_idx) {
-        /* Call the callback function */
-        ret_value = (*udata->cb_func)(item, udata->udata);
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB_NOERR(H5_ITER_ERROR) {
+            /* Call the callback function */
+            ret_value = (*udata->cb_func)(item, udata->udata);
+        } H5_AFTER_USER_CB_NOERR(H5_ITER_ERROR)
         if (ret_value != 0)
             HGOTO_DONE(ret_value);
     } /* end if */
@@ -4403,8 +4406,11 @@ H5P__iterate_pclass_cb(void *_item, void H5_ATTR_NDEBUG_UNUSED *_key, void *_uda
 
     /* Check if we've found the correctly indexed property */
     if (*udata->curr_idx_ptr >= udata->prev_idx) {
-        /* Call the callback function */
-        ret_value = (*udata->cb_func)(item, udata->udata);
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB_NOERR(H5_ITER_ERROR) {
+            /* Call the callback function */
+            ret_value = (*udata->cb_func)(item, udata->udata);
+        } H5_AFTER_USER_CB_NOERR(H5_ITER_ERROR)
         if (ret_value != 0)
             HGOTO_DONE(ret_value);
     } /* end if */

--- a/src/H5Pint.c
+++ b/src/H5Pint.c
@@ -779,8 +779,12 @@ H5P__do_prop_cb1(H5SL_t *slist, H5P_genprop_t *prop, H5P_prp_cb1_t cb)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTALLOC, FAIL, "memory allocation failed for temporary property value");
     H5MM_memcpy(tmp_value, prop->value, prop->size);
 
-    /* Call "type 1" callback ('create', 'copy' or 'close') */
-    if (cb(prop->name, prop->size, tmp_value) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call "type 1" callback ('create', 'copy' or 'close') */
+        ret_value = cb(prop->name, prop->size, tmp_value);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "Property callback failed");
 
     /* Make a copy of the class's property */
@@ -991,7 +995,13 @@ H5P_copy_plist(const H5P_genplist_t *old_plist, hbool_t app_ref)
 
             /* Call property copy callback, if it exists */
             if (new_prop->copy) {
-                if ((new_prop->copy)(new_prop->name, new_prop->size, new_prop->value) < 0) {
+                herr_t status;
+
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(H5I_INVALID_HID) {
+                    status = (new_prop->copy)(new_prop->name, new_prop->size, new_prop->value);
+                } H5_AFTER_USER_CB(H5I_INVALID_HID)
+                if (status < 0) {
                     H5P__free_prop(new_prop);
                     HGOTO_ERROR(H5E_PLIST, H5E_CANTCOPY, H5I_INVALID_HID, "Can't copy property");
                 } /* end if */
@@ -1079,7 +1089,13 @@ H5P_copy_plist(const H5P_genplist_t *old_plist, hbool_t app_ref)
     tclass = new_plist->pclass;
     while (NULL != tclass) {
         if (NULL != tclass->copy_func) {
-            if ((tclass->copy_func)(new_plist_id, old_plist->plist_id, old_plist->pclass->copy_data) < 0) {
+            herr_t status;
+
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(H5I_INVALID_HID) {
+                status = (tclass->copy_func)(new_plist_id, old_plist->plist_id, old_plist->pclass->copy_data);
+            } H5_AFTER_USER_CB(H5I_INVALID_HID)
+            if (status < 0) {
                 /* Delete ID, ignore return value */
                 H5I_remove(new_plist_id);
                 HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, H5I_INVALID_HID, "Can't initialize property");
@@ -1505,8 +1521,13 @@ H5P__free_prop_cb(void *item, void H5_ATTR_UNUSED *key, void *op_data)
     assert(tprop);
 
     /* Call the close callback and ignore the return value, there's nothing we can do about it */
-    if (make_cb && tprop->close != NULL)
-        (tprop->close)(tprop->name, tprop->size, tprop->value);
+    if (make_cb && tprop->close != NULL) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB_NOCHECK {
+            /* Call user's callback */
+            (tprop->close)(tprop->name, tprop->size, tprop->value);
+        } H5_AFTER_USER_CB_NOCHECK
+    }
 
     /* Free the property, ignoring return value, nothing we can do */
     H5P__free_prop(tprop);
@@ -1984,7 +2005,13 @@ H5P_create_id(H5P_genclass_t *pclass, hbool_t app_ref)
     tclass = plist->pclass;
     while (NULL != tclass) {
         if (NULL != tclass->create_func) {
-            if ((tclass->create_func)(plist_id, tclass->create_data) < 0) {
+            herr_t status;
+
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                status = (tclass->create_func)(plist_id, tclass->create_data);
+            } H5_AFTER_USER_CB(FAIL)
+            if (status < 0) {
                 /* Delete ID, ignore return value */
                 H5I_remove(plist_id);
                 HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, H5I_INVALID_HID, "Can't initialize property");
@@ -3015,8 +3042,12 @@ H5P__set_plist_cb(H5P_genplist_t *plist, const char *name, H5P_genprop_t *prop, 
             HGOTO_ERROR(H5E_PLIST, H5E_CANTALLOC, FAIL, "memory allocation failed temporary property value");
         H5MM_memcpy(tmp_value, udata->value, prop->size);
 
-        /* Call user's callback */
-        if ((*(prop->set))(plist->plist_id, name, prop->size, tmp_value) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            /* Call user's callback */
+            ret_value = (*(prop->set))(plist->plist_id, name, prop->size, tmp_value);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "can't set property value");
 
         /* Set the pointer for copying */
@@ -3028,8 +3059,12 @@ H5P__set_plist_cb(H5P_genplist_t *plist, const char *name, H5P_genprop_t *prop, 
 
     /* Free any previous value for the property */
     if (NULL != prop->del) {
-        /* Call user's 'delete' callback */
-        if ((*(prop->del))(plist->plist_id, name, prop->size, prop->value) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            /* Call user's callback */
+            ret_value = (*(prop->del))(plist->plist_id, name, prop->size, prop->value);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTFREE, FAIL, "can't release property value");
     } /* end if */
 
@@ -3093,8 +3128,12 @@ H5P__set_pclass_cb(H5P_genplist_t *plist, const char *name, H5P_genprop_t *prop,
             HGOTO_ERROR(H5E_PLIST, H5E_CANTALLOC, FAIL, "memory allocation failed temporary property value");
         H5MM_memcpy(tmp_value, udata->value, prop->size);
 
-        /* Call user's callback */
-        if ((*(prop->set))(plist->plist_id, name, prop->size, tmp_value) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            /* Call user's callback */
+            ret_value = (*(prop->set))(plist->plist_id, name, prop->size, tmp_value);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "can't set property value");
 
         /* Set the pointer for copying */
@@ -3690,8 +3729,13 @@ H5P__cmp_prop(const H5P_genprop_t *prop1, const H5P_genprop_t *prop2)
     if (prop1->value != NULL && prop2->value == NULL)
         HGOTO_DONE(1);
     if (prop1->value != NULL) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB_NOCHECK {
+            /* Call comparison routine */
+            cmp_value = prop1->cmp(prop1->value, prop2->value, prop1->size);
+        } H5_AFTER_USER_CB_NOCHECK
         /* Call comparison routine */
-        if ((cmp_value = prop1->cmp(prop1->value, prop2->value, prop1->size)) != 0)
+        if (0 != cmp_value)
             HGOTO_DONE(cmp_value);
     } /* end if */
 
@@ -4595,8 +4639,12 @@ H5P__get_cb(H5P_genplist_t *plist, const char *name, H5P_genprop_t *prop, void *
             HGOTO_ERROR(H5E_PLIST, H5E_CANTALLOC, FAIL, "memory allocation failed temporary property value");
         H5MM_memcpy(tmp_value, prop->value, prop->size);
 
-        /* Call user's callback */
-        if ((*(prop->get))(plist->plist_id, name, prop->size, tmp_value) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            /* Call user's callback */
+            ret_value = (*(prop->get))(plist->plist_id, name, prop->size, tmp_value);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "can't set property value");
 
         /* Copy new [possibly unchanged] value into return value */
@@ -4700,8 +4748,12 @@ H5P__del_plist_cb(H5P_genplist_t *plist, const char *name, H5P_genprop_t *prop, 
 
     /* Pass value to 'close' callback, if it exists */
     if (NULL != prop->del) {
-        /* Call user's callback */
-        if ((*(prop->del))(plist->plist_id, name, prop->size, prop->value) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            /* Call user's callback */
+            ret_value = (*(prop->del))(plist->plist_id, name, prop->size, prop->value);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTFREE, FAIL, "can't release property value");
     } /* end if */
 
@@ -4775,8 +4827,12 @@ H5P__del_pclass_cb(H5P_genplist_t *plist, const char *name, H5P_genprop_t *prop,
                         "memory allocation failed for temporary property value");
         H5MM_memcpy(tmp_value, prop->value, prop->size);
 
-        /* Call user's callback */
-        if ((*(prop->del))(plist->plist_id, name, prop->size, tmp_value) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            /* Call user's callback */
+            ret_value = (*(prop->del))(plist->plist_id, name, prop->size, tmp_value);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "can't close property value");
     } /* end if */
 
@@ -4913,7 +4969,12 @@ H5P__copy_prop_plist(hid_t dst_id, hid_t src_id, const char *name)
 
         /* Call property copy callback, if it exists */
         if (new_prop->copy) {
-            if ((new_prop->copy)(new_prop->name, new_prop->size, new_prop->value) < 0)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                /* Call user's callback */
+                ret_value = (new_prop->copy)(new_prop->name, new_prop->size, new_prop->value);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
                 HGOTO_ERROR(H5E_PLIST, H5E_CANTCOPY, FAIL, "Can't copy property");
         } /* end if */
 
@@ -4939,7 +5000,11 @@ H5P__copy_prop_plist(hid_t dst_id, hid_t src_id, const char *name)
 
         /* Call property creation callback, if it exists */
         if (new_prop->create) {
-            if ((new_prop->create)(new_prop->name, new_prop->size, new_prop->value) < 0)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                ret_value = (new_prop->create)(new_prop->name, new_prop->size, new_prop->value);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
                 HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "Can't initialize property");
         } /* end if */
 
@@ -5149,8 +5214,11 @@ H5P_close(H5P_genplist_t *plist)
         tclass = plist->pclass;
         while (NULL != tclass) {
             if (NULL != tclass->close_func) {
-                /* Call user's "close" callback function, ignoring return value */
-                (tclass->close_func)(plist->plist_id, tclass->close_data);
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(FAIL) {
+                    /* Call user's "close" callback function, ignoring return value */
+                    (tclass->close_func)(plist->plist_id, tclass->close_data);
+                } H5_AFTER_USER_CB(FAIL)
             } /* end if */
 
             /* Go up to parent class */
@@ -5176,8 +5244,11 @@ H5P_close(H5P_genplist_t *plist)
 
             /* Call property close callback, if it exists */
             if (tmp->close) {
-                /* Call the 'close' callback */
-                (tmp->close)(tmp->name, tmp->size, tmp->value);
+                /* Prepare & restore library for user callback */
+                H5_BEFORE_USER_CB(FAIL) {
+                    /* Call user's callback */
+                    (tmp->close)(tmp->name, tmp->size, tmp->value);
+                } H5_AFTER_USER_CB(FAIL)
             } /* end if */
 
             /* Add property name to "seen" list */
@@ -5223,8 +5294,11 @@ H5P_close(H5P_genplist_t *plist)
                                         "memory allocation failed for temporary property value");
                         H5MM_memcpy(tmp_value, tmp->value, tmp->size);
 
-                        /* Call the 'close' callback */
-                        (tmp->close)(tmp->name, tmp->size, tmp_value);
+                        /* Prepare & restore library for user callback */
+                        H5_BEFORE_USER_CB(FAIL) {
+                            /* Call user's callback */
+                            (tmp->close)(tmp->name, tmp->size, tmp_value);
+                        } H5_AFTER_USER_CB(FAIL)
 
                         /* Release the temporary value buffer */
                         H5MM_xfree(tmp_value);

--- a/src/H5SMcache.c
+++ b/src/H5SMcache.c
@@ -28,7 +28,7 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5Eprivate.h"  /* Error handling		  	*/
+#include "H5Eprivate.h"  /* Error handling		  	 */
 #include "H5Fprivate.h"  /* File access                          */
 #include "H5FLprivate.h" /* Free Lists                           */
 #include "H5MFprivate.h" /* File memory management		*/

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -1456,8 +1456,11 @@ H5S_select_iterate(void *buf, const H5T_t *type, H5S_t *space, const H5S_sel_ite
                 /* Check which type of callback to make */
                 switch (op->op_type) {
                     case H5S_SEL_ITER_OP_APP:
-                        /* Make the application callback */
-                        user_ret = (op->u.app_op.op)(loc, op->u.app_op.type_id, ndims, coords, op_data);
+                        /* Prepare & restore library for user callback */
+                        H5_BEFORE_USER_CB(H5_ITER_ERROR) {
+                            /* Make the application callback */
+                            user_ret = (op->u.app_op.op)(loc, op->u.app_op.type_id, ndims, coords, op_data);
+                        } H5_AFTER_USER_CB(H5_ITER_ERROR)
                         break;
 
                     case H5S_SEL_ITER_OP_LIB:

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -2536,8 +2536,12 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
             memset(&cdata, 0, sizeof cdata);
             cdata.command = H5T_CONV_INIT;
             if (conv->is_app) {
-                if ((conv->u.app_func)(tmp_sid, tmp_did, &cdata, (size_t)0, (size_t)0, (size_t)0, NULL, NULL,
-                                       H5CX_get_dxpl()) < 0) {
+                herr_t app_ret_value = FAIL;
+                H5_BEFORE_USER_CB(FAIL) {
+                    app_ret_value = (conv->u.app_func)(tmp_sid, tmp_did, &cdata, (size_t)0, (size_t)0, (size_t)0,
+                                                       NULL, NULL, H5CX_get_dxpl());
+                } H5_AFTER_USER_CB(FAIL)
+                if (app_ret_value < 0) {
                     H5I_dec_ref(tmp_sid);
                     H5I_dec_ref(tmp_did);
                     tmp_sid = tmp_did = -1;

--- a/src/H5TS.c
+++ b/src/H5TS.c
@@ -1116,4 +1116,48 @@ H5TS_create_thread(H5TS_thread_cb_t func, H5TS_attr_t *attr, void *udata)
     FUNC_LEAVE_NOAPI_NAMECHECK_ONLY(ret_value)
 } /* H5TS_create_thread */
 
+/*-------------------------------------------------------------------------
+ * Function:    H5TS_user_cb_prepare
+ *
+ * Purpose:     Prepare the H5E package before a user callback
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5TS_user_cb_prepare(void)
+{
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    // TODO
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5TS_user_cb_prepare() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5TS_user_cb_restore
+ *
+ * Purpose:     Restores the state of the H5TS package after a user callback
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5TS_user_cb_restore(void)
+{
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    // TODO
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5TS_user_cb_restore() */
+
 #endif /* H5_HAVE_THREADSAFE or H5_HAVE_MULTITHREAD */

--- a/src/H5TSprivate.h
+++ b/src/H5TSprivate.h
@@ -150,10 +150,15 @@ H5_DLL herr_t H5TS_have_mutex(H5TS_mutex_t *mutex, bool *have_mutex_ptr);
 /* Testing routines */
 H5_DLL H5TS_thread_t H5TS_create_thread(void *(*func)(void *), H5TS_attr_t *attr, void *udata);
 
+/* Prepare for / restore after user callback */
+H5_DLL herr_t H5TS_user_cb_prepare(void);
+H5_DLL herr_t H5TS_user_cb_restore(void);
+
 #else /* H5_HAVE_THREADSAFE or H5_HAVE_MULTITHREAD */
 
 #define H5TS_thread_id() ((uint64_t)0)
 
 #endif /* H5_HAVE_THREADSAFE or H5_HAVE_MULTITHREAD */
+
 
 #endif /* H5TSprivate_H_ */

--- a/src/H5Tconv.c
+++ b/src/H5Tconv.c
@@ -1796,8 +1796,10 @@ H5T__conv_b_b(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     if (cb_struct.func) { /*If user's exception handler is present, use it*/
                         H5T__reverse_order(src_rev, s, src->shared->size,
                                            src->shared->u.atomic.order); /*reverse order first*/
+                        H5_BEFORE_USER_CB(FAIL) {
                         except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev, d,
                                                       cb_struct.user_data);
+                        } H5_AFTER_USER_CB(FAIL)
                     } /* end if */
 
                     if (except_ret == H5T_CONV_UNHANDLED) {
@@ -2909,9 +2911,12 @@ H5T__conv_enum(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
                         /*overflow*/
                         except_ret = H5T_CONV_UNHANDLED;
                         /*If user's exception handler is present, use it*/
-                        if (cb_struct.func)
+                        if (cb_struct.func) {
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, s, d,
                                                           cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
+                        }
 
                         if (except_ret == H5T_CONV_UNHANDLED)
                             memset(d, 0xff, dst->shared->size);
@@ -2946,9 +2951,12 @@ H5T__conv_enum(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
                     if (lt >= rt) {
                         except_ret = H5T_CONV_UNHANDLED;
                         /*If user's exception handler is present, use it*/
-                        if (cb_struct.func)
+                        if (cb_struct.func) {
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src, d,
                                                           cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
+                        }
 
                         if (except_ret == H5T_CONV_UNHANDLED)
                             memset(d, 0xff, dst->shared->size);
@@ -3981,8 +3989,10 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                         if (cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev,
                                                           d, cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4014,8 +4024,10 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                         if (cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, src_rev,
                                                           d, cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4039,8 +4051,10 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                         if (cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev,
                                                           d, cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED)
@@ -4069,8 +4083,10 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                         if (cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev,
                                                           d, cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4114,8 +4130,10 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                         if (cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, src_rev,
                                                           d, cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4154,8 +4172,10 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                         if (cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev,
                                                           d, cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4441,12 +4461,17 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                             /*reverse order first*/
                             H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                src_p->shared->u.atomic.order);
-                            if (sign)
+                            if (sign) {
+                                H5_BEFORE_USER_CB(FAIL) {
                                 except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NINF, src_id, dst_id, src_rev,
                                                               d, cb_struct.user_data);
-                            else
+                                } H5_AFTER_USER_CB(FAIL);
+                            } else {
+                                H5_BEFORE_USER_CB(FAIL) {
                                 except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_PINF, src_id, dst_id, src_rev,
                                                               d, cb_struct.user_data);
+                                } H5_AFTER_USER_CB(FAIL);
+                            }
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4481,12 +4506,17 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     if (cb_struct.func) { /*If user's exception handler is present, use it*/
                         /*reverse order first*/
                         H5T__reverse_order(src_rev, s, src_p->shared->size, src_p->shared->u.atomic.order);
-                        if (sign)
+                        if (sign) {
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NINF, src_id, dst_id, src_rev, d,
                                                           cb_struct.user_data);
-                        else
+                            } H5_AFTER_USER_CB(FAIL);
+                        } else {
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_PINF, src_id, dst_id, src_rev, d,
                                                           cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
+                        }
                     }
 
                     if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4519,8 +4549,10 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     if (cb_struct.func) { /*If user's exception handler is present, use it*/
                         /*reverse order first*/
                         H5T__reverse_order(src_rev, s, src_p->shared->size, src_p->shared->u.atomic.order);
+                        H5_BEFORE_USER_CB(FAIL) {
                         except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NAN, src_id, dst_id, src_rev, d,
                                                       cb_struct.user_data);
+                        } H5_AFTER_USER_CB(FAIL);
                     }
 
                     if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4640,8 +4672,10 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     if (cb_struct.func) { /*If user's exception handler is present, use it*/
                         /*reverse order first*/
                         H5T__reverse_order(src_rev, s, src_p->shared->size, src_p->shared->u.atomic.order);
+                        H5_BEFORE_USER_CB(FAIL) {
                         except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev, d,
                                                       cb_struct.user_data);
+                        } H5_AFTER_USER_CB(FAIL);
                     }
 
                     if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4731,8 +4765,10 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                             /*reverse order first*/
                             H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                src_p->shared->u.atomic.order);
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev,
                                                           d, cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -7662,8 +7698,11 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
+                                H5_BEFORE_USER_CB(FAIL) {
                                 except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NINF, src_id, dst_id, src_rev,
                                                               d, cb_struct.user_data);
+                                } H5_AFTER_USER_CB(FAIL);
+                                
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED) {
@@ -7684,8 +7723,10 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
+                                H5_BEFORE_USER_CB(FAIL) {
                                 except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_PINF, src_id, dst_id, src_rev,
                                                               d, cb_struct.user_data);
+                                } H5_AFTER_USER_CB(FAIL);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED) {
@@ -7718,8 +7759,10 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                             /*reverse order first*/
                             H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                src_p->shared->u.atomic.order);
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NINF, src_id, dst_id, src_rev, d,
                                                           cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -7740,8 +7783,10 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                             /*reverse order first*/
                             H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                src_p->shared->u.atomic.order);
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_PINF, src_id, dst_id, src_rev, d,
                                                           cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -7766,8 +7811,10 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     if (cb_struct.func) { /*If user's exception handler is present, use it*/
                         /*reverse order first*/
                         H5T__reverse_order(src_rev, s, src_p->shared->size, src_p->shared->u.atomic.order);
+                        H5_BEFORE_USER_CB(FAIL) {
                         except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NAN, src_id, dst_id, src_rev, d,
                                                       cb_struct.user_data);
+                        } H5_AFTER_USER_CB(FAIL);
                     }
 
                     if (except_ret == H5T_CONV_UNHANDLED) {
@@ -7869,8 +7916,10 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                             /*reverse order first*/
                             H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                src_p->shared->u.atomic.order);
+                            H5_BEFORE_USER_CB(FAIL) {
                             except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, src_rev,
                                                           d, cb_struct.user_data);
+                            } H5_AFTER_USER_CB(FAIL);
                             if (except_ret == H5T_CONV_ABORT)
                                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL,
                                             "can't handle conversion exception");
@@ -7888,8 +7937,10 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
+                                H5_BEFORE_USER_CB(FAIL) {
                                 except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id,
                                                               src_rev, d, cb_struct.user_data);
+                                } H5_AFTER_USER_CB(FAIL);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED)
@@ -7909,8 +7960,10 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
+                                H5_BEFORE_USER_CB(FAIL) {
                                 except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_TRUNCATE, src_id, dst_id,
                                                               src_rev, d, cb_struct.user_data);
+                                } H5_AFTER_USER_CB(FAIL);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED)
@@ -7935,8 +7988,10 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
+                                H5_BEFORE_USER_CB(FAIL) {
                                 except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_TRUNCATE, src_id, dst_id,
                                                               src_rev, d, cb_struct.user_data);
+                                } H5_AFTER_USER_CB(FAIL);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED) { /*If this case ignored by user handler*/
@@ -7965,8 +8020,10 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
+                                H5_BEFORE_USER_CB(FAIL) {
                                 except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id,
                                                               src_rev, d, cb_struct.user_data);
+                                } H5_AFTER_USER_CB(FAIL);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED)
@@ -7988,8 +8045,10 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
+                                H5_BEFORE_USER_CB(FAIL) {
                                 except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id,
                                                               src_rev, d, cb_struct.user_data);
+                                } H5_AFTER_USER_CB(FAIL);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED)
@@ -8009,8 +8068,10 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
+                                H5_BEFORE_USER_CB(FAIL) {
                                 except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_TRUNCATE, src_id, dst_id,
                                                               src_rev, d, cb_struct.user_data);
+                                } H5_AFTER_USER_CB(FAIL);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED) {
@@ -8339,8 +8400,10 @@ H5T__conv_i_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     if (cb_struct.func) {
                         H5T__reverse_order(src_rev, s, src_p->shared->size,
                                            src_p->shared->u.atomic.order); /*reverse order first*/
+                        H5_BEFORE_USER_CB(FAIL) {
                         except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_PRECISION, src_id, dst_id, src_rev, d,
                                                       cb_struct.user_data);
+                        } H5_AFTER_USER_CB(FAIL);
                     }
 
                     if (except_ret == H5T_CONV_HANDLED) {
@@ -8410,8 +8473,10 @@ H5T__conv_i_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     if (cb_struct.func) { /*user's exception handler.  Reverse back source order*/
                         H5T__reverse_order(src_rev, s, src_p->shared->size,
                                            src_p->shared->u.atomic.order); /*reverse order first*/
+                        H5_BEFORE_USER_CB(FAIL) {
                         except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev, d,
                                                       cb_struct.user_data);
+                        } H5_AFTER_USER_CB(FAIL);
 
                         if (except_ret == H5T_CONV_ABORT)
                             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL,

--- a/src/H5Tvlen.c
+++ b/src/H5Tvlen.c
@@ -509,9 +509,12 @@ H5T__vlen_mem_seq_write(H5VL_object_t H5_ATTR_UNUSED *file, const H5T_vlen_alloc
 
         /* Use the user's memory allocation routine is one is defined */
         if (vl_alloc_info->alloc_func != NULL) {
-            if (NULL == (vl.p = (vl_alloc_info->alloc_func)(len, vl_alloc_info->alloc_info)))
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL,
-                            "application memory allocation routine failed for VL data");
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                vl.p = (vl_alloc_info->alloc_func)(len, vl_alloc_info->alloc_info);
+            } H5_AFTER_USER_CB(FAIL)
+            if (NULL == vl.p)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "application memory allocation routine failed for VL data");
         }    /* end if */
         else /* Default to system malloc */
             if (NULL == (vl.p = malloc(len)))
@@ -683,10 +686,12 @@ H5T__vlen_mem_str_write(H5VL_object_t H5_ATTR_UNUSED *file, const H5T_vlen_alloc
 
     /* Use the user's memory allocation routine if one is defined */
     if (vl_alloc_info->alloc_func != NULL) {
-        if (NULL ==
-            (t = (char *)(vl_alloc_info->alloc_func)((seq_len + 1) * base_size, vl_alloc_info->alloc_info)))
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL,
-                        "application memory allocation routine failed for VL data");
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            t = (vl_alloc_info->alloc_func)((seq_len + 1) * base_size, vl_alloc_info->alloc_info);
+        } H5_AFTER_USER_CB(FAIL)
+        if (NULL == t)
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, FAIL, "application memory allocation routine failed for VL data");
     }    /* end if */
     else /* Default to system malloc */
         if (NULL == (t = (char *)malloc((seq_len + 1) * base_size)))

--- a/src/H5VLcallback.c
+++ b/src/H5VLcallback.c
@@ -229,8 +229,14 @@ H5VLinitialize(hid_t connector_id, hid_t vipl_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a VOL connector ID");
 
     /* Invoke class' callback, if there is one */
-    if (cls->initialize && cls->initialize(vipl_id) < 0)
-        HGOTO_ERROR(H5E_VOL, H5E_CANTCLOSEOBJ, FAIL, "VOL connector did not initialize");
+    if (cls->initialize) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = cls->initialize(vipl_id);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VOL, H5E_CANTCLOSEOBJ, FAIL, "VOL connector did not initialize");
+    }
 
 done:
     FUNC_LEAVE_API_NOINIT(ret_value)
@@ -260,8 +266,14 @@ H5VLterminate(hid_t connector_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a VOL connector ID");
 
     /* Invoke class' callback, if there is one */
-    if (cls->terminate && cls->terminate() < 0)
-        HGOTO_ERROR(H5E_VOL, H5E_CANTCLOSEOBJ, FAIL, "VOL connector did not terminate cleanly");
+    if (cls->terminate) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value =  cls->terminate();
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VOL, H5E_CANTCLOSEOBJ, FAIL, "VOL connector did not terminate cleanly");
+    }
 
 done:
     FUNC_LEAVE_API_NOINIT(ret_value)
@@ -398,7 +410,11 @@ H5VL_copy_connector_info(const H5VL_class_t *connector, void **dst_info, const v
     if (src_info) {
         /* Allow the connector to copy or do it ourselves */
         if (connector->info_cls.copy) {
-            if (NULL == (new_connector_info = (connector->info_cls.copy)(src_info)))
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                new_connector_info = (connector->info_cls.copy)(src_info);
+            } H5_AFTER_USER_CB(FAIL)
+            if (NULL == new_connector_info)
                 HGOTO_ERROR(H5E_VOL, H5E_CANTCOPY, FAIL, "connector info copy callback failed");
         } /* end if */
         else if (connector->info_cls.size > 0) {
@@ -491,7 +507,11 @@ H5VL_cmp_connector_info(const H5VL_class_t *connector, int *cmp_value, const voi
      * memory buffers
      */
     if (connector->info_cls.cmp) {
-        if ((connector->info_cls.cmp)(cmp_value, info1, info2) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (connector->info_cls.cmp)(cmp_value, info1, info2);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VOL, H5E_CANTCOMPARE, FAIL, "can't compare connector info");
     } /* end if */
     else {
@@ -568,8 +588,12 @@ H5VL_free_connector_info(hid_t connector_id, const void *info)
     if (info) {
         /* Allow the connector to free info or do it ourselves */
         if (cls->info_cls.free) {
-            /* Cast through uintptr_t to de-const memory */
-            if ((cls->info_cls.free)((void *)(uintptr_t)info) < 0)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                /* Cast through uintptr_t to de-const memory */
+                ret_value = (cls->info_cls.free)((void *)(uintptr_t)info);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
                 HGOTO_ERROR(H5E_VOL, H5E_CANTRELEASE, FAIL, "connector info free request failed");
         }
         else
@@ -620,25 +644,27 @@ herr_t
 H5VLconnector_info_to_str(const void *info, hid_t connector_id, char **str)
 {
     herr_t ret_value = SUCCEED; /* Return value */
+    H5VL_class_t *cls; /* VOL connector's class struct */
 
     FUNC_ENTER_API_NOINIT
     H5TRACE3("e", "*xi**s", info, connector_id, str);
 
     /* Only serialize info object, if it's non-NULL */
     if (info) {
-        H5VL_class_t *cls; /* VOL connector's class struct */
-
         /* Check args and get class pointer */
         if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a VOL connector ID");
+    }
 
-        /* Allow the connector to serialize info */
-        if (cls->info_cls.to_str) {
-            if ((cls->info_cls.to_str)(info, str) < 0)
-                HGOTO_ERROR(H5E_VOL, H5E_CANTSERIALIZE, FAIL, "can't serialize connector info");
-        } /* end if */
-        else
-            *str = NULL;
+    /* Allow the connector to serialize info */
+    if (cls->info_cls.to_str) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (cls->info_cls.to_str)(info, str);
+        } H5_AFTER_USER_CB(FAIL)
+
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VOL, H5E_CANTSERIALIZE, FAIL, "can't serialize connector info");
     } /* end if */
     else
         *str = NULL;
@@ -700,7 +726,10 @@ H5VLget_object(void *obj, hid_t connector_id)
 
     /* Check for 'get_object' callback in connector */
     if (cls->wrap_cls.get_object)
-        ret_value = (cls->wrap_cls.get_object)(obj);
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(NULL) {
+            ret_value = (cls->wrap_cls.get_object)(obj);
+        } H5_AFTER_USER_CB(NULL)
     else
         ret_value = obj;
 
@@ -735,8 +764,12 @@ H5VL_get_wrap_ctx(const H5VL_class_t *connector, void *obj, void **wrap_ctx)
         /* Sanity check */
         assert(connector->wrap_cls.free_wrap_ctx);
 
-        /* Invoke connector's callback */
-        if ((connector->wrap_cls.get_wrap_ctx)(obj, wrap_ctx) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            /* Invoke connector's callback */
+            ret_value = (connector->wrap_cls.get_wrap_ctx)(obj, wrap_ctx);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "connector wrap context callback failed");
     } /* end if */
     else
@@ -800,8 +833,12 @@ H5VL_wrap_object(const H5VL_class_t *connector, void *wrap_ctx, void *obj, H5I_t
 
     /* Only wrap object if there's a wrap context */
     if (wrap_ctx) {
-        /* Ask the connector to wrap the object */
-        if (NULL == (ret_value = (connector->wrap_cls.wrap_object)(obj, obj_type, wrap_ctx)))
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(NULL) {
+            /* Ask the connector to wrap the object */
+            ret_value = (connector->wrap_cls.wrap_object)(obj, obj_type, wrap_ctx);
+        } H5_AFTER_USER_CB(NULL)
+        if (NULL == ret_value)
             HGOTO_ERROR(H5E_VOL, H5E_CANTGET, NULL, "can't wrap object");
     } /* end if */
     else
@@ -867,8 +904,12 @@ H5VL_unwrap_object(const H5VL_class_t *connector, void *obj)
 
     /* Only unwrap object if there's an unwrap callback */
     if (connector->wrap_cls.wrap_object) {
-        /* Ask the connector to unwrap the object */
-        if (NULL == (ret_value = (connector->wrap_cls.unwrap_object)(obj)))
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(NULL) {
+            /* Ask the connector to unwrap the object */
+            ret_value = (connector->wrap_cls.unwrap_object)(obj);
+        } H5_AFTER_USER_CB(NULL)
+        if (NULL == ret_value)
             HGOTO_ERROR(H5E_VOL, H5E_CANTGET, NULL, "can't unwrap object");
     } /* end if */
     else
@@ -933,8 +974,12 @@ H5VL_free_wrap_ctx(const H5VL_class_t *connector, void *wrap_ctx)
 
     /* Only free wrap context, if it's non-NULL */
     if (wrap_ctx) {
-        /* Free the connector's object wrapping context */
-        if ((connector->wrap_cls.free_wrap_ctx)(wrap_ctx) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            /* Free the connector's object wrapping context */
+            ret_value = (connector->wrap_cls.free_wrap_ctx)(wrap_ctx);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VOL, H5E_CANTRELEASE, FAIL, "connector wrap context free request failed");
     } /* end if */
 
@@ -995,9 +1040,12 @@ H5VL__attr_create(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_cla
     if (NULL == cls->attr_cls.create)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, NULL, "VOL connector has no 'attr create' method");
 
-    /* Call the corresponding VOL callback */
-    if (NULL == (ret_value = (cls->attr_cls.create)(obj, loc_params, name, type_id, space_id, acpl_id,
-                                                    aapl_id, dxpl_id, req)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(NULL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->attr_cls.create)(obj, loc_params, name, type_id, space_id, acpl_id, aapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(NULL)
+    if (NULL == ret_value)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCREATE, NULL, "attribute create failed");
 
 done:
@@ -1100,8 +1148,12 @@ H5VL__attr_open(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_class
     if (NULL == cls->attr_cls.open)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, NULL, "VOL connector has no 'attr open' method");
 
-    /* Call the corresponding VOL open callback */
-    if (NULL == (ret_value = (cls->attr_cls.open)(obj, loc_params, name, aapl_id, dxpl_id, req)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(NULL) {
+        /* Call the corresponding VOL open callback */
+        ret_value = (cls->attr_cls.open)(obj, loc_params, name, aapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(NULL)
+    if (NULL == ret_value)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPENOBJ, NULL, "attribute open failed");
 
 done:
@@ -1200,8 +1252,12 @@ H5VL__attr_read(void *obj, const H5VL_class_t *cls, hid_t mem_type_id, void *buf
     if (NULL == cls->attr_cls.read)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'attr read' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->attr_cls.read)(obj, mem_type_id, buf, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->attr_cls.read)(obj, mem_type_id, buf, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_READERROR, FAIL, "attribute read failed");
 
 done:
@@ -1298,8 +1354,12 @@ H5VL__attr_write(void *obj, const H5VL_class_t *cls, hid_t mem_type_id, const vo
     if (NULL == cls->attr_cls.write)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'attr write' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->attr_cls.write)(obj, mem_type_id, buf, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->attr_cls.write)(obj, mem_type_id, buf, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_WRITEERROR, FAIL, "write failed");
 
 done:
@@ -1396,8 +1456,12 @@ H5VL__attr_get(void *obj, const H5VL_class_t *cls, H5VL_attr_get_args_t *args, h
     if (NULL == cls->attr_cls.get)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'attr get' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->attr_cls.get)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->attr_cls.get)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "attribute get failed");
 
 done:
@@ -1496,9 +1560,13 @@ H5VL__attr_specific(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_c
     if (NULL == cls->attr_cls.specific)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'attr specific' method");
 
-    /* Call the corresponding VOL callback */
-    /* (Must return value from callback, for iterators) */
-    if ((ret_value = (cls->attr_cls.specific)(obj, loc_params, args, dxpl_id, req)) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        /* (Must return value from callback, for iterators) */
+        ret_value = (cls->attr_cls.specific)(obj, loc_params, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HERROR(H5E_VOL, H5E_CANTOPERATE, "unable to execute attribute 'specific' callback");
 
 done:
@@ -1599,9 +1667,13 @@ H5VL__attr_optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t *ar
     if (NULL == cls->attr_cls.optional)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'attr optional' method");
 
-    /* Call the corresponding VOL callback */
-    /* (Must return value from callback, for iterators) */
-    if ((ret_value = (cls->attr_cls.optional)(obj, args, dxpl_id, req)) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        /* (Must return value from callback, for iterators) */
+        ret_value = (cls->attr_cls.optional)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HERROR(H5E_VOL, H5E_CANTOPERATE, "unable to execute attribute optional callback");
 
 done:
@@ -1743,8 +1815,12 @@ H5VL__attr_close(void *obj, const H5VL_class_t *cls, hid_t dxpl_id, void **req)
     if (NULL == cls->attr_cls.close)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'attr close' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->attr_cls.close)(obj, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->attr_cls.close)(obj, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCLOSEOBJ, FAIL, "attribute close failed");
 
 done:
@@ -1835,9 +1911,12 @@ H5VL__dataset_create(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_
     if (NULL == cls->dataset_cls.create)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, NULL, "VOL connector has no 'dataset create' method");
 
-    /* Call the corresponding VOL callback */
-    if (NULL == (ret_value = (cls->dataset_cls.create)(obj, loc_params, name, lcpl_id, type_id, space_id,
-                                                       dcpl_id, dapl_id, dxpl_id, req)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(NULL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->dataset_cls.create)(obj, loc_params, name, lcpl_id, type_id, space_id, dcpl_id, dapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(NULL)
+    if (NULL == ret_value)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCREATE, NULL, "dataset create failed");
 
 done:
@@ -1942,8 +2021,12 @@ H5VL__dataset_open(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_cl
     if (NULL == cls->dataset_cls.open)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, NULL, "VOL connector has no 'dataset open' method");
 
-    /* Call the corresponding VOL callback */
-    if (NULL == (ret_value = (cls->dataset_cls.open)(obj, loc_params, name, dapl_id, dxpl_id, req)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(NULL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->dataset_cls.open)(obj, loc_params, name, dapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(NULL)
+    if (NULL == ret_value)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPENOBJ, NULL, "dataset open failed");
 
 done:
@@ -2043,8 +2126,12 @@ H5VL__dataset_read(size_t count, void *obj[], const H5VL_class_t *cls, hid_t mem
     if (NULL == cls->dataset_cls.read)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'dataset read' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->dataset_cls.read)(count, obj, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->dataset_cls.read)(count, obj, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_READERROR, FAIL, "dataset read failed");
 
 done:
@@ -2232,8 +2319,12 @@ H5VL__dataset_write(size_t count, void *obj[], const H5VL_class_t *cls, hid_t me
     if (NULL == cls->dataset_cls.write)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'dataset write' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->dataset_cls.write)(count, obj, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->dataset_cls.write)(count, obj, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_WRITEERROR, FAIL, "dataset write failed");
 
 done:
@@ -2422,8 +2513,12 @@ H5VL__dataset_get(void *obj, const H5VL_class_t *cls, H5VL_dataset_get_args_t *a
     if (NULL == cls->dataset_cls.get)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'dataset get' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->dataset_cls.get)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->dataset_cls.get)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "dataset get failed");
 
 done:
@@ -2521,8 +2616,12 @@ H5VL__dataset_specific(void *obj, const H5VL_class_t *cls, H5VL_dataset_specific
     if (NULL == cls->dataset_cls.specific)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'dataset specific' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->dataset_cls.specific)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->dataset_cls.specific)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "unable to execute dataset specific callback");
 
 done:
@@ -2621,8 +2720,12 @@ H5VL__dataset_optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t 
     if (NULL == cls->dataset_cls.optional)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'dataset optional' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->dataset_cls.optional)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->dataset_cls.optional)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "unable to execute dataset optional callback");
 
 done:
@@ -2766,8 +2869,12 @@ H5VL__dataset_close(void *obj, const H5VL_class_t *cls, hid_t dxpl_id, void **re
     if (NULL == cls->dataset_cls.close)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'dataset close' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->dataset_cls.close)(obj, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->dataset_cls.close)(obj, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCLOSEOBJ, FAIL, "dataset close failed");
 
 done:
@@ -2871,9 +2978,12 @@ H5VL__datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const H5VL
     if (NULL == cls->datatype_cls.commit)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, NULL, "VOL connector has no 'datatype commit' method");
 
-    /* Call the corresponding VOL callback */
-    if (NULL == (ret_value = (cls->datatype_cls.commit)(obj, loc_params, name, type_id, lcpl_id, tcpl_id,
-                                                        tapl_id, dxpl_id, req)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(NULL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->datatype_cls.commit)(obj, loc_params, name, type_id, lcpl_id, tcpl_id, tapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(NULL)
+    if (NULL == ret_value)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCREATE, NULL, "datatype commit failed");
 
 done:
@@ -2976,8 +3086,12 @@ H5VL__datatype_open(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_c
     if (NULL == cls->datatype_cls.open)
         HGOTO_ERROR(H5E_VOL, H5E_CANTINIT, NULL, "no datatype open callback");
 
-    /* Call the corresponding VOL callback */
-    if (NULL == (ret_value = (cls->datatype_cls.open)(obj, loc_params, name, tapl_id, dxpl_id, req)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(NULL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->datatype_cls.open)(obj, loc_params, name, tapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(NULL)
+    if (NULL == ret_value)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPENOBJ, NULL, "datatype open failed");
 
 done:
@@ -3077,8 +3191,12 @@ H5VL__datatype_get(void *obj, const H5VL_class_t *cls, H5VL_datatype_get_args_t 
     if (NULL == cls->datatype_cls.get)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'datatype get' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->datatype_cls.get)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->datatype_cls.get)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "datatype 'get' failed");
 
 done:
@@ -3176,8 +3294,12 @@ H5VL__datatype_specific(void *obj, const H5VL_class_t *cls, H5VL_datatype_specif
     if (NULL == cls->datatype_cls.specific)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'datatype specific' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->datatype_cls.specific)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->datatype_cls.specific)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "unable to execute datatype specific callback");
 
 done:
@@ -3276,8 +3398,12 @@ H5VL__datatype_optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t
     if (NULL == cls->datatype_cls.optional)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'datatype optional' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->datatype_cls.optional)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->datatype_cls.optional)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "unable to execute datatype optional callback");
 
 done:
@@ -3465,8 +3591,12 @@ H5VL__datatype_close(void *obj, const H5VL_class_t *cls, hid_t dxpl_id, void **r
     if (NULL == cls->datatype_cls.close)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'datatype close' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->datatype_cls.close)(obj, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->datatype_cls.close)(obj, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCLOSEOBJ, FAIL, "datatype close failed");
 
 done:
@@ -3566,8 +3696,12 @@ H5VL__file_create(const H5VL_class_t *cls, const char *name, unsigned flags, hid
     if (NULL == cls->file_cls.create)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, NULL, "VOL connector has no 'file create' method");
 
-    /* Call the corresponding VOL callback */
-    if (NULL == (ret_value = (cls->file_cls.create)(name, flags, fcpl_id, fapl_id, dxpl_id, req)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(NULL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->file_cls.create)(name, flags, fcpl_id, fapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(NULL)
+    if (NULL == ret_value)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCREATE, NULL, "file create failed");
 
 done:
@@ -3670,8 +3804,12 @@ H5VL__file_open(const H5VL_class_t *cls, const char *name, unsigned flags, hid_t
     if (NULL == cls->file_cls.open)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, NULL, "VOL connector has no 'file open' method");
 
-    /* Call the corresponding VOL callback */
-    if (NULL == (ret_value = (cls->file_cls.open)(name, flags, fapl_id, dxpl_id, req)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(NULL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->file_cls.open)(name, flags, fapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(NULL)
+    if (NULL == ret_value)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPENOBJ, NULL, "open failed");
 
 done:
@@ -3930,8 +4068,12 @@ H5VL__file_get(void *obj, const H5VL_class_t *cls, H5VL_file_get_args_t *args, h
     if (NULL == cls->file_cls.get)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'file get' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->file_cls.get)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->file_cls.get)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "file get failed");
 
 done:
@@ -4028,8 +4170,12 @@ H5VL__file_specific(void *obj, const H5VL_class_t *cls, H5VL_file_specific_args_
     if (NULL == cls->file_cls.specific)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'file specific' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->file_cls.specific)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->file_cls.specific)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "file specific failed");
 
 done:
@@ -4160,8 +4306,12 @@ H5VL__file_optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t *ar
     if (NULL == cls->file_cls.optional)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'file optional' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->file_cls.optional)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->file_cls.optional)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "file optional failed");
 
 done:
@@ -4305,8 +4455,12 @@ H5VL__file_close(void *obj, const H5VL_class_t *cls, hid_t dxpl_id, void **req)
     if (NULL == cls->file_cls.close)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'file close' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->file_cls.close)(obj, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->file_cls.close)(obj, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCLOSEFILE, FAIL, "file close failed");
 
 done:
@@ -4403,9 +4557,12 @@ H5VL__group_create(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_cl
     if (NULL == cls->group_cls.create)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, NULL, "VOL connector has no 'group create' method");
 
-    /* Call the corresponding VOL callback */
-    if (NULL ==
-        (ret_value = (cls->group_cls.create)(obj, loc_params, name, lcpl_id, gcpl_id, gapl_id, dxpl_id, req)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(NULL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->group_cls.create)(obj, loc_params, name, lcpl_id, gcpl_id, gapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(NULL)
+    if (NULL == ret_value)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCREATE, NULL, "group create failed");
 
 done:
@@ -4507,8 +4664,12 @@ H5VL__group_open(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_clas
     if (NULL == cls->group_cls.open)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, NULL, "VOL connector has no 'group open' method");
 
-    /* Call the corresponding VOL callback */
-    if (NULL == (ret_value = (cls->group_cls.open)(obj, loc_params, name, gapl_id, dxpl_id, req)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(NULL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->group_cls.open)(obj, loc_params, name, gapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(NULL)
+    if (NULL == ret_value)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPENOBJ, NULL, "group open failed");
 
 done:
@@ -4607,8 +4768,12 @@ H5VL__group_get(void *obj, const H5VL_class_t *cls, H5VL_group_get_args_t *args,
     if (NULL == cls->group_cls.get)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'group get' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->group_cls.get)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->group_cls.get)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "group get failed");
 
 done:
@@ -4705,8 +4870,12 @@ H5VL__group_specific(void *obj, const H5VL_class_t *cls, H5VL_group_specific_arg
     if (NULL == cls->group_cls.specific)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'group specific' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->group_cls.specific)(obj, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->group_cls.specific)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "unable to execute group specific callback");
 
 done:
@@ -4804,9 +4973,13 @@ H5VL__group_optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t *a
     if (NULL == cls->group_cls.optional)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'group optional' method");
 
-    /* Call the corresponding VOL callback */
-    /* (Must return value from callback, for iterators) */
-    if ((ret_value = (cls->group_cls.optional)(obj, args, dxpl_id, req)) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        /* (Must return value from callback, for iterators) */
+        ret_value = (cls->group_cls.optional)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HERROR(H5E_VOL, H5E_CANTOPERATE, "unable to execute group optional callback");
 
 done:
@@ -4952,8 +5125,12 @@ H5VL__group_close(void *obj, const H5VL_class_t *cls, hid_t dxpl_id, void **req)
     if (NULL == cls->group_cls.close)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'group close' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->group_cls.close)(obj, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->group_cls.close)(obj, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCLOSEOBJ, FAIL, "group close failed");
 
 done:
@@ -5052,8 +5229,12 @@ H5VL__link_create(H5VL_link_create_args_t *args, void *obj, const H5VL_loc_param
     if (NULL == cls->link_cls.create)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'link create' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->link_cls.create)(args, obj, loc_params, lcpl_id, lapl_id, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->link_cls.create)(args, obj, loc_params, lcpl_id, lapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCREATE, FAIL, "link create failed");
 
 done:
@@ -5164,8 +5345,12 @@ H5VL__link_copy(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_o
     if (NULL == cls->link_cls.copy)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'link copy' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->link_cls.copy)(src_obj, loc_params1, dst_obj, loc_params2, lcpl_id, lapl_id, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->link_cls.copy)(src_obj, loc_params1, dst_obj, loc_params2, lcpl_id, lapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCOPY, FAIL, "link copy failed");
 
 done:
@@ -5271,8 +5456,12 @@ H5VL__link_move(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_o
     if (NULL == cls->link_cls.move)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'link move' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->link_cls.move)(src_obj, loc_params1, dst_obj, loc_params2, lcpl_id, lapl_id, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->link_cls.move)(src_obj, loc_params1, dst_obj, loc_params2, lcpl_id, lapl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTMOVE, FAIL, "link move failed");
 
 done:
@@ -5377,8 +5566,12 @@ H5VL__link_get(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_class_
     if (NULL == cls->link_cls.get)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'link get' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->link_cls.get)(obj, loc_params, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->link_cls.get)(obj, loc_params, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "link get failed");
 
 done:
@@ -5477,9 +5670,13 @@ H5VL__link_specific(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_c
     if (NULL == cls->link_cls.specific)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'link specific' method");
 
-    /* Call the corresponding VOL callback */
-    /* (Must return value from callback, for iterators) */
-    if ((ret_value = (cls->link_cls.specific)(obj, loc_params, args, dxpl_id, req)) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        /* (Must return value from callback, for iterators) */
+        ret_value = (cls->link_cls.specific)(obj, loc_params, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HERROR(H5E_VOL, H5E_CANTOPERATE, "unable to execute link specific callback");
 
 done:
@@ -5581,8 +5778,12 @@ H5VL__link_optional(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_c
     if (NULL == cls->link_cls.optional)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'link optional' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->link_cls.optional)(obj, loc_params, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->link_cls.optional)(obj, loc_params, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "unable to execute link optional callback");
 
 done:
@@ -5742,8 +5943,12 @@ H5VL__object_open(void *obj, const H5VL_loc_params_t *params, const H5VL_class_t
     if (NULL == cls->object_cls.open)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, NULL, "VOL connector has no 'object open' method");
 
-    /* Call the corresponding VOL callback */
-    if (NULL == (ret_value = (cls->object_cls.open)(obj, params, opened_type, dxpl_id, req)))
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(NULL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->object_cls.open)(obj, params, opened_type, dxpl_id, req);
+    } H5_AFTER_USER_CB(NULL)
+    if (NULL == ret_value)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPENOBJ, NULL, "object open failed");
 
 done:
@@ -5844,9 +6049,12 @@ H5VL__object_copy(void *src_obj, const H5VL_loc_params_t *src_loc_params, const 
     if (NULL == cls->object_cls.copy)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'object copy' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->object_cls.copy)(src_obj, src_loc_params, src_name, dst_obj, dst_loc_params, dst_name,
-                               ocpypl_id, lcpl_id, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->object_cls.copy)(src_obj, src_loc_params, src_name, dst_obj, dst_loc_params, dst_name, ocpypl_id, lcpl_id, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTCOPY, FAIL, "object copy failed");
 
 done:
@@ -5955,8 +6163,12 @@ H5VL__object_get(void *obj, const H5VL_loc_params_t *loc_params, const H5VL_clas
     if (NULL == cls->object_cls.get)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'object get' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->object_cls.get)(obj, loc_params, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->object_cls.get)(obj, loc_params, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "get failed");
 
 done:
@@ -6055,9 +6267,13 @@ H5VL__object_specific(void *obj, const H5VL_loc_params_t *loc_params, const H5VL
     if (NULL == cls->object_cls.specific)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'object specific' method");
 
-    /* Call the corresponding VOL callback */
-    /* (Must return value from callback, for iterators) */
-    if ((ret_value = (cls->object_cls.specific)(obj, loc_params, args, dxpl_id, req)) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        /* (Must return value from callback, for iterators) */
+        ret_value = (cls->object_cls.specific)(obj, loc_params, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HERROR(H5E_VOL, H5E_CANTOPERATE, "object specific failed");
 
 done:
@@ -6128,9 +6344,13 @@ H5VLobject_specific(void *obj, const H5VL_loc_params_t *loc_params, hid_t connec
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a VOL connector ID");
 
-    /* Bypass the H5VLint layer, calling the VOL callback directly */
-    /* (Must return value from callback, for iterators) */
-    if ((ret_value = (cls->object_cls.specific)(obj, loc_params, args, dxpl_id, req)) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Bypass the H5VLint layer, calling the VOL callback directly */
+        /* (Must return value from callback, for iterators) */
+        ret_value = (cls->object_cls.specific)(obj, loc_params, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HERROR(H5E_VOL, H5E_CANTOPERATE, "unable to execute object specific callback");
 
 done:
@@ -6159,8 +6379,12 @@ H5VL__object_optional(void *obj, const H5VL_loc_params_t *loc_params, const H5VL
     if (NULL == cls->object_cls.optional)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'object optional' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->object_cls.optional)(obj, loc_params, args, dxpl_id, req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->object_cls.optional)(obj, loc_params, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "unable to execute object optional callback");
 
 done:
@@ -6328,8 +6552,12 @@ H5VL__introspect_get_conn_cls(void *obj, const H5VL_class_t *cls, H5VL_get_conn_
     if (NULL == cls->introspect_cls.get_conn_cls)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'get_conn_cls' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->introspect_cls.get_conn_cls)(obj, lvl, conn_cls) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->introspect_cls.get_conn_cls)(obj, lvl, conn_cls);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "can't query connector class");
 
 done:
@@ -6438,8 +6666,12 @@ H5VL_introspect_get_cap_flags(const void *info, const H5VL_class_t *cls, uint64_
     if (NULL == cls->introspect_cls.get_cap_flags)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'get_cap_flags' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->introspect_cls.get_cap_flags)(info, cap_flags) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->introspect_cls.get_cap_flags)(info, cap_flags);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "can't query connector capability flags");
 
 done:
@@ -6505,8 +6737,12 @@ H5VL__introspect_opt_query(void *obj, const H5VL_class_t *cls, H5VL_subclass_t s
     if (NULL == cls->introspect_cls.opt_query)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'opt_query' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->introspect_cls.opt_query)(obj, subcls, opt_type, flags) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->introspect_cls.opt_query)(obj, subcls, opt_type, flags);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "can't query optional operation support");
 
 done:
@@ -6608,8 +6844,12 @@ H5VL__request_wait(void *req, const H5VL_class_t *cls, uint64_t timeout, H5VL_re
     if (NULL == cls->request_cls.wait)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'async wait' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->request_cls.wait)(req, timeout, status) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->request_cls.wait)(req, timeout, status);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTRELEASE, FAIL, "request wait failed");
 
 done:
@@ -6711,8 +6951,12 @@ H5VL__request_notify(void *req, const H5VL_class_t *cls, H5VL_request_notify_t c
     if (NULL == cls->request_cls.notify)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'async notify' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->request_cls.notify)(req, cb, ctx) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->request_cls.notify)(req, cb, ctx);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTRELEASE, FAIL, "request notify failed");
 
 done:
@@ -6815,8 +7059,12 @@ H5VL__request_cancel(void *req, const H5VL_class_t *cls, H5VL_request_status_t *
     if (NULL == cls->request_cls.cancel)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'async cancel' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->request_cls.cancel)(req, status) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->request_cls.cancel)(req, status);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTRELEASE, FAIL, "request cancel failed");
 
 done:
@@ -6917,10 +7165,13 @@ H5VL__request_specific(void *req, const H5VL_class_t *cls, H5VL_request_specific
     if (NULL == cls->request_cls.specific)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'async specific' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->request_cls.specific)(req, args) < 0)
-        HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL,
-                    "unable to execute asynchronous request specific callback");
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->request_cls.specific)(req, args);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
+        HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "unable to execute asynchronous request specific callback");
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -7022,10 +7273,13 @@ H5VL__request_optional(void *req, const H5VL_class_t *cls, H5VL_optional_args_t 
     if (NULL == cls->request_cls.optional)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'async optional' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->request_cls.optional)(req, args) < 0)
-        HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL,
-                    "unable to execute asynchronous request optional callback");
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->request_cls.optional)(req, args);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
+        HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "unable to execute asynchronous request optional callback");
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -7164,8 +7418,12 @@ H5VL__request_free(void *req, const H5VL_class_t *cls)
     if (NULL == cls->request_cls.free)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'async free' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->request_cls.free)(req) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->request_cls.free)(req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTRELEASE, FAIL, "request free failed");
 
 done:
@@ -7267,8 +7525,12 @@ H5VL__blob_put(void *obj, const H5VL_class_t *cls, const void *buf, size_t size,
     if (NULL == cls->blob_cls.put)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'blob put' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->blob_cls.put)(obj, buf, size, blob_id, ctx) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->blob_cls.put)(obj, buf, size, blob_id, ctx);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "blob put callback failed");
 
 done:
@@ -7362,8 +7624,12 @@ H5VL__blob_get(void *obj, const H5VL_class_t *cls, const void *blob_id, void *bu
     if (NULL == cls->blob_cls.get)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'blob get' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->blob_cls.get)(obj, blob_id, buf, size, ctx) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->blob_cls.get)(obj, blob_id, buf, size, ctx);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTGET, FAIL, "blob get callback failed");
 
 done:
@@ -7456,8 +7722,12 @@ H5VL__blob_specific(void *obj, const H5VL_class_t *cls, void *blob_id, H5VL_blob
     if (NULL == cls->blob_cls.specific)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'blob specific' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->blob_cls.specific)(obj, blob_id, args) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->blob_cls.specific)(obj, blob_id, args);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "unable to execute blob specific callback");
 
 done:
@@ -7550,8 +7820,12 @@ H5VL__blob_optional(void *obj, const H5VL_class_t *cls, void *blob_id, H5VL_opti
     if (NULL == cls->blob_cls.optional)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'blob optional' method");
 
-    /* Call the corresponding VOL callback */
-    if ((cls->blob_cls.optional)(obj, blob_id, args) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->blob_cls.optional)(obj, blob_id, args);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTOPERATE, FAIL, "unable to execute blob optional callback");
 
 done:
@@ -7646,23 +7920,31 @@ H5VL__token_cmp(void *obj, const H5VL_class_t *cls, const H5O_token_t *token1, c
     assert(cmp_value);
 
     /* Take care of cases where one or both pointers is NULL */
-    if (token1 == NULL && token2 != NULL)
+    if (token1 == NULL && token2 != NULL) {
         *cmp_value = -1;
-    else if (token1 != NULL && token2 == NULL)
+    } else if (token1 != NULL && token2 == NULL) {
         *cmp_value = 1;
-    else if (token1 == NULL && token2 == NULL)
+    } else if (token1 == NULL && token2 == NULL) {
         *cmp_value = 0;
+        HGOTO_DONE(SUCCEED);
+    }
+
+    /* Use the class's token comparison routine to compare the tokens,
+     * if there is a callback, otherwise just compare the tokens as
+     * memory buffers.
+     */
+    if (cls->token_cls.cmp) {
+        if ((cls->token_cls.cmp)(obj, token1, token2, cmp_value) < 0)
+            HGOTO_ERROR(H5E_VOL, H5E_CANTCOMPARE, FAIL, "can't compare object tokens");
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (cls->token_cls.cmp)(obj, token1, token2, cmp_value);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VOL, H5E_CANTCOMPARE, FAIL, "can't compare object tokens");
+    } /* end if */
     else {
-        /* Use the class's token comparison routine to compare the tokens,
-         * if there is a callback, otherwise just compare the tokens as
-         * memory buffers.
-         */
-        if (cls->token_cls.cmp) {
-            if ((cls->token_cls.cmp)(obj, token1, token2, cmp_value) < 0)
-                HGOTO_ERROR(H5E_VOL, H5E_CANTCOMPARE, FAIL, "can't compare object tokens");
-        } /* end if */
-        else
-            *cmp_value = memcmp(token1, token2, sizeof(H5O_token_t));
+        *cmp_value = memcmp(token1, token2, sizeof(H5O_token_t));
     } /* end else */
 
 done:
@@ -7771,7 +8053,11 @@ H5VL__token_to_str(void *obj, H5I_type_t obj_type, const H5VL_class_t *cls, cons
      *  callback, otherwise just set the token_str to NULL.
      */
     if (cls->token_cls.to_str) {
-        if ((cls->token_cls.to_str)(obj, obj_type, token, token_str) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (cls->token_cls.to_str)(obj, obj_type, token, token_str);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VOL, H5E_CANTSERIALIZE, FAIL, "can't serialize object token");
     } /* end if */
     else
@@ -7878,7 +8164,11 @@ H5VL__token_from_str(void *obj, H5I_type_t obj_type, const H5VL_class_t *cls, co
      *  callback, otherwise just set the token to H5_TOKEN_UNDEF.
      */
     if (cls->token_cls.from_str) {
-        if ((cls->token_cls.from_str)(obj, obj_type, token_str, token) < 0)
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = (cls->token_cls.from_str)(obj, obj_type, token_str, token);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
             HGOTO_ERROR(H5E_VOL, H5E_CANTUNSERIALIZE, FAIL, "can't deserialize object token string");
     } /* end if */
     else
@@ -7978,8 +8268,12 @@ H5VL__optional(void *obj, const H5VL_class_t *cls, H5VL_optional_args_t *args, h
     if (NULL == cls->optional)
         HGOTO_ERROR(H5E_VOL, H5E_UNSUPPORTED, FAIL, "VOL connector has no 'optional' method");
 
-    /* Call the corresponding VOL callback */
-    if ((ret_value = (cls->optional)(obj, args, dxpl_id, req)) < 0)
+    /* Prepare & restore library for user callback */
+    H5_BEFORE_USER_CB(FAIL) {
+        /* Call the corresponding VOL callback */
+        ret_value = (cls->optional)(obj, args, dxpl_id, req);
+    } H5_AFTER_USER_CB(FAIL)
+    if (ret_value < 0)
         HERROR(H5E_VOL, H5E_CANTOPERATE, "unable to execute optional callback");
 
 done:

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -612,8 +612,7 @@ H5VL_conn_copy(H5VL_connector_prop_t *connector_prop)
                     HGOTO_ERROR(H5E_PLIST, H5E_BADTYPE, FAIL, "not a VOL connector ID");
 
                 /* Allocate and copy connector info */
-                if (H5VL_copy_connector_info(connector, &new_connector_info, connector_prop->connector_info) <
-                    0)
+                if (H5VL_copy_connector_info(connector, &new_connector_info, connector_prop->connector_info) < 0)
                     HGOTO_ERROR(H5E_PLIST, H5E_CANTCOPY, FAIL, "connector info copy failed");
 
                 /* Set the connector info to the copy */
@@ -1651,7 +1650,11 @@ H5VL__connector_str_to_info(const char *str, hid_t connector_id, void **info)
 
         /* Allow the connector to deserialize info */
         if (cls->info_cls.from_str) {
-            if ((cls->info_cls.from_str)(str, info) < 0)
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                ret_value = (cls->info_cls.from_str)(str, info);
+            } H5_AFTER_USER_CB(FAIL)
+            if (ret_value < 0)
                 HGOTO_ERROR(H5E_VOL, H5E_CANTUNSERIALIZE, FAIL, "can't deserialize connector info");
         } /* end if */
         else
@@ -1767,7 +1770,10 @@ H5VL_object_data(const H5VL_object_t *vol_obj)
 
     /* Check for 'get_object' callback in connector */
     if (vol_obj->connector->cls->wrap_cls.get_object)
-        ret_value = (vol_obj->connector->cls->wrap_cls.get_object)(vol_obj->data);
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB_NOERR(NULL) {
+            ret_value = (vol_obj->connector->cls->wrap_cls.get_object)(vol_obj->data);
+        } H5_AFTER_USER_CB_NOERR(NULL)
     else
         ret_value = vol_obj->data;
 
@@ -2179,10 +2185,13 @@ H5VL__free_vol_wrapper(H5VL_wrap_ctx_t *vol_wrap_ctx)
 
     /* If there is a VOL connector object wrapping context, release it */
     if (vol_wrap_ctx->obj_wrap_ctx)
-        /* Release the VOL connector's object wrapping context */
-        if ((*vol_wrap_ctx->connector->cls->wrap_cls.free_wrap_ctx)(vol_wrap_ctx->obj_wrap_ctx) < 0)
-            HGOTO_ERROR(H5E_VOL, H5E_CANTRELEASE, FAIL,
-                        "unable to release connector's object wrapping context");
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            /* Release the VOL connector's object wrapping context */
+            ret_value = (*vol_wrap_ctx->connector->cls->wrap_cls.free_wrap_ctx)(vol_wrap_ctx->obj_wrap_ctx);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VOL, H5E_CANTRELEASE, FAIL, "unable to release connector's object wrapping context");
 
     /* Decrement refcount on connector */
     if (H5VL_conn_dec_rc(vol_wrap_ctx->connector) < 0)

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -286,8 +286,14 @@ H5VL__free_cls(H5VL_class_t *cls, void H5_ATTR_UNUSED **request)
     assert(cls);
 
     /* Shut down the VOL connector */
-    if (cls->terminate && cls->terminate() < 0)
-        HGOTO_ERROR(H5E_VOL, H5E_CANTCLOSEOBJ, FAIL, "VOL connector did not terminate cleanly");
+    if (cls->terminate) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = cls->terminate();
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VOL, H5E_CANTCLOSEOBJ, FAIL, "VOL connector did not terminate cleanly");
+    }
 
     /* Release the class */
     H5MM_xfree_const(cls->name);
@@ -1187,8 +1193,14 @@ H5VL__register_connector(const void *_cls, hbool_t app_ref, hid_t vipl_id)
                     "memory allocation failed for VOL connector name");
 
     /* Initialize the VOL connector */
-    if (cls->initialize && cls->initialize(vipl_id) < 0)
-        HGOTO_ERROR(H5E_VOL, H5E_CANTINIT, H5I_INVALID_HID, "unable to init VOL connector");
+    if (cls->initialize) {
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL) {
+            ret_value = cls->initialize(vipl_id);
+        } H5_AFTER_USER_CB(FAIL)
+        if (ret_value < 0)
+            HGOTO_ERROR(H5E_VOL, H5E_CANTINIT, H5I_INVALID_HID, "unable to init VOL connector");
+    }
 
     /* Create the new class ID */
     if ((ret_value = H5I_register(H5I_VOL, saved, app_ref)) < 0)

--- a/src/H5Z.c
+++ b/src/H5Z.c
@@ -740,8 +740,13 @@ H5Z__prelude_callback(const H5O_pline_t *pline, hid_t dcpl_id, hid_t type_id, hi
 
                     /* Check if there is a "can apply" callback */
                     if (fclass->can_apply) {
-                        /* Make callback to filter's "can apply" function */
-                        htri_t status = (fclass->can_apply)(dcpl_id, type_id, space_id);
+                        htri_t status;
+
+                        /* Prepare & restore library for user callback */
+                        H5_BEFORE_USER_CB(FAIL) {
+                            /* Make callback to filter's "can apply" function */
+                            status = (fclass->can_apply)(dcpl_id, type_id, space_id);
+                        } H5_AFTER_USER_CB(FAIL)
 
                         /* Indicate error during filter callback */
                         if (status < 0)
@@ -757,9 +762,16 @@ H5Z__prelude_callback(const H5O_pline_t *pline, hid_t dcpl_id, hid_t type_id, hi
                 case H5Z_PRELUDE_SET_LOCAL:
                     /* Check if there is a "set local" callback */
                     if (fclass->set_local) {
-                        /* Make callback to filter's "set local" function */
-                        if ((fclass->set_local)(dcpl_id, type_id, space_id) < 0)
-                            /* Indicate error during filter callback */
+                        herr_t status;
+
+                        /* Prepare & restore library for user callback */
+                        H5_BEFORE_USER_CB(FAIL) {
+                            /* Make callback to filter's "set local" function */
+                            status = (fclass->set_local)(dcpl_id, type_id, space_id);
+                        } H5_AFTER_USER_CB(FAIL)
+
+                        /* Indicate error during filter callback */
+                        if (status < 0)
                             HGOTO_ERROR(H5E_PLINE, H5E_SETLOCAL, FAIL, "error during user callback");
                     } /* end if */
                     break;
@@ -1369,8 +1381,11 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
 
             tmp_flags = flags | (pline->filter[idx].flags);
             tmp_flags |= (edc_read == H5Z_DISABLE_EDC) ? H5Z_FLAG_SKIP_EDC : 0;
-            new_nbytes = (fclass->filter)(tmp_flags, pline->filter[idx].cd_nelmts,
-                                          pline->filter[idx].cd_values, *nbytes, buf_size, buf);
+
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                new_nbytes = (fclass->filter)(tmp_flags, pline->filter[idx].cd_nelmts, pline->filter[idx].cd_values, *nbytes, buf_size, buf);
+            } H5_AFTER_USER_CB(FAIL)
 
 #ifdef H5Z_DEBUG
             H5_timer_stop(&timer);
@@ -1420,8 +1435,10 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
             H5_timer_start(&timer);
 #endif
 
-            new_nbytes = (fclass->filter)(flags | (pline->filter[idx].flags), pline->filter[idx].cd_nelmts,
-                                          pline->filter[idx].cd_values, *nbytes, buf_size, buf);
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL) {
+                new_nbytes = (fclass->filter)(flags | (pline->filter[idx].flags), pline->filter[idx].cd_nelmts, pline->filter[idx].cd_values, *nbytes, buf_size, buf);
+            } H5_AFTER_USER_CB(FAIL)
 
 #ifdef H5Z_DEBUG
             H5_timer_stop(&timer);

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -1264,6 +1264,30 @@ extern H5_debug_t H5_debug_g;
 /* Embedded build information */
 extern const char H5libhdf5_settings[];
 
+/* Prepare to call / return from user callback */
+#define H5_BEFORE_USER_CB(err)              \
+    {                                       \
+        if (H5_user_cb_prepare() < 0)       \
+            HGOTO_ERROR(H5E_LIB, H5E_CANTSET, (err), "preparation for user callback failed");
+
+#define H5_AFTER_USER_CB(err)                                                                     \
+        if (H5_user_cb_restore() < 0)                                                             \
+            HGOTO_ERROR(H5E_LIB, H5E_CANTRESTORE, (err), "preparation for user callback failed"); \
+    }
+
+#define H5_BEFORE_USER_CB_NOERR(err)        \
+    {                                       \
+        if (H5_user_cb_prepare() < 0)       \
+            ret_value = (err);              \
+        else {
+
+#define H5_AFTER_USER_CB_NOERR(err)             \
+            if (H5_user_cb_restore() < 0)       \
+                ret_value = (err);              \
+        } /* end else */                        \
+    }
+
+
 /*-------------------------------------------------------------------------
  * Purpose: These macros are inserted automatically just after the
  *          FUNC_ENTER() macro of API functions and are used to trace
@@ -2240,4 +2264,7 @@ H5_DLL herr_t  H5_mpio_get_file_sync_required(MPI_File fh, hbool_t *file_sync_re
 H5_DLL herr_t H5_buffer_dump(FILE *stream, int indent, const uint8_t *buf, const uint8_t *marker,
                              size_t buf_offset, size_t buf_size);
 
+/* Functions for preparing for / returning from user callbacks */
+H5_DLL herr_t H5_user_cb_prepare(void);
+H5_DLL herr_t H5_user_cb_restore(void);
 #endif /* H5private_H */

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -1287,6 +1287,14 @@ extern const char H5libhdf5_settings[];
         } /* end else */                        \
     }
 
+#define H5_BEFORE_USER_CB_NOCHECK   \
+    {                               \
+        H5_user_cb_prepare(); \
+
+#define H5_AFTER_USER_CB_NOCHECK    \
+        H5_user_cb_restore(); \
+    }
+
 
 /*-------------------------------------------------------------------------
  * Purpose: These macros are inserted automatically just after the


### PR DESCRIPTION
`H5_BEFORE_USER_CB/H5_AFTER_USER_CB` are used before/after user-defined callbacks to make certain operations re-entrant safe in the develop branch of the main library, added in HDFGroup/hdf5#5015.

In the library, the things the macros actually do depend on changes that aren't in 1.14.2 yet. So this PR just brings down the macros themselves in the correct locations. 

This was motivated by a need to handle re-entrance for the virtual ID locks, but there's likely to be other cases where we need to do special handling around user callbacks.