### PR TITLE
Add macros for single-thread only free lists

### DIFF
--- a/src/H5D.c
+++ b/src/H5D.c
@@ -68,10 +68,10 @@ static herr_t H5D__set_extent_api_common(hid_t dset_id, const hsize_t size[], vo
 /*****************************/
 
 /* Declare extern free list to manage the H5S_sel_iter_t struct */
-H5FL_EXTERN(H5S_sel_iter_t);
+H5FL_EXTERN_MT(H5S_sel_iter_t);
 
 /* Declare extern the free list to manage blocks of type conversion data */
-H5FL_BLK_EXTERN(type_conv);
+H5FL_BLK_EXTERN_MT(type_conv);
 
 /*******************/
 /* Local Variables */
@@ -1698,7 +1698,7 @@ H5Dscatter(H5D_scatter_func_t op, void *op_data, hid_t type_id, hid_t dst_space_
         HGOTO_ERROR(H5E_DATASET, H5E_CANTCOUNT, FAIL, "unable to get number of elements in selection");
 
     /* Allocate the selection iterator */
-    if (NULL == (iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate selection iterator");
 
     /* Initialize selection iterator */
@@ -1737,7 +1737,7 @@ done:
     if (iter_init && H5S_SELECT_ITER_RELEASE(iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "can't release selection iterator");
     if (iter)
-        iter = H5FL_FREE(H5S_sel_iter_t, iter);
+        iter = H5FL_FREE_MT(H5S_sel_iter_t, iter);
 
     FUNC_LEAVE_API(ret_value)
 } /* H5Dscatter() */
@@ -1804,7 +1804,7 @@ H5Dgather(hid_t src_space_id, const void *src_buf, hid_t type_id, size_t dst_buf
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no callback supplied and destination buffer too small");
 
     /* Allocate the selection iterator */
-    if (NULL == (iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate selection iterator");
 
     /* Initialize selection iterator */
@@ -1833,7 +1833,7 @@ done:
     if (iter_init && H5S_SELECT_ITER_RELEASE(iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "can't release selection iterator");
     if (iter)
-        iter = H5FL_FREE(H5S_sel_iter_t, iter);
+        iter = H5FL_FREE_MT(H5S_sel_iter_t, iter);
 
     FUNC_LEAVE_API(ret_value)
 } /* H5Dgather() */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -365,7 +365,7 @@ H5FL_DEFINE(H5D_piece_info_t);
 H5FL_BLK_DEFINE_STATIC(chunk);
 
 /* Declare extern free list to manage the H5S_sel_iter_t struct */
-H5FL_EXTERN(H5S_sel_iter_t);
+H5FL_EXTERN_MT(H5S_sel_iter_t);
 
 /*-------------------------------------------------------------------------
  * Function:    H5D__chunk_direct_write
@@ -5815,7 +5815,7 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, hbool_t new_unfilt_chunk)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "can't refill fill value buffer");
 
     /* Allocate the chunk selection iterator */
-    if (NULL == (chunk_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (chunk_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate chunk selection iterator");
 
     /* Create a selection iterator for scattering the elements to memory buffer */
@@ -5841,7 +5841,7 @@ done:
     if (chunk_iter_init && H5S_SELECT_ITER_RELEASE(chunk_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (chunk_iter)
-        chunk_iter = H5FL_FREE(H5S_sel_iter_t, chunk_iter);
+        chunk_iter = H5FL_FREE_MT(H5S_sel_iter_t, chunk_iter);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5D__chunk_prune_fill */

--- a/src/H5Dcompact.c
+++ b/src/H5Dcompact.c
@@ -570,17 +570,17 @@ H5D__compact_copy(H5F_t *f_src, H5O_storage_compact_t *_storage_src, H5F_t *f_ds
         } /* end if */
 
         /* Allocate memory for recclaim buf */
-        if (NULL == (reclaim_buf = H5FL_BLK_MALLOC(type_conv, buf_size)))
+        if (NULL == (reclaim_buf = H5FL_BLK_MALLOC_MT(type_conv, buf_size)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
 
         /* Allocate memory for copying the chunk */
-        if (NULL == (buf = H5FL_BLK_MALLOC(type_conv, buf_size)))
+        if (NULL == (buf = H5FL_BLK_MALLOC_MT(type_conv, buf_size)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
 
         H5MM_memcpy(buf, storage_src->buf, storage_src->size);
 
         /* allocate temporary bkg buff for data conversion */
-        if (NULL == (bkg = H5FL_BLK_MALLOC(type_conv, buf_size)))
+        if (NULL == (bkg = H5FL_BLK_MALLOC_MT(type_conv, buf_size)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
 
         /* Convert from source file to memory */
@@ -637,11 +637,11 @@ done:
     if (tid_mem > 0 && H5I_dec_ref(tid_mem) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
     if (buf)
-        buf = H5FL_BLK_FREE(type_conv, buf);
+        buf = H5FL_BLK_FREE_MT(type_conv, buf);
     if (reclaim_buf)
-        reclaim_buf = H5FL_BLK_FREE(type_conv, reclaim_buf);
+        reclaim_buf = H5FL_BLK_FREE_MT(type_conv, reclaim_buf);
     if (bkg)
-        bkg = H5FL_BLK_FREE(type_conv, bkg);
+        bkg = H5FL_BLK_FREE_MT(type_conv, bkg);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__compact_copy() */

--- a/src/H5Dcontig.c
+++ b/src/H5Dcontig.c
@@ -1727,16 +1727,16 @@ H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f
 
     /* Allocate space for copy buffer */
     assert(buf_size);
-    if (NULL == (buf = H5FL_BLK_MALLOC(type_conv, buf_size)))
+    if (NULL == (buf = H5FL_BLK_MALLOC_MT(type_conv, buf_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for copy buffer");
 
     /* Need extra buffer for datatype conversions, to prevent stranding/leaking memory */
     if (is_vlen || fix_ref) {
-        if (NULL == (reclaim_buf = H5FL_BLK_MALLOC(type_conv, buf_size)))
+        if (NULL == (reclaim_buf = H5FL_BLK_MALLOC_MT(type_conv, buf_size)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for copy buffer");
 
         /* allocate temporary bkg buff for data conversion */
-        if (NULL == (bkg = H5FL_BLK_MALLOC(type_conv, buf_size)))
+        if (NULL == (bkg = H5FL_BLK_MALLOC_MT(type_conv, buf_size)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for copy buffer");
     } /* end if */
 
@@ -1843,11 +1843,11 @@ done:
     if (tid_mem > 0 && H5I_dec_ref(tid_mem) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
     if (buf)
-        buf = H5FL_BLK_FREE(type_conv, buf);
+        buf = H5FL_BLK_FREE_MT(type_conv, buf);
     if (reclaim_buf)
-        reclaim_buf = H5FL_BLK_FREE(type_conv, reclaim_buf);
+        reclaim_buf = H5FL_BLK_FREE_MT(type_conv, reclaim_buf);
     if (bkg)
-        bkg = H5FL_BLK_FREE(type_conv, bkg);
+        bkg = H5FL_BLK_FREE_MT(type_conv, bkg);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__contig_copy() */

--- a/src/H5Dfill.c
+++ b/src/H5Dfill.c
@@ -78,7 +78,7 @@ H5FL_BLK_DEFINE_STATIC(non_zero_fill);
 H5FL_BLK_DEFINE_STATIC(zero_fill);
 
 /* Declare extern free list to manage the H5S_sel_iter_t struct */
-H5FL_EXTERN(H5S_sel_iter_t);
+H5FL_EXTERN_MT(H5S_sel_iter_t);
 
 /*--------------------------------------------------------------------------
  NAME
@@ -190,12 +190,12 @@ H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_
             H5_CHECK_OVERFLOW(nelmts, hsize_t, size_t);
 
             /* Allocate a temporary buffer */
-            if (NULL == (tmp_buf = H5FL_BLK_MALLOC(type_conv, (size_t)nelmts * buf_size)))
+            if (NULL == (tmp_buf = H5FL_BLK_MALLOC_MT(type_conv, (size_t)nelmts * buf_size)))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
 
             /* Allocate a background buffer, if necessary */
             if (H5T_path_bkg(tpath) &&
-                NULL == (bkg_buf = H5FL_BLK_CALLOC(type_conv, (size_t)nelmts * buf_size)))
+                NULL == (bkg_buf = H5FL_BLK_CALLOC_MT(type_conv, (size_t)nelmts * buf_size)))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
 
             /* Replicate the file's fill value into the temporary buffer */
@@ -207,7 +207,7 @@ H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "data type conversion failed");
 
             /* Allocate the chunk selection iterator */
-            if (NULL == (mem_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+            if (NULL == (mem_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate memory selection iterator");
 
             /* Create a selection iterator for scattering the elements to memory buffer */
@@ -272,19 +272,19 @@ done:
     if (mem_iter_init && H5S_SELECT_ITER_RELEASE(mem_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (mem_iter)
-        mem_iter = H5FL_FREE(H5S_sel_iter_t, mem_iter);
+        mem_iter = H5FL_FREE_MT(H5S_sel_iter_t, mem_iter);
     if (src_id != (-1) && H5I_dec_ref(src_id) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
     if (dst_id != (-1) && H5I_dec_ref(dst_id) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
     if (tmp_buf)
-        tmp_buf = H5FL_BLK_FREE(type_conv, tmp_buf);
+        tmp_buf = H5FL_BLK_FREE_MT(type_conv, tmp_buf);
     if (elem_wb && H5WB_unwrap(elem_wb) < 0)
         HDONE_ERROR(H5E_ATTR, H5E_CLOSEERROR, FAIL, "can't close wrapped buffer");
     if (bkg_elem_wb && H5WB_unwrap(bkg_elem_wb) < 0)
         HDONE_ERROR(H5E_ATTR, H5E_CLOSEERROR, FAIL, "can't close wrapped buffer");
     if (bkg_buf)
-        bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
+        bkg_buf = H5FL_BLK_FREE_MT(type_conv, bkg_buf);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5D__fill() */
@@ -395,7 +395,7 @@ H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocat
                     fb_info->bkg_buf_size = fb_info->max_elmt_size;
 
                 /* Allocate the background buffer */
-                if (NULL == (fb_info->bkg_buf = H5FL_BLK_MALLOC(type_conv, fb_info->bkg_buf_size)))
+                if (NULL == (fb_info->bkg_buf = H5FL_BLK_MALLOC_MT(type_conv, fb_info->bkg_buf_size)))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
             } /* end if */
         }     /* end if */
@@ -627,7 +627,7 @@ H5D__fill_term(H5D_fill_buf_info_t *fb_info)
         else if (fb_info->mem_type)
             (void)H5T_close_real(fb_info->mem_type);
         if (fb_info->bkg_buf)
-            fb_info->bkg_buf = H5FL_BLK_FREE(type_conv, fb_info->bkg_buf);
+            fb_info->bkg_buf = H5FL_BLK_FREE_MT(type_conv, fb_info->bkg_buf);
     } /* end if */
 
     FUNC_LEAVE_NOAPI(SUCCEED)

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -3649,7 +3649,7 @@ H5D_get_create_plist(const H5D_t *dset)
 
             /* Allocate a background buffer */
             bkg_size = MAX(H5T_GET_SIZE(copied_fill.type), H5T_GET_SIZE(dset->shared->type));
-            if (H5T_path_bkg(tpath) && NULL == (bkg_buf = H5FL_BLK_CALLOC(type_conv, bkg_size))) {
+            if (H5T_path_bkg(tpath) && NULL == (bkg_buf = H5FL_BLK_CALLOC_MT(type_conv, bkg_size))) {
                 H5I_dec_ref(src_id);
                 H5I_dec_ref(dst_id);
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "memory allocation failed");
@@ -3661,7 +3661,7 @@ H5D_get_create_plist(const H5D_t *dset)
                 H5I_dec_ref(src_id);
                 H5I_dec_ref(dst_id);
                 if (bkg_buf)
-                    bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
+                    bkg_buf = H5FL_BLK_FREE_MT(type_conv, bkg_buf);
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
             } /* end if */
 
@@ -3671,7 +3671,7 @@ H5D_get_create_plist(const H5D_t *dset)
             if (H5I_dec_ref(dst_id) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTDEC, FAIL, "unable to close temporary object");
             if (bkg_buf)
-                bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
+                bkg_buf = H5FL_BLK_FREE_MT(type_conv, bkg_buf);
         } /* end if */
     }     /* end if */
 

--- a/src/H5Dio.c
+++ b/src/H5Dio.c
@@ -1377,7 +1377,7 @@ H5D__typeinfo_init_phase3(H5D_io_info_t *io_info)
              * on the free list.  Should we change this to a regular malloc?  Would require
              * keeping track of which version of free() to call. -NAF */
             if (io_info->tconv_buf_size > 0) {
-                if (NULL == (io_info->tconv_buf = H5FL_BLK_MALLOC(type_conv, io_info->tconv_buf_size)))
+                if (NULL == (io_info->tconv_buf = H5FL_BLK_MALLOC_MT(type_conv, io_info->tconv_buf_size)))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL,
                                 "memory allocation failed for type conversion");
                 io_info->tconv_buf_allocated = TRUE;
@@ -1385,7 +1385,7 @@ H5D__typeinfo_init_phase3(H5D_io_info_t *io_info)
 
             /* Allocate global background buffer (if any) */
             if (io_info->bkg_buf_size > 0) {
-                if (NULL == (io_info->bkg_buf = H5FL_BLK_MALLOC(type_conv, io_info->bkg_buf_size)))
+                if (NULL == (io_info->bkg_buf = H5FL_BLK_MALLOC_MT(type_conv, io_info->bkg_buf_size)))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL,
                                 "memory allocation failed for type conversion");
                 io_info->bkg_buf_allocated = TRUE;
@@ -1431,7 +1431,7 @@ H5D__typeinfo_init_phase3(H5D_io_info_t *io_info)
              * buffer is shared among all datasets in the operation. */
             if (NULL == (io_info->tconv_buf = (uint8_t *)tconv_buf)) {
                 /* Allocate temporary buffer */
-                if (NULL == (io_info->tconv_buf = H5FL_BLK_MALLOC(type_conv, target_size)))
+                if (NULL == (io_info->tconv_buf = H5FL_BLK_MALLOC_MT(type_conv, target_size)))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL,
                                 "memory allocation failed for type conversion");
                 io_info->tconv_buf_allocated = TRUE;
@@ -1452,7 +1452,7 @@ H5D__typeinfo_init_phase3(H5D_io_info_t *io_info)
                      * this since the number of elements that fit in the type conversion buffer will never be
                      * larger than the number that could fit in a background buffer of equal size, since the
                      * tconv element size is max(src, dst) and the bkg element size is dst */
-                    if (NULL == (io_info->bkg_buf = H5FL_BLK_MALLOC(type_conv, target_size)))
+                    if (NULL == (io_info->bkg_buf = H5FL_BLK_MALLOC_MT(type_conv, target_size)))
                         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL,
                                     "memory allocation failed for background conversion");
                     io_info->bkg_buf_allocated = TRUE;
@@ -1482,11 +1482,11 @@ H5D__typeinfo_term(H5D_io_info_t *io_info)
     /* Check for releasing datatype conversion & background buffers */
     if (io_info->tconv_buf_allocated) {
         assert(io_info->tconv_buf);
-        (void)H5FL_BLK_FREE(type_conv, io_info->tconv_buf);
+        (void)H5FL_BLK_FREE_MT(type_conv, io_info->tconv_buf);
     } /* end if */
     if (io_info->bkg_buf_allocated) {
         assert(io_info->bkg_buf);
-        (void)H5FL_BLK_FREE(type_conv, io_info->bkg_buf);
+        (void)H5FL_BLK_FREE_MT(type_conv, io_info->bkg_buf);
     } /* end if */
 
     FUNC_LEAVE_NOAPI(SUCCEED)

--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -379,7 +379,7 @@ static herr_t H5D__mpio_dump_collective_filtered_chunk_list(H5D_filtered_collect
 /*******************/
 
 /* Declare extern free list to manage the H5S_sel_iter_t struct */
-H5FL_EXTERN(H5S_sel_iter_t);
+H5FL_EXTERN_MT(H5S_sel_iter_t);
 
 #ifdef H5Dmpio_DEBUG
 
@@ -3686,7 +3686,7 @@ H5D__mpio_share_chunk_modification_data(H5D_filtered_collective_io_info_t *chunk
 
     if (chunk_list->num_chunk_infos > 0) {
         /* Allocate a selection iterator for iterating over chunk dataspaces */
-        if (NULL == (mem_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+        if (NULL == (mem_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
             HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "couldn't allocate dataspace selection iterator");
 
         /*
@@ -4027,7 +4027,7 @@ done:
     if (mem_iter) {
         if (mem_iter_init && H5S_SELECT_ITER_RELEASE(mem_iter) < 0)
             HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "couldn't release dataspace selection iterator");
-        mem_iter = H5FL_FREE(H5S_sel_iter_t, mem_iter);
+        mem_iter = H5FL_FREE_MT(H5S_sel_iter_t, mem_iter);
     }
 
 #ifdef H5Dmpio_DEBUG
@@ -4480,7 +4480,7 @@ H5D__mpio_collective_filtered_chunk_update(H5D_filtered_collective_io_info_t *ch
     }
 
     /* Allocate iterator for memory selection */
-    if (NULL == (sel_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (sel_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "couldn't allocate memory iterator");
 
     /* Now process all received chunk message buffers */
@@ -4563,7 +4563,7 @@ done:
     if (sel_iter) {
         if (sel_iter_init && H5S_SELECT_ITER_RELEASE(sel_iter) < 0)
             HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "couldn't release selection iterator");
-        sel_iter = H5FL_FREE(H5S_sel_iter_t, sel_iter);
+        sel_iter = H5FL_FREE_MT(H5S_sel_iter_t, sel_iter);
     }
     if (dataspace && (H5S_close(dataspace) < 0))
         HDONE_ERROR(H5E_DATASPACE, H5E_CANTFREE, FAIL, "can't close dataspace");

--- a/src/H5Dscatgath.c
+++ b/src/H5Dscatgath.c
@@ -66,7 +66,7 @@ static herr_t H5D__compound_opt_write(size_t nelmts, const H5D_type_info_t *type
 /*******************/
 
 /* Declare extern free list to manage the H5S_sel_iter_t struct */
-H5FL_EXTERN(H5S_sel_iter_t);
+H5FL_EXTERN_MT(H5S_sel_iter_t);
 
 /* Declare extern free list to manage sequences of size_t */
 H5FL_SEQ_EXTERN(size_t);
@@ -479,11 +479,11 @@ H5D__scatgath_read(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset_
                      dset_info->layout_io_info.contig_piece_info->in_place_tconv;
 
     /* Allocate the iterators */
-    if (NULL == (mem_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (mem_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate memory iterator");
-    if (NULL == (bkg_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (bkg_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate background iterator");
-    if (NULL == (file_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (file_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate file iterator");
 
     /* Figure out the strip mine size. */
@@ -595,15 +595,15 @@ done:
     if (file_iter_init && H5S_SELECT_ITER_RELEASE(file_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (file_iter)
-        file_iter = H5FL_FREE(H5S_sel_iter_t, file_iter);
+        file_iter = H5FL_FREE_MT(H5S_sel_iter_t, file_iter);
     if (mem_iter_init && H5S_SELECT_ITER_RELEASE(mem_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (mem_iter)
-        mem_iter = H5FL_FREE(H5S_sel_iter_t, mem_iter);
+        mem_iter = H5FL_FREE_MT(H5S_sel_iter_t, mem_iter);
     if (bkg_iter_init && H5S_SELECT_ITER_RELEASE(bkg_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (bkg_iter)
-        bkg_iter = H5FL_FREE(H5S_sel_iter_t, bkg_iter);
+        bkg_iter = H5FL_FREE_MT(H5S_sel_iter_t, bkg_iter);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__scatgath_read() */
@@ -654,11 +654,11 @@ H5D__scatgath_write(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset
                      dset_info->layout_io_info.contig_piece_info->in_place_tconv;
 
     /* Allocate the iterators */
-    if (NULL == (mem_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (mem_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate memory iterator");
-    if (NULL == (bkg_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (bkg_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate background iterator");
-    if (NULL == (file_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (file_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate file iterator");
 
     /* Figure out the strip mine size. */
@@ -770,15 +770,15 @@ done:
     if (file_iter_init && H5S_SELECT_ITER_RELEASE(file_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (file_iter)
-        file_iter = H5FL_FREE(H5S_sel_iter_t, file_iter);
+        file_iter = H5FL_FREE_MT(H5S_sel_iter_t, file_iter);
     if (mem_iter_init && H5S_SELECT_ITER_RELEASE(mem_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (mem_iter)
-        mem_iter = H5FL_FREE(H5S_sel_iter_t, mem_iter);
+        mem_iter = H5FL_FREE_MT(H5S_sel_iter_t, mem_iter);
     if (bkg_iter_init && H5S_SELECT_ITER_RELEASE(bkg_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (bkg_iter)
-        bkg_iter = H5FL_FREE(H5S_sel_iter_t, bkg_iter);
+        bkg_iter = H5FL_FREE_MT(H5S_sel_iter_t, bkg_iter);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__scatgath_write() */
@@ -821,7 +821,7 @@ H5D__scatgath_read_select(H5D_io_info_t *io_info)
         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "memory allocation failed for temporary buffer list");
 
     /* Allocate the iterator */
-    if (NULL == (mem_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (mem_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate memory iterator");
 
     /* Allocate list of block memory spaces */
@@ -995,7 +995,7 @@ done:
     if (mem_iter_init && H5S_SELECT_ITER_RELEASE(mem_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (mem_iter)
-        mem_iter = H5FL_FREE(H5S_sel_iter_t, mem_iter);
+        mem_iter = H5FL_FREE_MT(H5S_sel_iter_t, mem_iter);
 
     /* Free tmp_bufs */
     H5MM_free(tmp_bufs);
@@ -1058,7 +1058,7 @@ H5D__scatgath_write_select(H5D_io_info_t *io_info)
         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "memory allocation failed for temporary buffer list");
 
     /* Allocate the iterator */
-    if (NULL == (mem_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (mem_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate memory iterator");
 
     /* Allocate list of block memory spaces */
@@ -1298,7 +1298,7 @@ done:
     if (mem_iter_init && H5S_SELECT_ITER_RELEASE(mem_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (mem_iter)
-        mem_iter = H5FL_FREE(H5S_sel_iter_t, mem_iter);
+        mem_iter = H5FL_FREE_MT(H5S_sel_iter_t, mem_iter);
 
     /* Free write_bufs */
     H5MM_free(write_bufs);

--- a/src/H5Dselect.c
+++ b/src/H5Dselect.c
@@ -167,9 +167,9 @@ H5D__select_io(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset_info
             HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate I/O offset vector array");
 
         /* Allocate the iterators */
-        if (NULL == (mem_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+        if (NULL == (mem_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
             HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate memory iterator");
-        if (NULL == (file_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+        if (NULL == (file_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
             HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate file iterator");
 
         /* Initialize file iterator */
@@ -237,11 +237,11 @@ done:
     if (file_iter_init && H5S_SELECT_ITER_RELEASE(file_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "unable to release selection iterator");
     if (file_iter)
-        file_iter = H5FL_FREE(H5S_sel_iter_t, file_iter);
+        file_iter = H5FL_FREE_MT(H5S_sel_iter_t, file_iter);
     if (mem_iter_init && H5S_SELECT_ITER_RELEASE(mem_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "unable to release selection iterator");
     if (mem_iter)
-        mem_iter = H5FL_FREE(H5S_sel_iter_t, mem_iter);
+        mem_iter = H5FL_FREE_MT(H5S_sel_iter_t, mem_iter);
 
     /* Release vector arrays, if allocated */
     if (file_len)
@@ -356,9 +356,9 @@ H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, H5S_t *s
             HGOTO_ERROR(H5E_IO, H5E_CANTALLOC, FAIL, "can't allocate I/O offset vector array");
 
         /* Allocate the dataspace selection iterators */
-        if (NULL == (dst_sel_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+        if (NULL == (dst_sel_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
             HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, FAIL, "can't allocate destination selection iterator");
-        if (NULL == (src_sel_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+        if (NULL == (src_sel_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
             HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, FAIL, "can't allocate source selection iterator");
 
         /* Initialize destination selection iterator */
@@ -416,13 +416,13 @@ done:
         if (src_sel_iter_init && H5S_SELECT_ITER_RELEASE(src_sel_iter) < 0)
             HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, FAIL, "unable to release selection iterator");
 
-        src_sel_iter = H5FL_FREE(H5S_sel_iter_t, src_sel_iter);
+        src_sel_iter = H5FL_FREE_MT(H5S_sel_iter_t, src_sel_iter);
     }
     if (dst_sel_iter) {
         if (dst_sel_iter_init && H5S_SELECT_ITER_RELEASE(dst_sel_iter) < 0)
             HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, FAIL, "unable to release selection iterator");
 
-        dst_sel_iter = H5FL_FREE(H5S_sel_iter_t, dst_sel_iter);
+        dst_sel_iter = H5FL_FREE_MT(H5S_sel_iter_t, dst_sel_iter);
     }
 
     /* Release vector arrays, if allocated */

--- a/src/H5E.c
+++ b/src/H5E.c
@@ -145,13 +145,13 @@ static herr_t     H5E__append_stack(H5E_t *dst_estack, const H5E_t *src_stack);
 #ifndef H5_HAVE_MULTITHREAD
 
 /* Declare a free list to manage the H5E_t struct */
-H5FL_DEFINE_STATIC(H5E_t);
+H5FL_DEFINE_STATIC_MT(H5E_t);
 
 /* Declare a free list to manage the H5E_cls_t struct */
-H5FL_DEFINE_STATIC(H5E_cls_t);
+H5FL_DEFINE_STATIC_MT(H5E_cls_t);
 
 /* Declare a free list to manage the H5E_msg_t struct */
-H5FL_DEFINE_STATIC(H5E_msg_t);
+H5FL_DEFINE_STATIC_MT(H5E_msg_t);
 
 #endif /* H5_HAVE_MULTITHREAD */
 
@@ -476,7 +476,7 @@ H5E__free_class(H5E_cls_t *cls)
     cls->cls_name = (char *)H5MM_xfree((void *)cls->cls_name);
     cls->lib_name = (char *)H5MM_xfree((void *)cls->lib_name);
     cls->lib_vers = (char *)H5MM_xfree((void *)cls->lib_vers);
-    cls           = H5FL_FREE(H5E_cls_t, cls);
+    cls           = H5FL_FREE_MT(H5E_cls_t, cls);
 #endif /* H5_HAVE_MULTITHREAD */
 
     FUNC_LEAVE_NOAPI(SUCCEED)
@@ -563,7 +563,7 @@ H5E__register_class(const char *cls_name, const char *lib_name, const char *vers
 
     /* Allocate space for new error class */
 
-    if (NULL == (cls = H5FL_CALLOC(H5E_cls_t)))
+    if (NULL == (cls = H5FL_CALLOC_MT(H5E_cls_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
     /* Duplicate string information */
@@ -918,7 +918,7 @@ H5E__close_msg(H5E_msg_t *err, void H5_ATTR_UNUSED **request)
     /* Release message */
     err->msg = (char *)H5MM_xfree((void *)err->msg);
     /* Don't free err->cls here */
-    err = H5FL_FREE(H5E_msg_t, err);
+    err = H5FL_FREE_MT(H5E_msg_t, err);
 
 #endif /* H5_HAVE_MULTITHREAD */
 
@@ -1007,7 +1007,7 @@ H5E__create_msg(H5E_cls_t *cls, H5E_type_t msg_type, const char *msg_str)
 #else /* H5_HAVE_MULTITHREAD */
 
     /* Allocate new message object */
-    if (NULL == (msg = H5FL_MALLOC(H5E_msg_t)))
+    if (NULL == (msg = H5FL_MALLOC_MT(H5E_msg_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
     /* Fill new message object */
@@ -1088,7 +1088,7 @@ H5Ecreate_stack(void)
 
 #else /* H5_HAVE_MULTITHREAD */
 
-    if (NULL == (stk = H5FL_CALLOC(H5E_t)))
+    if (NULL == (stk = H5FL_CALLOC_MT(H5E_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5I_INVALID_HID, "memory allocation failed");
 
 #endif /* H5_HAVE_MULTITHREAD */
@@ -1174,7 +1174,7 @@ H5E__get_current_stack(void)
 
 #else /* H5_HAVE_MULTITHREAD */
 
-    if (NULL == (estack_copy = H5FL_CALLOC(H5E_t)))
+    if (NULL == (estack_copy = H5FL_CALLOC_MT(H5E_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
 #endif /* H5_HAVE_MULTITHREAD */
@@ -1242,7 +1242,7 @@ done:
 #else /* H5_HAVE_MULTITHREAD */
 
         if (estack_copy)
-            estack_copy = H5FL_FREE(H5E_t, estack_copy);
+            estack_copy = H5FL_FREE_MT(H5E_t, estack_copy);
 
 #endif /* H5_HAVE_MULTITHREAD */
 
@@ -1427,7 +1427,7 @@ H5E__close_stack(H5E_t *estack, void H5_ATTR_UNUSED **request)
 
 #else /* H5_HAVE_MULTITHREAD */
 
-    estack = H5FL_FREE(H5E_t, estack);
+    estack = H5FL_FREE_MT(H5E_t, estack);
 
 #endif /* H5_HAVE_MULTITHREAD */
 

--- a/src/H5F.c
+++ b/src/H5F.c
@@ -89,10 +89,10 @@ static herr_t H5F__flush_api_common(hid_t object_id, H5F_scope_t scope, void **t
 /*******************/
 
 /* Declare a free list to manage the H5VL_t struct */
-H5FL_EXTERN(H5VL_t);
+H5FL_EXTERN_MT(H5VL_t);
 
 /* Declare a free list to manage the H5VL_object_t struct */
-H5FL_EXTERN(H5VL_object_t);
+H5FL_EXTERN_MT(H5VL_object_t);
 
 /*-------------------------------------------------------------------------
  * Function:    H5Fget_create_plist

--- a/src/H5FDint.c
+++ b/src/H5FDint.c
@@ -808,9 +808,9 @@ H5FD__read_selection_translate(uint32_t skip_vector_cb, H5FD_t *file, H5FD_mem_t
         assert(bufs[0] != NULL);
 
         /* Allocate sequence lists for memory and file spaces */
-        if (NULL == (file_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+        if (NULL == (file_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
             HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, "couldn't allocate file selection iterator");
-        if (NULL == (mem_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+        if (NULL == (mem_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
             HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, "couldn't allocate memory selection iterator");
     }
 
@@ -1015,12 +1015,12 @@ done:
     if (file_iter) {
         if (file_iter_init && H5S_SELECT_ITER_RELEASE(file_iter) < 0)
             HGOTO_ERROR(H5E_INTERNAL, H5E_CANTFREE, FAIL, "can't release file selection iterator");
-        file_iter = H5FL_FREE(H5S_sel_iter_t, file_iter);
+        file_iter = H5FL_FREE_MT(H5S_sel_iter_t, file_iter);
     }
     if (mem_iter) {
         if (mem_iter_init && H5S_SELECT_ITER_RELEASE(mem_iter) < 0)
             HGOTO_ERROR(H5E_INTERNAL, H5E_CANTFREE, FAIL, "can't release memory selection iterator");
-        mem_iter = H5FL_FREE(H5S_sel_iter_t, mem_iter);
+        mem_iter = H5FL_FREE_MT(H5S_sel_iter_t, mem_iter);
     }
 
     /* Cleanup vector arrays */
@@ -1465,9 +1465,9 @@ H5FD__write_selection_translate(uint32_t skip_vector_cb, H5FD_t *file, H5FD_mem_
         assert(bufs[0] != NULL);
 
         /* Allocate sequence lists for memory and file spaces */
-        if (NULL == (file_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+        if (NULL == (file_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
             HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, "couldn't allocate file selection iterator");
-        if (NULL == (mem_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+        if (NULL == (mem_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
             HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, "couldn't allocate memory selection iterator");
     }
 
@@ -1672,12 +1672,12 @@ done:
     if (file_iter) {
         if (file_iter_init && H5S_SELECT_ITER_RELEASE(file_iter) < 0)
             HGOTO_ERROR(H5E_INTERNAL, H5E_CANTFREE, FAIL, "can't release file selection iterator");
-        file_iter = H5FL_FREE(H5S_sel_iter_t, file_iter);
+        file_iter = H5FL_FREE_MT(H5S_sel_iter_t, file_iter);
     }
     if (mem_iter) {
         if (mem_iter_init && H5S_SELECT_ITER_RELEASE(mem_iter) < 0)
             HGOTO_ERROR(H5E_INTERNAL, H5E_CANTFREE, FAIL, "can't release memory selection iterator");
-        mem_iter = H5FL_FREE(H5S_sel_iter_t, mem_iter);
+        mem_iter = H5FL_FREE_MT(H5S_sel_iter_t, mem_iter);
     }
 
     /* Cleanup vector arrays */

--- a/src/H5FLprivate.h
+++ b/src/H5FLprivate.h
@@ -143,6 +143,25 @@ typedef struct H5FL_reg_head_t {
 #define H5FL_FREE(t, obj)     (t *)H5MM_xfree(obj)
 #endif /* H5_NO_REG_FREE_LISTS */
 
+/* These macros only compile to free-list operations if multithreading is disabled */
+#if !defined H5_NO_REG_FREE_LISTS && !defined H5_HAVE_MULTITHREAD
+#define H5FL_DEFINE_COMMON_MT(t) H5FL_DEFINE_COMMON(t)
+#define H5FL_DEFINE_MT(t)        H5FL_DEFINE(t)
+#define H5FL_EXTERN_MT(t)        H5FL_EXTERN(t)
+#define H5FL_DEFINE_STATIC_MT(t) H5FL_DEFINE_STATIC(t)
+#define H5FL_MALLOC_MT(t)        H5FL_MALLOC(t)
+#define H5FL_CALLOC_MT(t)        H5FL_CALLOC(t)
+#define H5FL_FREE_MT(t, obj)     H5FL_FREE(t, obj)
+#else /* !H5_NO_REG_FREE_LISTS && !H5_HAVE_MULTITHREAD */
+#define H5FL_DEFINE_COMMON_MT(t) int H5_ATTR_UNUSED H5FL_REG_NAME(t##_unused)
+#define H5FL_DEFINE_MT(t)        H5_DLL H5FL_DEFINE_COMMON_MT(t)
+#define H5FL_EXTERN_MT(t)        H5_DLLVAR H5FL_DEFINE_COMMON_MT(t)
+#define H5FL_DEFINE_STATIC_MT(t) static H5FL_DEFINE_COMMON_MT(t)
+#define H5FL_MALLOC_MT(t)        (t *)H5MM_malloc(sizeof(t))
+#define H5FL_CALLOC_MT(t)        (t *)H5MM_calloc(sizeof(t))
+#define H5FL_FREE_MT(t, obj)     (t *)H5MM_xfree(obj) 
+#endif /* !H5_NO_REG_FREE_LISTS && !H5_HAVE_MULTITHREAD */
+
 /* Data structure to store information about each block allocated */
 typedef union H5FL_blk_list_t {
     size_t                 size;    /* Size of the page */
@@ -217,6 +236,30 @@ typedef struct H5FL_blk_head_t {
 #define H5FL_BLK_REALLOC(t, blk, new_size) (uint8_t *)H5MM_realloc(blk, new_size)
 #define H5FL_BLK_AVAIL(t, size)            (FALSE)
 #endif /* H5_NO_BLK_FREE_LISTS */
+
+
+/* These macros only compile to free-list operations if multithreading is disabled */
+#if !defined H5_NO_BLK_FREE_LISTS && !defined H5_HAVE_MULTITHREAD
+#define H5FL_BLK_DEFINE_COMMON_MT(t) H5FL_BLK_DEFINE_COMMON(t)
+#define H5FL_BLK_DEFINE_MT(t)        H5FL_BLK_DEFINE(t)
+#define H5FL_BLK_EXTERN_MT(t)        H5FL_BLK_EXTERN(t)
+#define H5FL_BLK_DEFINE_STATIC_MT(t) H5FL_BLK_DEFINE_STATIC(t)
+#define H5FL_BLK_MALLOC_MT(t, size)  H5FL_BLK_MALLOC(t, size)
+#define H5FL_BLK_CALLOC_MT(t, size)  H5FL_BLK_CALLOC(t, size)
+#define H5FL_BLK_FREE_MT(t, blk)     H5FL_BLK_FREE(t, blk)
+#define H5FL_BLK_REALLOC_MT(t, blk, new_size) H5FL_BLK_REALLOC(t, blk, new_size)
+#define H5FL_BLK_AVAIL_MT(t, size)   H5FL_BLK_AVAIL(t, size)
+#else /* !H5_NO_BLK_FREE_LISTS && !H5_HAVE_MULTITHREAD */
+#define H5FL_BLK_DEFINE_COMMON_MT(t) int H5_ATTR_UNUSED H5FL_BLK_NAME(t##_unused)
+#define H5FL_BLK_DEFINE_MT(t)        H5_DLL H5FL_BLK_DEFINE_COMMON_MT(t)
+#define H5FL_BLK_EXTERN_MT(t)        H5_DLLVAR H5FL_BLK_DEFINE_COMMON_MT(t)
+#define H5FL_BLK_DEFINE_STATIC_MT(t) static H5FL_BLK_DEFINE_COMMON_MT(t)
+#define H5FL_BLK_MALLOC_MT(t, size)  (uint8_t *)H5MM_malloc(size)
+#define H5FL_BLK_CALLOC_MT(t, size)  (uint8_t *)H5MM_calloc(size)
+#define H5FL_BLK_FREE_MT(t, blk)     (uint8_t *)H5MM_xfree(blk)
+#define H5FL_BLK_REALLOC_MT(t, blk, new_size) (uint8_t *)H5MM_realloc(blk, new_size)
+#define H5FL_BLK_AVAIL_MT(t, size)   (FALSE)
+#endif /* !H5_NO_BLK_FREE_LISTS && !H5_HAVE_MULTITHREAD */
 
 /* Data structure to store each array in free list */
 typedef union H5FL_arr_list_t {
@@ -299,6 +342,32 @@ typedef struct H5FL_arr_head_t {
 #define H5FL_ARR_REALLOC(t, obj, new_elem) H5MM_realloc(obj, H5FL_ARR_NAME(t) + ((new_elem) * sizeof(t)))
 #endif /* H5_NO_ARR_FREE_LISTS */
 
+
+/* These macros only compile to free-list operations if multithreading is disabled */
+#if !defined H5_NO_ARR_FREE_LISTS && !defined H5_HAVE_MULTITHREAD
+#define H5FL_ARR_DEFINE_COMMON_MT(t, m) H5FL_ARR_DEFINE_COMMON(t, m)
+#define H5FL_ARR_DEFINE_MT(t, m)        H5FL_ARR_DEFINE(t, m)
+#define H5FL_BARR_DEFINE_MT(b, t, m)    H5FL_BARR_DEFINE(b, t, m)
+#define H5FL_ARR_EXTERN_MT(t)           H5FL_ARR_EXTERN(t)
+#define H5FL_ARR_DEFINE_STATIC_MT(t, m) H5FL_ARR_DEFINE_STATIC(t, m)
+#define H5FL_BARR_DEFINE_STATIC_MT(b, t, m) H5FL_BARR_DEFINE_STATIC(b, t, m)
+#define H5FL_ARR_MALLOC_MT(t, elem)     H5FL_ARR_MALLOC(t, elem)
+#define H5FL_ARR_CALLOC_MT(t, elem)     H5FL_ARR_CALLOC(t, elem)
+#define H5FL_ARR_FREE_MT(t, obj)        H5FL_ARR_FREE(t, obj)
+#define H5FL_ARR_REALLOC_MT(t, obj, new_elem) H5FL_ARR_REALLOC(t, obj, new_elem)
+#else /* !H5_NO_ARR_FREE_LISTS && !H5_HAVE_MULTITHREAD */
+#define H5FL_ARR_DEFINE_COMMON_MT(t, m) size_t H5FL_ARR_NAME(t##_unused)
+#define H5FL_ARR_DEFINE_MT(t, m)        H5FL_ARR_DEFINE_COMMON_MT(t, m) = 0
+#define H5FL_BARR_DEFINE_MT(b, t, m)    H5FL_ARR_DEFINE_COMMON_MT(t, m) = sizeof(b)
+#define H5FL_ARR_EXTERN_MT(t)           H5FL_ARR_DEFINE_COMMON_MT(t, m)
+#define H5FL_ARR_DEFINE_STATIC_MT(t, m) static H5FL_ARR_DEFINE_COMMON_MT(t, m) = 0
+#define H5FL_BARR_DEFINE_STATIC_MT(b, t, m) static H5FL_ARR_DEFINE_COMMON_MT(t, m) = sizeof(b)
+#define H5FL_ARR_MALLOC_MT(t, elem)     H5MM_malloc(H5FL_ARR_NAME(t) + ((elem) * sizeof(t)))
+#define H5FL_ARR_CALLOC_MT(t, elem)     H5MM_calloc(H5FL_ARR_NAME(t) + ((elem) * sizeof(t)))
+#define H5FL_ARR_FREE_MT(t, obj)        H5MM_xfree(obj)
+#define H5FL_ARR_REALLOC_MT(t, obj, new_elem) H5MM_realloc(obj, H5FL_ARR_NAME(t) + ((new_elem) * sizeof(t)))
+#endif /* !H5_NO_ARR_FREE_LISTS && !H5_HAVE_MULTITHREAD */
+
 /* Data structure for free list of sequence blocks */
 typedef struct H5FL_seq_head_t {
     H5FL_blk_head_t queue; /* Priority queue of sequence blocks */
@@ -351,6 +420,27 @@ typedef struct H5FL_seq_head_t {
 #define H5FL_SEQ_FREE(t, obj)              (t *)H5MM_xfree(obj)
 #define H5FL_SEQ_REALLOC(t, obj, new_elem) (t *)H5MM_realloc(obj, (new_elem) * sizeof(t))
 #endif /* H5_NO_SEQ_FREE_LISTS */
+
+/* These macros only compile to free-list operations if multithreading is disabled */
+#if !defined H5_NO_SEQ_FREE_LISTS && !defined H5_HAVE_MULTITHREAD
+#define H5FL_SEQ_DEFINE_COMMON_MT(t) H5FL_SEQ_DEFINE_COMMON(t)
+#define H5FL_SEQ_DEFINE_MT(t)        H5FL_SEQ_DEFINE(t)
+#define H5FL_SEQ_EXTERN_MT(t)        H5FL_SEQ_EXTERN(t)
+#define H5FL_SEQ_DEFINE_STATIC_MT(t) H5FL_SEQ_DEFINE_STATIC(t)
+#define H5FL_SEQ_MALLOC_MT(t, elem)  H5FL_SEQ_MALLOC(t, elem)
+#define H5FL_SEQ_CALLOC_MT(t, elem)  H5FL_SEQ_CALLOC(t, elem)
+#define H5FL_SEQ_FREE_MT(t, obj)     H5FL_SEQ_FREE(t, obj)
+#define H5FL_SEQ_REALLOC_MT(t, obj, new_elem) H5FL_SEQ_REALLOC(t, obj, new_elem)
+#else /* !H5_NO_SEQ_FREE_LISTS && !H5_HAVE_MULTITHREAD */
+#define H5FL_SEQ_DEFINE_COMMON_MT(t) int H5_ATTR_UNUSED H5FL_SEQ_NAME(t##_unused)
+#define H5FL_SEQ_DEFINE_MT(t)        H5_DLL H5FL_SEQ_DEFINE_COMMON_MT(t)
+#define H5FL_SEQ_EXTERN_MT(t)        H5_DLLVAR H5FL_SEQ_DEFINE_COMMON_MT(t)
+#define H5FL_SEQ_DEFINE_STATIC_MT(t) static H5FL_SEQ_DEFINE_COMMON_MT(t)
+#define H5FL_SEQ_MALLOC_MT(t, elem)  (t *)H5MM_malloc((elem) * sizeof(t))
+#define H5FL_SEQ_CALLOC_MT(t, elem)  (t *)H5MM_calloc((elem) * sizeof(t))
+#define H5FL_SEQ_FREE_MT(t, obj)     (t *)H5MM_xfree(obj)
+#define H5FL_SEQ_REALLOC_MT(t, obj, new_elem) (t *)H5MM_realloc(obj, (new_elem) * sizeof(t))
+#endif /* !H5_NO_SEQ_FREE_LISTS && !H5_HAVE_MULTITHREAD */
 
 /* Forward declarations of the data structures for free list block factory */
 typedef struct H5FL_fac_gc_node_t H5FL_fac_gc_node_t;

--- a/src/H5Ocopy_ref.c
+++ b/src/H5Ocopy_ref.c
@@ -341,7 +341,7 @@ H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, hid_t tid_src, const H5T_t *dt
     /* Use extra conversion buffer (TODO we should avoid using an extra buffer once the H5Ocopy code has been
      * reworked) */
     conv_buf_size = MAX(H5T_get_size(dt_src), H5T_get_size(dt_mem)) * ref_count;
-    if (NULL == (conv_buf = H5FL_BLK_MALLOC(type_conv, conv_buf_size)))
+    if (NULL == (conv_buf = H5FL_BLK_MALLOC_MT(type_conv, conv_buf_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for copy buffer");
     H5MM_memcpy(conv_buf, buf_src, nbytes_src);
 
@@ -385,7 +385,7 @@ H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, hid_t tid_src, const H5T_t *dt
     }     /* end for */
 
     /* Copy into another buffer, to reclaim memory later */
-    if (NULL == (reclaim_buf = H5FL_BLK_MALLOC(type_conv, conv_buf_size)))
+    if (NULL == (reclaim_buf = H5FL_BLK_MALLOC_MT(type_conv, conv_buf_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for copy buffer");
     H5MM_memcpy(reclaim_buf, conv_buf, conv_buf_size);
     if (NULL == (buf_space = H5S_create_simple((unsigned)1, buf_dim, NULL)))
@@ -411,9 +411,9 @@ done:
     if ((tid_dst > 0) && H5I_dec_ref(tid_dst) < 0)
         HDONE_ERROR(H5E_OHDR, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
     if (reclaim_buf)
-        reclaim_buf = H5FL_BLK_FREE(type_conv, reclaim_buf);
+        reclaim_buf = H5FL_BLK_FREE_MT(type_conv, reclaim_buf);
     if (conv_buf)
-        conv_buf = H5FL_BLK_FREE(type_conv, conv_buf);
+        conv_buf = H5FL_BLK_FREE_MT(type_conv, conv_buf);
     if ((dst_loc_id != H5I_INVALID_HID) && (H5I_dec_ref(dst_loc_id) < 0))
         HDONE_ERROR(H5E_OHDR, H5E_CANTDEC, FAIL, "unable to decrement refcount on location id");
 

--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -1424,7 +1424,7 @@ H5O__dtype_copy(const void *_src, void *_dst)
     /* Was result already allocated? */
     if (_dst) {
         *((H5T_t *)_dst) = *dst;
-        dst              = H5FL_FREE(H5T_t, dst);
+        dst              = H5FL_FREE_MT(H5T_t, dst);
         dst              = (H5T_t *)_dst;
     } /* end if */
 

--- a/src/H5Ofill.c
+++ b/src/H5Ofill.c
@@ -587,7 +587,7 @@ H5O__fill_copy(const void *_src, void *_dst)
 
                 /* Allocate a background buffer */
                 bkg_size = MAX(H5T_get_size(dst->type), H5T_get_size(src->type));
-                if (H5T_path_bkg(tpath) && NULL == (bkg_buf = H5FL_BLK_CALLOC(type_conv, bkg_size))) {
+                if (H5T_path_bkg(tpath) && NULL == (bkg_buf = H5FL_BLK_CALLOC_MT(type_conv, bkg_size))) {
                     H5I_dec_ref(src_id);
                     H5I_dec_ref(dst_id);
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
@@ -599,7 +599,7 @@ H5O__fill_copy(const void *_src, void *_dst)
                     H5I_dec_ref(src_id);
                     H5I_dec_ref(dst_id);
                     if (bkg_buf)
-                        bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
+                        bkg_buf = H5FL_BLK_FREE_MT(type_conv, bkg_buf);
                     HGOTO_ERROR(H5E_OHDR, H5E_CANTCONVERT, NULL, "datatype conversion failed");
                 } /* end if */
 
@@ -607,7 +607,7 @@ H5O__fill_copy(const void *_src, void *_dst)
                 H5I_dec_ref(src_id);
                 H5I_dec_ref(dst_id);
                 if (bkg_buf)
-                    bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
+                    bkg_buf = H5FL_BLK_FREE_MT(type_conv, bkg_buf);
             } /* end if */
         }     /* end if */
     }         /* end if */

--- a/src/H5Pdcpl.c
+++ b/src/H5Pdcpl.c
@@ -3038,20 +3038,20 @@ H5Pset_fill_value(hid_t plist_id, hid_t type_id, const void *value)
             uint8_t *bkg_buf = NULL; /* Background conversion buffer */
 
             /* Allocate a background buffer */
-            if (H5T_path_bkg(tpath) && NULL == (bkg_buf = H5FL_BLK_CALLOC(type_conv, (size_t)fill.size)))
+            if (H5T_path_bkg(tpath) && NULL == (bkg_buf = H5FL_BLK_CALLOC_MT(type_conv, (size_t)fill.size)))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
 
             /* Convert the fill value */
             if (H5T_convert(tpath, type_id, type_id, (size_t)1, (size_t)0, (size_t)0, fill.buf, bkg_buf) <
                 0) {
                 if (bkg_buf)
-                    bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
+                    bkg_buf = H5FL_BLK_FREE_MT(type_conv, bkg_buf);
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
             } /* end if */
 
             /* Release the background buffer */
             if (bkg_buf)
-                bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
+                bkg_buf = H5FL_BLK_FREE_MT(type_conv, bkg_buf);
         } /* end if */
     }     /* end if */
     else

--- a/src/H5Smpio.c
+++ b/src/H5Smpio.c
@@ -525,7 +525,7 @@ H5S__mpio_permute_type(H5S_t *space, size_t elmt_size, hsize_t **permute, MPI_Da
         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "can't allocate sequence lengths array");
 
     /* Allocate a selection iterator for iterating over the dataspace */
-    if (NULL == (sel_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (sel_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, FAIL, "couldn't allocate dataspace selection iterator");
 
     /* Initialize selection iterator */
@@ -604,7 +604,7 @@ done:
     if (sel_iter) {
         if (sel_iter_init && H5S_SELECT_ITER_RELEASE(sel_iter) < 0)
             HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, FAIL, "unable to release selection iterator");
-        sel_iter = H5FL_FREE(H5S_sel_iter_t, sel_iter);
+        sel_iter = H5FL_FREE_MT(H5S_sel_iter_t, sel_iter);
     }
 
     H5MM_free(len);
@@ -672,7 +672,7 @@ H5S__mpio_reg_hyper_type(H5S_t *space, size_t elmt_size, MPI_Datatype *new_type,
     bigio_count = H5_mpi_get_bigio_count();
 
     /* Allocate a selection iterator for iterating over the dataspace */
-    if (NULL == (sel_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (sel_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, FAIL, "couldn't allocate dataspace selection iterator");
 
     /* Initialize selection iterator */
@@ -961,7 +961,7 @@ done:
     if (sel_iter) {
         if (sel_iter_init && H5S_SELECT_ITER_RELEASE(sel_iter) < 0)
             HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, FAIL, "unable to release selection iterator");
-        sel_iter = H5FL_FREE(H5S_sel_iter_t, sel_iter);
+        sel_iter = H5FL_FREE_MT(H5S_sel_iter_t, sel_iter);
     }
 
 #ifdef H5S_DEBUG

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -1384,7 +1384,7 @@ H5S_select_iterate(void *buf, const H5T_t *type, H5S_t *space, const H5S_sel_ite
         HGOTO_ERROR(H5E_DATATYPE, H5E_BADSIZE, FAIL, "datatype size invalid");
 
     /* Allocate the selection iterator */
-    if (NULL == (iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, FAIL, "can't allocate selection iterator");
 
     /* Initialize iterator */
@@ -1499,7 +1499,7 @@ done:
     if (iter_init && H5S_SELECT_ITER_RELEASE(iter) < 0)
         HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, FAIL, "unable to release selection iterator");
     if (iter)
-        iter = H5FL_FREE(H5S_sel_iter_t, iter);
+        iter = H5FL_FREE_MT(H5S_sel_iter_t, iter);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5S_select_iterate() */
@@ -1728,9 +1728,9 @@ H5S_select_shape_same(H5S_t *space1, H5S_t *space2)
             hbool_t  first_block = TRUE;    /* Flag to indicate the first block */
 
             /* Allocate the selection iterators */
-            if (NULL == (iter_a = H5FL_MALLOC(H5S_sel_iter_t)))
+            if (NULL == (iter_a = H5FL_MALLOC_MT(H5S_sel_iter_t)))
                 HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, FAIL, "can't allocate selection iterator");
-            if (NULL == (iter_b = H5FL_MALLOC(H5S_sel_iter_t)))
+            if (NULL == (iter_b = H5FL_MALLOC_MT(H5S_sel_iter_t)))
                 HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, FAIL, "can't allocate selection iterator");
 
             /* Initialize iterator for each dataspace selection
@@ -1848,11 +1848,11 @@ done:
     if (iter_a_init && H5S_SELECT_ITER_RELEASE(iter_a) < 0)
         HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, FAIL, "unable to release selection iterator a");
     if (iter_a)
-        iter_a = H5FL_FREE(H5S_sel_iter_t, iter_a);
+        iter_a = H5FL_FREE_MT(H5S_sel_iter_t, iter_a);
     if (iter_b_init && H5S_SELECT_ITER_RELEASE(iter_b) < 0)
         HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, FAIL, "unable to release selection iterator b");
     if (iter_b)
-        iter_b = H5FL_FREE(H5S_sel_iter_t, iter_b);
+        iter_b = H5FL_FREE_MT(H5S_sel_iter_t, iter_b);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5S_select_shape_same() */
@@ -2312,7 +2312,7 @@ H5S_select_fill(const void *fill, size_t fill_size, H5S_t *space, void *_buf)
     assert(_buf);
 
     /* Allocate the selection iterator */
-    if (NULL == (iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, FAIL, "can't allocate selection iterator");
 
     /* Initialize iterator */
@@ -2371,7 +2371,7 @@ done:
     if (iter_init && H5S_SELECT_ITER_RELEASE(iter) < 0)
         HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, FAIL, "unable to release selection iterator");
     if (iter)
-        iter = H5FL_FREE(H5S_sel_iter_t, iter);
+        iter = H5FL_FREE_MT(H5S_sel_iter_t, iter);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5S_select_fill() */
@@ -2430,9 +2430,9 @@ H5S_select_project_intersection(H5S_t *src_space, H5S_t *dst_space, H5S_t *src_i
     assert(H5S_GET_SELECT_NPOINTS(src_space) == H5S_GET_SELECT_NPOINTS(dst_space));
     assert(H5S_GET_EXTENT_NDIMS(src_space) == H5S_GET_EXTENT_NDIMS(src_intersect_space));
 
-    if (NULL == (ss_iter = H5FL_CALLOC(H5S_sel_iter_t)))
+    if (NULL == (ss_iter = H5FL_CALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, FAIL, "can't allocate selection iterator");
-    if (NULL == (ds_iter = H5FL_CALLOC(H5S_sel_iter_t)))
+    if (NULL == (ds_iter = H5FL_CALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, FAIL, "can't allocate selection iterator");
 
     /* Create new space, using dst extent.  Start with "all" selection. */
@@ -2620,8 +2620,8 @@ done:
     if (ds_iter_init && H5S_SELECT_ITER_RELEASE(ds_iter) < 0)
         HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, FAIL, "unable to release destination selection iterator");
 
-    ss_iter = H5FL_FREE(H5S_sel_iter_t, ss_iter);
-    ds_iter = H5FL_FREE(H5S_sel_iter_t, ds_iter);
+    ss_iter = H5FL_FREE_MT(H5S_sel_iter_t, ss_iter);
+    ds_iter = H5FL_FREE_MT(H5S_sel_iter_t, ds_iter);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5S_select_project_intersection() */
@@ -2829,7 +2829,7 @@ H5Ssel_iter_create(hid_t space_id, size_t elmt_size, unsigned flags)
         HGOTO_ERROR(H5E_DATASPACE, H5E_BADVALUE, H5I_INVALID_HID, "invalid selection iterator flag");
 
     /* Allocate the iterator */
-    if (NULL == (sel_iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (sel_iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, H5I_INVALID_HID, "can't allocate selection iterator");
 
     /* Add flag to indicate that this iterator is from an API call */
@@ -2971,7 +2971,7 @@ H5S_select_contig_block(H5S_t *space, hbool_t *is_contig, hsize_t *off, size_t *
     assert(space);
 
     /* Allocate and initialize the iterator */
-    if (NULL == (iter = H5FL_MALLOC(H5S_sel_iter_t)))
+    if (NULL == (iter = H5FL_MALLOC_MT(H5S_sel_iter_t)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, FAIL, "can't allocate iterator");
     if (H5S_select_iter_init(iter, space, 1, 0) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, FAIL, "unable to initialize memory selection information");
@@ -2999,7 +2999,7 @@ done:
     if (iter_init && H5S_SELECT_ITER_RELEASE(iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (iter)
-        iter = H5FL_FREE(H5S_sel_iter_t, iter);
+        iter = H5FL_FREE_MT(H5S_sel_iter_t, iter);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5S_select_contig_block() */
@@ -3107,7 +3107,7 @@ H5S_sel_iter_close(H5S_sel_iter_t *sel_iter)
                     "problem releasing a selection iterator's type-specific info");
 
     /* Release the structure */
-    sel_iter = H5FL_FREE(H5S_sel_iter_t, sel_iter);
+    sel_iter = H5FL_FREE_MT(H5S_sel_iter_t, sel_iter);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -1419,8 +1419,8 @@ done:
             else {
                 if (dt->shared->owned_vol_obj && H5VL_free_object(dt->shared->owned_vol_obj) < 0)
                     HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "unable to close owned VOL object");
-                dt->shared = H5FL_FREE(H5T_shared_t, dt->shared);
-                dt         = H5FL_FREE(H5T_t, dt);
+                dt->shared = H5FL_FREE_MT(H5T_shared_t, dt->shared);
+                dt         = H5FL_FREE_MT(H5T_t, dt);
             } /* end else */
         }     /* end if */
     }         /* end if */
@@ -3291,8 +3291,8 @@ done:
         if (dt) {
             if (dt->shared->owned_vol_obj && H5VL_free_object(dt->shared->owned_vol_obj) < 0)
                 HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "unable to close owned VOL object");
-            dt->shared = H5FL_FREE(H5T_shared_t, dt->shared);
-            dt         = H5FL_FREE(H5T_t, dt);
+            dt->shared = H5FL_FREE_MT(H5T_shared_t, dt->shared);
+            dt         = H5FL_FREE_MT(H5T_t, dt);
         }
     }
 
@@ -3322,9 +3322,9 @@ H5T__initiate_copy(const H5T_t *old_dt)
     FUNC_ENTER_PACKAGE
 
     /* Allocate space */
-    if (NULL == (new_dt = H5FL_MALLOC(H5T_t)))
+    if (NULL == (new_dt = H5FL_MALLOC_MT(H5T_t)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, NULL, "H5T_t memory allocation failed");
-    if (NULL == (new_dt->shared = H5FL_MALLOC(H5T_shared_t)))
+    if (NULL == (new_dt->shared = H5FL_MALLOC_MT(H5T_shared_t)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, NULL, "H5T_shared_t memory allocation failed");
 
     /* Copy shared information */
@@ -3346,9 +3346,9 @@ done:
             if (new_dt->shared) {
                 if (new_dt->shared->owned_vol_obj && H5VL_free_object(new_dt->shared->owned_vol_obj) < 0)
                     HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "unable to close owned VOL object");
-                new_dt->shared = H5FL_FREE(H5T_shared_t, new_dt->shared);
+                new_dt->shared = H5FL_FREE_MT(H5T_shared_t, new_dt->shared);
             } /* end if */
-            new_dt = H5FL_FREE(H5T_t, new_dt);
+            new_dt = H5FL_FREE_MT(H5T_t, new_dt);
         } /* end if */
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -3673,8 +3673,8 @@ done:
             assert(new_dt->shared);
             if (new_dt->shared->owned_vol_obj && H5VL_free_object(new_dt->shared->owned_vol_obj) < 0)
                 HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "unable to close owned VOL object");
-            new_dt->shared = H5FL_FREE(H5T_shared_t, new_dt->shared);
-            new_dt         = H5FL_FREE(H5T_t, new_dt);
+            new_dt->shared = H5FL_FREE_MT(H5T_shared_t, new_dt->shared);
+            new_dt         = H5FL_FREE_MT(H5T_t, new_dt);
         } /* end if */
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -3739,7 +3739,7 @@ H5T_copy_reopen(H5T_t *old_dt)
              * Not terribly efficient. */
             if (new_dt->shared->owned_vol_obj && H5VL_free_object(new_dt->shared->owned_vol_obj) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "unable to close owned VOL object");
-            new_dt->shared = H5FL_FREE(H5T_shared_t, new_dt->shared);
+            new_dt->shared = H5FL_FREE_MT(H5T_shared_t, new_dt->shared);
             new_dt->shared = reopened_fo;
 
             reopened_fo->fo_count++;
@@ -3777,8 +3777,8 @@ done:
             assert(new_dt->shared);
             if (new_dt->shared->owned_vol_obj && H5VL_free_object(new_dt->shared->owned_vol_obj) < 0)
                 HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "unable to close owned VOL object");
-            new_dt->shared = H5FL_FREE(H5T_shared_t, new_dt->shared);
-            new_dt         = H5FL_FREE(H5T_t, new_dt);
+            new_dt->shared = H5FL_FREE_MT(H5T_shared_t, new_dt->shared);
+            new_dt         = H5FL_FREE_MT(H5T_t, new_dt);
         } /* end if */
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -3846,14 +3846,14 @@ H5T__alloc(void)
     FUNC_ENTER_PACKAGE
 
     /* Allocate & initialize datatype wrapper info */
-    if (NULL == (dt = H5FL_CALLOC(H5T_t)))
+    if (NULL == (dt = H5FL_CALLOC_MT(H5T_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
     H5O_loc_reset(&(dt->oloc));
     H5G_name_reset(&(dt->path));
     H5O_msg_reset_share(H5O_DTYPE_ID, dt);
 
     /* Allocate & initialize shared datatype structure */
-    if (NULL == (dt->shared = H5FL_CALLOC(H5T_shared_t)))
+    if (NULL == (dt->shared = H5FL_CALLOC_MT(H5T_shared_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
     dt->shared->version = H5O_DTYPE_VERSION_1;
 
@@ -3868,9 +3868,9 @@ done:
         if (dt) {
             if (dt->shared) {
                 assert(!dt->shared->owned_vol_obj);
-                dt->shared = H5FL_FREE(H5T_shared_t, dt->shared);
+                dt->shared = H5FL_FREE_MT(H5T_shared_t, dt->shared);
             } /* end if */
-            dt = H5FL_FREE(H5T_t, dt);
+            dt = H5FL_FREE_MT(H5T_t, dt);
         } /* end if */
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -3985,14 +3985,14 @@ H5T_close_real(H5T_t *dt)
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTFREE, FAIL, "unable to free datatype");
 
         assert(!dt->shared->owned_vol_obj);
-        dt->shared = H5FL_FREE(H5T_shared_t, dt->shared);
+        dt->shared = H5FL_FREE_MT(H5T_shared_t, dt->shared);
     } /* end if */
     else
         /* Free the group hier. path since we're not calling H5T__free() */
         H5G_name_free(&(dt->path));
 
     /* Free the 'top' datatype struct */
-    dt = H5FL_FREE(H5T_t, dt);
+    dt = H5FL_FREE_MT(H5T_t, dt);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -78,10 +78,10 @@ static H5T_t *H5T__open_oid(const H5G_loc_t *loc);
 /*******************/
 
 /* Declare a free list to manage the H5VL_t struct */
-H5FL_EXTERN(H5VL_t);
+H5FL_EXTERN_MT(H5VL_t);
 
 /* Declare a free list to manage the H5VL_object_t struct */
-H5FL_EXTERN(H5VL_object_t);
+H5FL_EXTERN_MT(H5VL_object_t);
 
 /*-------------------------------------------------------------------------
  * Function:    H5T__commit_api_common

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -1096,7 +1096,7 @@ H5T_open(const H5G_loc_t *loc)
         dt->shared->fo_count = 1;
     } /* end if */
     else {
-        if (NULL == (dt = H5FL_MALLOC(H5T_t)))
+        if (NULL == (dt = H5FL_MALLOC_MT(H5T_t)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "can't allocate space for datatype");
         dt->vol_obj = NULL;
 
@@ -1151,13 +1151,13 @@ done:
             if (shared_fo == NULL) { /* Need to free shared file object */
                 if (dt->shared->owned_vol_obj && H5VL_free_object(dt->shared->owned_vol_obj) < 0)
                     HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "unable to close owned VOL object");
-                dt->shared = H5FL_FREE(H5T_shared_t, dt->shared);
+                dt->shared = H5FL_FREE_MT(H5T_shared_t, dt->shared);
             } /* end if */
 
             H5O_loc_free(&(dt->oloc));
             H5G_name_free(&(dt->path));
 
-            dt = H5FL_FREE(H5T_t, dt);
+            dt = H5FL_FREE_MT(H5T_t, dt);
         } /* end if */
 
         if (shared_fo)

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -460,8 +460,8 @@ H5_DLLVAR double H5T_NATIVE_LDOUBLE_POS_INF_g;
 H5_DLLVAR double H5T_NATIVE_LDOUBLE_NEG_INF_g;
 
 /* Declare extern the free lists for H5T_t's and H5T_shared_t's */
-H5FL_EXTERN(H5T_t);
-H5FL_EXTERN(H5T_shared_t);
+H5FL_EXTERN_MT(H5T_t);
+H5FL_EXTERN_MT(H5T_shared_t);
 
 /* Common functions */
 H5_DLL herr_t H5T__init_native(void);

--- a/src/H5VLdyn_ops.c
+++ b/src/H5VLdyn_ops.c
@@ -103,7 +103,7 @@ static H5_ATOMIC_SPECIFIER(H5SL_t *) H5VL_opt_ops_g[H5VL_SUBCLS_TOKEN + 1] =
     };
 
 /* Declare a free list to manage the H5VL_class_t struct */
-H5FL_DEFINE_STATIC(H5VL_dyn_op_t);
+H5FL_DEFINE_STATIC_MT(H5VL_dyn_op_t);
 
 /*---------------------------------------------------------------------------
  * Function:    H5VL__release_dyn_op
@@ -121,7 +121,7 @@ H5VL__release_dyn_op(H5VL_dyn_op_t *dyn_op)
     FUNC_ENTER_PACKAGE_NOERR
 
     H5MM_xfree(dyn_op->op_name);
-    H5FL_FREE(H5VL_dyn_op_t, dyn_op);
+    H5FL_FREE_MT(H5VL_dyn_op_t, dyn_op);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* H5VL__release_dyn_op() */
@@ -245,7 +245,7 @@ H5VL__register_opt_operation(H5VL_subclass_t subcls, const char *op_name, int *o
     } /* end else */
 
     /* Register new operation */
-    if (NULL == (new_op = H5FL_CALLOC(H5VL_dyn_op_t)))
+    if (NULL == (new_op = H5FL_CALLOC_MT(H5VL_dyn_op_t)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, FAIL, "can't allocate memory for dynamic operation info");
     if (NULL == (new_op->op_name = H5MM_strdup(op_name)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, FAIL, "can't allocate name for dynamic operation info");

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -136,16 +136,16 @@ static const H5I_class_t H5I_VOL_CLS[1] = {{
 }};
 
 /* Declare a free list to manage the H5VL_class_t struct */
-H5FL_DEFINE_STATIC(H5VL_class_t);
+H5FL_DEFINE_STATIC_MT(H5VL_class_t);
 
 /* Declare a free list to manage the H5VL_t struct */
-H5FL_DEFINE(H5VL_t);
+H5FL_DEFINE_MT(H5VL_t);
 
 /* Declare a free list to manage the H5VL_object_t struct */
-H5FL_DEFINE(H5VL_object_t);
+H5FL_DEFINE_MT(H5VL_object_t);
 
 /* Declare a free list to manage the H5VL_wrap_ctx_t struct */
-H5FL_DEFINE_STATIC(H5VL_wrap_ctx_t);
+H5FL_DEFINE_STATIC_MT(H5VL_wrap_ctx_t);
 
 /* Default VOL connector */
 static H5VL_connector_prop_t H5VL_def_conn_s = {-1, NULL};
@@ -318,7 +318,7 @@ H5VL__free_cls(H5VL_class_t *cls, void H5_ATTR_UNUSED **request)
 
     /* Release the class */
     H5MM_xfree_const(cls->name);
-    H5FL_FREE(H5VL_class_t, cls);
+    H5FL_FREE_MT(H5VL_class_t, cls);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -544,7 +544,7 @@ H5VL__new_vol_obj(H5I_type_t type, void *object, H5VL_t *vol_connector, hbool_t 
     conn_rc_incr = TRUE;
 
     /* Create the new VOL object */
-    if (NULL == (new_vol_obj = H5FL_CALLOC(H5VL_object_t)))
+    if (NULL == (new_vol_obj = H5FL_CALLOC_MT(H5VL_object_t)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, NULL, "can't allocate memory for VOL object");
     new_vol_obj->connector = vol_connector;
     if (wrap_obj) {
@@ -578,7 +578,7 @@ done:
             HDONE_ERROR(H5E_VOL, H5E_CANTDEC, NULL, "unable to decrement ref count on VOL connector");
         
         if (new_vol_obj)
-            new_vol_obj = H5FL_FREE(H5VL_object_t, new_vol_obj);
+            new_vol_obj = H5FL_FREE_MT(H5VL_object_t, new_vol_obj);
     } /* end if */
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -726,7 +726,7 @@ H5VL_register(H5I_type_t type, void *object, H5VL_t *vol_connector, hbool_t app_
 
 done:
     if (ret_value < 0 && vol_obj)
-        vol_obj = H5FL_FREE(H5VL_object_t, vol_obj);
+        vol_obj = H5FL_FREE_MT(H5VL_object_t, vol_obj);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5VL_register() */
@@ -773,7 +773,7 @@ H5VL_register_using_existing_id(H5I_type_t type, void *object, H5VL_t *vol_conne
 
 done:
     if (ret_value < 0 && new_vol_obj)
-        new_vol_obj = H5FL_FREE(H5VL_object_t, new_vol_obj);
+        new_vol_obj = H5FL_FREE_MT(H5VL_object_t, new_vol_obj);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5VL_register_using_existing_id() */
@@ -809,7 +809,7 @@ H5VL_new_connector(hid_t connector_id)
         HGOTO_ERROR(H5E_VOL, H5E_BADTYPE, NULL, "not a VOL connector ID");
 
     /* Setup VOL info struct */
-    if (NULL == (connector = H5FL_CALLOC(H5VL_t)))
+    if (NULL == (connector = H5FL_CALLOC_MT(H5VL_t)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, NULL, "can't allocate VOL connector struct");
     connector->cls = cls;
     connector->id  = connector_id;
@@ -839,8 +839,8 @@ done:
         }
        
         /* Free VOL connector struct */
-        if (connector)
-            connector = H5FL_FREE(H5VL_t, connector);
+        if (NULL != connector)
+            connector = H5FL_FREE_MT(H5VL_t, connector);
     } /* end if */
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -912,7 +912,7 @@ H5VL_create_object(void *object, H5VL_t *vol_connector)
 
     /* Set up VOL object for the passed-in data */
     /* (Does not wrap object, since it's from a VOL callback) */
-    if (NULL == (ret_value = H5FL_CALLOC(H5VL_object_t)))
+    if (NULL == (ret_value = H5FL_CALLOC_MT(H5VL_object_t)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, NULL, "can't allocate memory for VOL object");
 
     /* Bump the reference count on the VOL connector */
@@ -963,7 +963,7 @@ H5VL_create_object_using_vol_id(H5I_type_t type, void *obj, hid_t connector_id)
         HGOTO_ERROR(H5E_VOL, H5E_BADTYPE, NULL, "not a VOL connector ID");
 
     /* Setup VOL info struct */
-    if (NULL == (connector = H5FL_CALLOC(H5VL_t)))
+    if (NULL == (connector = H5FL_CALLOC_MT(H5VL_t)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, NULL, "can't allocate VOL info struct");
     connector->cls = cls;
     connector->id  = connector_id;
@@ -994,8 +994,8 @@ done:
         }
 
         /* Free VOL connector struct */
-        if (connector)
-            connector = H5FL_FREE(H5VL_t, connector);
+        if (NULL != connector)
+            connector = H5FL_FREE_MT(H5VL_t, connector);
     } /* end if */
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1086,7 +1086,7 @@ H5VL_conn_dec_rc(H5VL_t *connector)
         assert(connector->nrefs == 0);
 #endif
 
-        H5FL_FREE(H5VL_t, connector);
+        H5FL_FREE_MT(H5VL_t, connector);
 
         /* Set return value */
         ret_value = 0;
@@ -1182,7 +1182,7 @@ H5VL_free_object(H5VL_object_t *vol_obj)
         /* Sanity Check */
         assert(atomic_load(&vol_obj->rc) == 0);
 
-        vol_obj = H5FL_FREE(H5VL_object_t, vol_obj); 
+        vol_obj = H5FL_FREE_MT(H5VL_object_t, vol_obj); 
     }
 
 #else
@@ -1198,7 +1198,7 @@ H5VL_free_object(H5VL_object_t *vol_obj)
         /* Sanity Check */
         assert(vol_obj->rc == 0);
 
-        vol_obj = H5FL_FREE(H5VL_object_t, vol_obj);
+        vol_obj = H5FL_FREE_MT(H5VL_object_t, vol_obj);
     } /* end if */
 
 #endif
@@ -1338,7 +1338,7 @@ H5VL__register_connector(const void *_cls, hbool_t app_ref, hid_t vipl_id)
     assert(cls);
 
     /* Copy the class structure so the caller can reuse or free it */
-    if (NULL == (saved = H5FL_MALLOC(H5VL_class_t)))
+    if (NULL == (saved = H5FL_MALLOC_MT(H5VL_class_t)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, H5I_INVALID_HID,
                     "memory allocation failed for VOL connector class struct");
     H5MM_memcpy(saved, cls, sizeof(H5VL_class_t));
@@ -1359,7 +1359,7 @@ done:
         if (saved->name)
             H5MM_xfree_const(saved->name);
 
-        H5FL_FREE(H5VL_class_t, saved);
+        H5FL_FREE_MT(H5VL_class_t, saved);
     } /* end if */
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -2643,7 +2643,7 @@ H5VL__free_vol_wrapper(H5VL_wrap_ctx_t *vol_wrap_ctx)
         HGOTO_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector");
 
     /* Release object wrapping context */
-    H5FL_FREE(H5VL_wrap_ctx_t, vol_wrap_ctx);
+    H5FL_FREE_MT(H5VL_wrap_ctx_t, vol_wrap_ctx);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -2690,6 +2690,10 @@ H5VL_set_vol_wrapper(const H5VL_object_t *vol_obj)
         HGOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "can't set VOL object wrap context");
 
 done:
+    if (ret_value < 0 && vol_wrap_ctx)
+        /* Release object wrapping context */
+        H5FL_FREE_MT(H5VL_wrap_ctx_t, vol_wrap_ctx);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5VL_set_vol_wrapper() */
 
@@ -2726,7 +2730,7 @@ H5VL__new_vol_wrapper(const H5VL_object_t *vol_obj, H5VL_wrap_ctx_t **wrap_ctx_o
     } /* end if */
 
     /* Allocate VOL object wrapper context */
-    if (NULL == (new_wrap_ctx = H5FL_MALLOC(H5VL_wrap_ctx_t)))
+    if (NULL == (new_wrap_ctx = H5FL_MALLOC_MT(H5VL_wrap_ctx_t)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, FAIL, "can't allocate VOL wrap context");
 
     /* Increment the outstanding objects that are using the connector */
@@ -2747,7 +2751,7 @@ H5VL__new_vol_wrapper(const H5VL_object_t *vol_obj, H5VL_wrap_ctx_t **wrap_ctx_o
 done:
     if (ret_value < 0 && new_wrap_ctx)
         /* Release object wrapping context */
-        H5FL_FREE(H5VL_wrap_ctx_t, new_wrap_ctx);
+        H5FL_FREE_MT(H5VL_wrap_ctx_t, new_wrap_ctx);
 
     if (ret_value < 0 && conn_incr_rc)
         /* Undo ref count increment on connector */

--- a/src/H5detect.c
+++ b/src/H5detect.c
@@ -41,6 +41,7 @@ static const char *FileHeader = "\n\
  */
 #undef NDEBUG
 #include "H5private.h"
+#include "H5MMprivate.h"
 /* Do NOT use fprintf in this file as it is not linked with the library,
  * which contains the H5system.c file in which the function is defined.
  */
@@ -423,8 +424,8 @@ dt->shared->u.atomic.u.f.pad = H5T_PAD_ZERO;\n",
 done:\n\
     if(ret_value < 0) {\n\
         if(dt != NULL) {\n\
-            dt->shared = H5FL_FREE(H5T_shared_t, dt->shared);\n\
-            dt = H5FL_FREE(H5T_t, dt);\n\
+            dt->shared = H5FL_FREE_MT(H5T_shared_t, dt->shared);\n\
+            dt = H5FL_FREE_MT(H5T_t, dt);\n\
         } /* end if */\n\
     } /* end if */\n\
 \n\


### PR DESCRIPTION
These macros replace the default free list macros in modules that will have the global mutex removed from many or all operations.