### PR TITLE
Share API test container functions between parallel/nonparallel tests

### DIFF
--- a/test/API/H5_api_async_test.c
+++ b/test/API/H5_api_async_test.c
@@ -2524,11 +2524,11 @@ test_file_cleanup(TestParams_t H5_ATTR_UNUSED *params)
         return SKIP;
     }
 
-    remove_test_file(ASYNC_API_TEST_FILE);
+    remove_test_file(ASYNC_API_TEST_FILE, H5P_DEFAULT);
 
     for (i = 0; i <= max_printf_file; i++) {
         snprintf(file_name, sizeof(file_name), ASYNC_API_TEST_FILE_PRINTF, i);
-        remove_test_file(file_name);
+        remove_test_file(file_name, H5P_DEFAULT);
     }
 
     return SUCCEED;

--- a/test/API/H5_api_link_test.c
+++ b/test/API/H5_api_link_test.c
@@ -801,7 +801,7 @@ test_create_hard_link_invalid_params(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -814,7 +814,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(ext_file_id);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -1764,7 +1764,7 @@ test_create_external_link(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -1777,7 +1777,7 @@ error:
         H5Gclose(group_id);
         H5Gclose(container_group);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -1889,7 +1889,7 @@ test_create_external_link_dangling(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(ext_file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -1903,7 +1903,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(file_id);
         H5Fclose(ext_file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -2199,11 +2199,11 @@ test_create_external_link_multi(TestParams_t *params)
     }
     SUBTEST_END(params);
 
-    if (remove_test_file(ext_link_filename1) < 0)
+    if (remove_test_file(ext_link_filename1, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename2) < 0)
+    if (remove_test_file(ext_link_filename2, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename3) < 0)
+    if (remove_test_file(ext_link_filename3, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
 
     free(ext_link_filename1);
@@ -2221,9 +2221,9 @@ error:
         H5Gclose(group_id3);
         H5Gclose(container_group);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename1);
-        remove_test_file(ext_link_filename2);
-        remove_test_file(ext_link_filename3);
+        remove_test_file(ext_link_filename1, H5P_DEFAULT);
+        remove_test_file(ext_link_filename2, H5P_DEFAULT);
+        remove_test_file(ext_link_filename3, H5P_DEFAULT);
         free(ext_link_filename1);
         free(ext_link_filename2);
         free(ext_link_filename3);
@@ -2462,9 +2462,9 @@ test_create_external_link_ping_pong(TestParams_t *params)
     }
     SUBTEST_END(params);
 
-    if (remove_test_file(ext_link_filename1) < 0)
+    if (remove_test_file(ext_link_filename1, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename2) < 0)
+    if (remove_test_file(ext_link_filename2, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
 
     free(ext_link_filename1);
@@ -2478,8 +2478,8 @@ error:
         H5Gclose(group_id);
         H5Gclose(group_id2);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename1);
-        remove_test_file(ext_link_filename2);
+        remove_test_file(ext_link_filename1, H5P_DEFAULT);
+        remove_test_file(ext_link_filename2, H5P_DEFAULT);
         free(ext_link_filename1);
         free(ext_link_filename2);
     }
@@ -2707,7 +2707,7 @@ test_create_external_link_invalid_params(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -2719,7 +2719,7 @@ error:
         H5Gclose(group_id);
         H5Gclose(container_group);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -5905,7 +5905,7 @@ test_delete_link(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(ext_file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -5920,7 +5920,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(ext_file_id);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -7395,7 +7395,7 @@ test_copy_link(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(ext_file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -7410,7 +7410,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(ext_file_id);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -7703,7 +7703,7 @@ test_copy_link_invalid_params(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(ext_file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -7718,7 +7718,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(ext_file_id);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -8921,7 +8921,7 @@ test_move_link(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(ext_file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -8936,7 +8936,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(file_id);
         H5Fclose(ext_file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -9593,7 +9593,7 @@ test_move_link_invalid_params(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(ext_file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -9608,7 +9608,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(ext_file_id);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -11344,7 +11344,7 @@ test_get_link_val(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(ext_file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -11359,7 +11359,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(ext_file_id);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -13870,7 +13870,7 @@ test_get_link_info(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -13885,7 +13885,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(ext_file_id);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -15995,7 +15995,7 @@ test_get_link_name(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -16010,7 +16010,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(ext_file_id);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -17118,7 +17118,7 @@ test_link_iterate_external_links(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -17131,7 +17131,7 @@ error:
         H5Gclose(group_id);
         H5Gclose(container_group);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -17582,7 +17582,7 @@ test_link_iterate_mixed_links(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -17598,7 +17598,7 @@ error:
         H5Gclose(group_id);
         H5Gclose(container_group);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -17927,7 +17927,7 @@ test_link_iterate_invalid_params(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -17942,7 +17942,7 @@ error:
         H5Gclose(group_id);
         H5Gclose(container_group);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -19051,7 +19051,7 @@ test_link_visit_external_links_no_cycles(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -19065,7 +19065,7 @@ error:
         H5Gclose(group_id);
         H5Gclose(container_group);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -19475,7 +19475,7 @@ test_link_visit_mixed_links_no_cycles(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -19493,7 +19493,7 @@ error:
         H5Gclose(group_id);
         H5Gclose(container_group);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -20764,7 +20764,7 @@ test_link_visit_mixed_links_cycles(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -20779,7 +20779,7 @@ error:
         H5Gclose(group_id);
         H5Gclose(container_group);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY
@@ -21151,7 +21151,7 @@ test_link_visit_invalid_params(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(ext_link_filename) < 0)
+    if (remove_test_file(ext_link_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(ext_link_filename);
 
@@ -21168,7 +21168,7 @@ error:
         H5Gclose(group_id);
         H5Gclose(container_group);
         H5Fclose(file_id);
-        remove_test_file(ext_link_filename);
+        remove_test_file(ext_link_filename, H5P_DEFAULT);
         free(ext_link_filename);
     }
     H5E_END_TRY

--- a/test/API/H5_api_object_test.c
+++ b/test/API/H5_api_object_test.c
@@ -3964,7 +3964,7 @@ test_object_copy_between_files(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(obj_copy_filename) < 0)
+    if (remove_test_file(obj_copy_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(obj_copy_filename);
 
@@ -3988,7 +3988,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(file_id2);
         H5Fclose(file_id);
-        remove_test_file(obj_copy_filename);
+        remove_test_file(obj_copy_filename, H5P_DEFAULT);
         free(obj_copy_filename);
     }
     H5E_END_TRY
@@ -4733,7 +4733,7 @@ test_object_visit(TestParams_t *params)
         TESTFRAME_TEST_ERROR(params);
     if (H5Fclose(file_id2) < 0)
         TESTFRAME_TEST_ERROR(params);
-    if (remove_test_file(visit_filename) < 0)
+    if (remove_test_file(visit_filename, H5P_DEFAULT) < 0)
         TESTFRAME_TEST_ERROR(params);
     free(visit_filename);
 
@@ -4756,7 +4756,7 @@ error:
         H5Gclose(container_group);
         H5Fclose(file_id);
         H5Fclose(file_id2);
-        remove_test_file(visit_filename);
+        remove_test_file(visit_filename, H5P_DEFAULT);
         free(visit_filename);
     }
     H5E_END_TRY;

--- a/test/API/H5_api_test.c
+++ b/test/API/H5_api_test.c
@@ -66,11 +66,6 @@ static char *H5_api_test_base_filename_g = NULL;
 
 const char *test_path_prefix;
 
-static herr_t H5_api_test_setup_container_names(const char *prefix, const char *filename);
-
-static int H5_api_test_create_containers(char **filenames, size_t num_filenames, uint64_t vol_cap_flags);
-static int H5_api_test_destroy_container_files(char **filenames, size_t num_filenames);
-
 /* X-macro to define the following for each test:
  * - enum type
  * - name
@@ -402,7 +397,7 @@ main(int argc, char **argv)
     if (GetTestCleanup()) {
         printf("Deleting container file(s) for tests\n\n");
 
-        if (H5_api_test_destroy_container_files(H5_api_test_filenames_g, H5_api_test_num_filenames_g) < 0) {
+        if (H5_api_test_destroy_container_files(H5_api_test_filenames_g, H5_api_test_num_filenames_g, H5P_DEFAULT) < 0) {
             TestErrPrintf("Error cleaning up testing container files\n");
             goto done;
         }
@@ -440,146 +435,4 @@ done:
         exit(EXIT_FAILURE);
     else
         exit(EXIT_SUCCESS);
-}
-
-/* Create the API container test file(s), one per thread.
- * Returns negative on failure, 0 on success */
-static int
-H5_api_test_create_containers(char **filenames, size_t num_filenames, uint64_t vol_cap_flags)
-{
-    hid_t file_id  = H5I_INVALID_HID;
-    hid_t group_id = H5I_INVALID_HID;
-
-    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
-        TestErrPrintf("VOL connector doesn't support file creation\n");
-        goto error;
-    }
-
-    for (size_t i = 0; i < num_filenames; i++) {
-        if ((file_id = H5Fcreate(filenames[i], H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
-            TestErrPrintf("Couldn't create testing container file '%s'\n", filenames[i]);
-            goto error;
-        }
-
-        /* Create container groups for each of the test interfaces
-         * (group, attribute, dataset, etc.).
-         */
-        if (vol_cap_flags & H5VL_CAP_FLAG_GROUP_BASIC) {
-            if ((group_id = H5Gcreate2(file_id, GROUP_TEST_GROUP_NAME,
-                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
-                TestErrPrintf("Couldn't create container group '%s'\n", GROUP_TEST_GROUP_NAME);
-                goto error;
-            }
-            if (H5Gclose(group_id) < 0) {
-                TestErrPrintf("Couldn't close container group '%s'\n", GROUP_TEST_GROUP_NAME);
-                goto error;
-            }
-
-            if ((group_id = H5Gcreate2(file_id, ATTRIBUTE_TEST_GROUP_NAME,
-                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
-                TestErrPrintf("Couldn't create container group '%s'\n", ATTRIBUTE_TEST_GROUP_NAME);
-                goto error;
-            }
-            if (H5Gclose(group_id) < 0) {
-                TestErrPrintf("Couldn't close container group '%s'\n", ATTRIBUTE_TEST_GROUP_NAME);
-                goto error;
-            }
-
-            if ((group_id = H5Gcreate2(file_id, DATASET_TEST_GROUP_NAME,
-                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
-                TestErrPrintf("Couldn't create container group '%s'\n", DATASET_TEST_GROUP_NAME);
-                goto error;
-            }
-            if (H5Gclose(group_id) < 0) {
-                TestErrPrintf("Couldn't close container group '%s'\n", DATASET_TEST_GROUP_NAME);
-                goto error;
-            }
-
-            if ((group_id = H5Gcreate2(file_id, DATATYPE_TEST_GROUP_NAME,
-                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
-                TestErrPrintf("Couldn't create container group '%s'\n", DATATYPE_TEST_GROUP_NAME);
-                goto error;
-            }
-            if (H5Gclose(group_id) < 0) {
-                TestErrPrintf("Couldn't close container group '%s'\n", DATATYPE_TEST_GROUP_NAME);
-                goto error;
-            }
-
-            if ((group_id = H5Gcreate2(file_id, LINK_TEST_GROUP_NAME,
-                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
-                TestErrPrintf("Couldn't create container group '%s'\n", LINK_TEST_GROUP_NAME);
-                goto error;
-            }
-            if (H5Gclose(group_id) < 0) {
-                TestErrPrintf("Couldn't close container group '%s'\n", LINK_TEST_GROUP_NAME);
-                goto error;
-            }
-
-            if ((group_id = H5Gcreate2(file_id, OBJECT_TEST_GROUP_NAME,
-                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
-                TestErrPrintf("Couldn't create container group '%s'\n", OBJECT_TEST_GROUP_NAME);
-                goto error;
-            }
-            if (H5Gclose(group_id) < 0) {
-                TestErrPrintf("Couldn't close container group '%s'\n", OBJECT_TEST_GROUP_NAME);
-                goto error;
-            }
-
-            if ((group_id = H5Gcreate2(file_id, MISCELLANEOUS_TEST_GROUP_NAME,
-                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
-                TestErrPrintf("Couldn't create container group '%s'\n", MISCELLANEOUS_TEST_GROUP_NAME);
-                goto error;
-            }
-            if (H5Gclose(group_id) < 0) {
-                TestErrPrintf("Couldn't close container group '%s'\n", MISCELLANEOUS_TEST_GROUP_NAME);
-                goto error;
-            }
-        }
-
-        if (H5Fclose(file_id) < 0) {
-            TestErrPrintf("Couldn't close testing container file '%s'\n", filenames[i]);
-            goto error;
-        }
-    }
-
-    if (num_filenames == 1)
-        printf("Created container file '%s'\n\n", filenames[0]);
-    else if (num_filenames > 1)
-        printf("Created container files '%s' through '%s'\n\n", filenames[0], filenames[num_filenames - 1]);
-
-    return 0;
-
-error:
-    H5E_BEGIN_TRY
-    {
-        H5Gclose(group_id);
-        H5Fclose(file_id);
-        for (size_t i = 0; i < num_filenames; i++)
-            H5Fdelete(filenames[i], H5P_DEFAULT);
-    }
-    H5E_END_TRY
-
-    return -1;
-}
-
-/* Delete the API test container file(s).
- * Returns negative on failure, 0 on success */
-static int
-H5_api_test_destroy_container_files(char **filenames, size_t num_filenames)
-{
-    int ret_value = 0;
-
-    if (!(vol_cap_flags_g & H5VL_CAP_FLAG_FILE_BASIC)) {
-        TestErrPrintf("VOL connector doesn't support file deletion\n");
-        goto error;
-    }
-
-    for (size_t i = 0; i < num_filenames; i++)
-        if (remove_test_file(filenames[i]) < 0)
-            ret_value = -1;
-
-    return ret_value;
-
-error:
-    return -1;
 }

--- a/test/API/H5_api_test_util.c
+++ b/test/API/H5_api_test_util.c
@@ -725,7 +725,7 @@ done:
  * of testing files has not been disabled.
  */
 herr_t
-remove_test_file(const char *filename)
+remove_test_file(const char *filename, hid_t fapl_id)
 {
     herr_t ret_value = SUCCEED;
 
@@ -734,8 +734,8 @@ remove_test_file(const char *filename)
 
     H5E_BEGIN_TRY
     {
-        if (H5Fis_accessible(filename, H5P_DEFAULT) > 0) {
-            if (H5Fdelete(filename, H5P_DEFAULT) < 0) {
+        if (H5Fis_accessible(filename, fapl_id) > 0) {
+            if (H5Fdelete(filename, fapl_id) < 0) {
                 TestErrPrintf("couldn't remove file '%s'\n", filename);
                 ret_value = FAIL;
                 goto done;
@@ -746,4 +746,146 @@ remove_test_file(const char *filename)
 
 done:
     return ret_value;
+}
+
+/* Create the API container test file(s), one per thread.
+ * Returns negative on failure, 0 on success */
+int
+H5_api_test_create_containers(char **filenames, size_t num_filenames, uint64_t vol_cap_flags)
+{
+    hid_t file_id  = H5I_INVALID_HID;
+    hid_t group_id = H5I_INVALID_HID;
+
+    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
+        TestErrPrintf("VOL connector doesn't support file creation\n");
+        goto error;
+    }
+
+    for (size_t i = 0; i < num_filenames; i++) {
+        if ((file_id = H5Fcreate(filenames[i], H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
+            TestErrPrintf("Couldn't create testing container file '%s'\n", filenames[i]);
+            goto error;
+        }
+
+        /* Create container groups for each of the test interfaces
+         * (group, attribute, dataset, etc.).
+         */
+        if (vol_cap_flags & H5VL_CAP_FLAG_GROUP_BASIC) {
+            if ((group_id = H5Gcreate2(file_id, GROUP_TEST_GROUP_NAME,
+                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
+                TestErrPrintf("Couldn't create container group '%s'\n", GROUP_TEST_GROUP_NAME);
+                goto error;
+            }
+            if (H5Gclose(group_id) < 0) {
+                TestErrPrintf("Couldn't close container group '%s'\n", GROUP_TEST_GROUP_NAME);
+                goto error;
+            }
+
+            if ((group_id = H5Gcreate2(file_id, ATTRIBUTE_TEST_GROUP_NAME,
+                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
+                TestErrPrintf("Couldn't create container group '%s'\n", ATTRIBUTE_TEST_GROUP_NAME);
+                goto error;
+            }
+            if (H5Gclose(group_id) < 0) {
+                TestErrPrintf("Couldn't close container group '%s'\n", ATTRIBUTE_TEST_GROUP_NAME);
+                goto error;
+            }
+
+            if ((group_id = H5Gcreate2(file_id, DATASET_TEST_GROUP_NAME,
+                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
+                TestErrPrintf("Couldn't create container group '%s'\n", DATASET_TEST_GROUP_NAME);
+                goto error;
+            }
+            if (H5Gclose(group_id) < 0) {
+                TestErrPrintf("Couldn't close container group '%s'\n", DATASET_TEST_GROUP_NAME);
+                goto error;
+            }
+
+            if ((group_id = H5Gcreate2(file_id, DATATYPE_TEST_GROUP_NAME,
+                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
+                TestErrPrintf("Couldn't create container group '%s'\n", DATATYPE_TEST_GROUP_NAME);
+                goto error;
+            }
+            if (H5Gclose(group_id) < 0) {
+                TestErrPrintf("Couldn't close container group '%s'\n", DATATYPE_TEST_GROUP_NAME);
+                goto error;
+            }
+
+            if ((group_id = H5Gcreate2(file_id, LINK_TEST_GROUP_NAME,
+                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
+                TestErrPrintf("Couldn't create container group '%s'\n", LINK_TEST_GROUP_NAME);
+                goto error;
+            }
+            if (H5Gclose(group_id) < 0) {
+                TestErrPrintf("Couldn't close container group '%s'\n", LINK_TEST_GROUP_NAME);
+                goto error;
+            }
+
+            if ((group_id = H5Gcreate2(file_id, OBJECT_TEST_GROUP_NAME,
+                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
+                TestErrPrintf("Couldn't create container group '%s'\n", OBJECT_TEST_GROUP_NAME);
+                goto error;
+            }
+            if (H5Gclose(group_id) < 0) {
+                TestErrPrintf("Couldn't close container group '%s'\n", OBJECT_TEST_GROUP_NAME);
+                goto error;
+            }
+
+            if ((group_id = H5Gcreate2(file_id, MISCELLANEOUS_TEST_GROUP_NAME,
+                                       H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
+                TestErrPrintf("Couldn't create container group '%s'\n", MISCELLANEOUS_TEST_GROUP_NAME);
+                goto error;
+            }
+            if (H5Gclose(group_id) < 0) {
+                TestErrPrintf("Couldn't close container group '%s'\n", MISCELLANEOUS_TEST_GROUP_NAME);
+                goto error;
+            }
+        }
+
+        if (H5Fclose(file_id) < 0) {
+            TestErrPrintf("Couldn't close testing container file '%s'\n", filenames[i]);
+            goto error;
+        }
+    }
+
+    if (num_filenames == 1)
+        printf("Created container file '%s'\n\n", filenames[0]);
+    else if (num_filenames > 1)
+        printf("Created container files '%s' through '%s'\n\n", filenames[0], filenames[num_filenames - 1]);
+
+    return 0;
+
+error:
+    H5E_BEGIN_TRY
+    {
+        H5Gclose(group_id);
+        H5Fclose(file_id);
+        for (size_t i = 0; i < num_filenames; i++)
+            H5Fdelete(filenames[i], H5P_DEFAULT);
+    }
+    H5E_END_TRY
+
+    return -1;
+}
+
+/* Delete the API test container file(s).
+ * Returns negative on failure, 0 on success */
+int
+H5_api_test_destroy_container_files(char **filenames, size_t num_filenames, hid_t fapl_id)
+{
+    int ret_value = 0;
+
+    if (!(vol_cap_flags_g & H5VL_CAP_FLAG_FILE_BASIC)) {
+        TestErrPrintf("VOL connector doesn't support file deletion\n");
+        goto error;
+    }
+
+    for (size_t i = 0; i < num_filenames; i++)
+        if (remove_test_file(filenames[i], fapl_id) < 0)
+            ret_value = -1;
+
+    return ret_value;
+
+error:
+    return -1;
 }

--- a/test/API/H5_api_test_util.h
+++ b/test/API/H5_api_test_util.h
@@ -22,6 +22,9 @@ hid_t  generate_random_dataspace(int rank, const hsize_t *max_dims, hsize_t *dim
 
 herr_t prefix_test_filename(TestParams_t *test_params, const char *prefix, const char *filename,
                             char **filename_out);
-herr_t remove_test_file(const char *filename);
+herr_t remove_test_file(const char *filename, hid_t fapl_id);
+
+int H5_api_test_create_containers(char **filenames, size_t num_filenames, uint64_t vol_cap_flags);
+int H5_api_test_destroy_container_files(char **filenames, size_t num_filenames, hid_t fapl_id);
 
 #endif /* H5_API_TEST_UTIL_H_ */

--- a/testpar/API/H5_api_async_test_parallel.c
+++ b/testpar/API/H5_api_async_test_parallel.c
@@ -3391,11 +3391,11 @@ test_async_file_cleanup(TestParams_t H5_ATTR_UNUSED *params)
     int  i;
 
     if (MAINPROCESS) {
-        remove_test_file(PAR_ASYNC_API_TEST_FILE);
+        remove_test_file(PAR_ASYNC_API_TEST_FILE, H5P_DEFAULT);
 
         for (i = 0; i <= max_printf_file; i++) {
             snprintf(file_name, sizeof(file_name), PAR_ASYNC_API_TEST_FILE_PRINTF, i);
-            remove_test_file(file_name);
+            remove_test_file(file_name, H5P_DEFAULT);
         }
     }
 

--- a/testpar/API/H5_api_test_parallel.c
+++ b/testpar/API/H5_api_test_parallel.c
@@ -194,91 +194,6 @@ usage(FILE *stream)
     fprintf(stream, "async       run only the async interface tests\n");
 }
 
-static int
-create_test_container(char *filename, uint64_t vol_cap_flags)
-{
-    hid_t file_id  = H5I_INVALID_HID;
-    hid_t group_id = H5I_INVALID_HID;
-
-    printf("Creating container file for tests\n");
-
-    if (!(vol_cap_flags & H5VL_CAP_FLAG_FILE_BASIC)) {
-        printf("   VOL connector doesn't support file creation\n");
-        goto error;
-    }
-
-    if ((file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
-        printf("    couldn't create testing container file '%s'\n", filename);
-        goto error;
-    }
-
-    printf("    created container file\n");
-
-    if (vol_cap_flags & H5VL_CAP_FLAG_GROUP_BASIC) {
-        /* Create container groups for each of the test interfaces
-         * (group, attribute, dataset, etc.).
-         */
-        if ((group_id = H5Gcreate2(file_id, GROUP_TEST_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) >=
-            0) {
-            printf("    created container group for Group tests\n");
-            H5Gclose(group_id);
-        }
-
-        if ((group_id = H5Gcreate2(file_id, ATTRIBUTE_TEST_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT,
-                                   H5P_DEFAULT)) >= 0) {
-            printf("    created container group for Attribute tests\n");
-            H5Gclose(group_id);
-        }
-
-        if ((group_id =
-                 H5Gcreate2(file_id, DATASET_TEST_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) >= 0) {
-            printf("    created container group for Dataset tests\n");
-            H5Gclose(group_id);
-        }
-
-        if ((group_id =
-                 H5Gcreate2(file_id, DATATYPE_TEST_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) >= 0) {
-            printf("    created container group for Datatype tests\n");
-            H5Gclose(group_id);
-        }
-
-        if ((group_id = H5Gcreate2(file_id, LINK_TEST_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) >=
-            0) {
-            printf("    created container group for Link tests\n");
-            H5Gclose(group_id);
-        }
-
-        if ((group_id = H5Gcreate2(file_id, OBJECT_TEST_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) >=
-            0) {
-            printf("    created container group for Object tests\n");
-            H5Gclose(group_id);
-        }
-
-        if ((group_id = H5Gcreate2(file_id, MISCELLANEOUS_TEST_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT,
-                                   H5P_DEFAULT)) >= 0) {
-            printf("    created container group for Miscellaneous tests\n");
-            H5Gclose(group_id);
-        }
-    }
-
-    if (H5Fclose(file_id) < 0) {
-        printf("    failed to close testing container\n");
-        goto error;
-    }
-
-    return 0;
-
-error:
-    H5E_BEGIN_TRY
-    {
-        H5Gclose(group_id);
-        H5Fclose(file_id);
-    }
-    H5E_END_TRY
-
-    return -1;
-}
-
 int
 main(int argc, char **argv)
 {
@@ -494,7 +409,7 @@ main(int argc, char **argv)
     BEGIN_INDEPENDENT_OP(create_test_container)
     {
         if (MAINPROCESS) {
-            if (create_test_container(H5_api_test_parallel_filename, vol_cap_flags_g) < 0) {
+            if (H5_api_test_create_containers(&H5_api_test_parallel_filename, 1, vol_cap_flags_g) < 0) {
                 TestErrPrintf("    failed to create testing container file '%s'\n",
                         H5_api_test_parallel_filename);
                 INDEPENDENT_OP_ERROR(create_test_container);
@@ -520,7 +435,7 @@ main(int argc, char **argv)
     }
 
     if (GetTestCleanup())
-        H5Fdelete(H5_api_test_parallel_filename, fapl_id);
+        H5_api_test_destroy_container_files(&H5_api_test_parallel_filename, 1, fapl_id);
 
     if (GetTestsExecutedCount() > 0) {
         size_t n_tests_run     = GetTestsExecutedCount();


### PR DESCRIPTION
- Move H5_api_test_create_containers(), H5_api_test_create_single_container(), and H5_api_test_destroy_container_files() into API test utilities so that they can be shared with the parallel API tests. 

- Remove the parallel test helper `create_test_container` since it was mostly duplicating work from `H5_api_test_create_containers()`

- Add a FAPL parameter to remove_test_file() and H5_api_destroy_container_files() for compatibility with the parallel API tests