### PR TITLE
Add virtual lock assertion scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,6 +909,7 @@ endif ()
 #-----------------------------------------------------------------------------
 # Option to enable multi-thread capable library
 #-----------------------------------------------------------------------------
+set (H5_HAVE_VIRTUAL_LOCK 0)
 option (HDF5_ENABLE_MULTITHREAD "Enable multi-thread library" OFF)
 if (HDF5_ENABLE_MULTITHREAD)
   if (HDF5_BUILD_FORTRAN)
@@ -970,6 +971,11 @@ if (HDF5_ENABLE_MULTITHREAD)
 
   set (H5_HAVE_MULTITHREAD 1)
   set (H5_MT_TEST_VOL_DIR "\"${HDF5_BINARY_DIR}/bin/\"")
+
+  if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
+  set (H5_HAVE_VIRTUAL_LOCK 1)
+  endif()
+
 endif ()
 
 #-----------------------------------------------------------------------------

--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -231,6 +231,9 @@
 /* Define if we have multi-thread support */
 #cmakedefine H5_HAVE_MULTITHREAD @H5_HAVE_MULTITHREAD@
 
+/* Define to enable virtual locking */
+#cmakedefine01 H5_HAVE_VIRTUAL_LOCK
+
 /* Define to 1 if you have the <netdb.h> header file. */
 #cmakedefine H5_HAVE_NETDB_H @H5_HAVE_NETDB_H@
 

--- a/configure.ac
+++ b/configure.ac
@@ -2180,6 +2180,12 @@ else
     AC_DEFINE([MT_TEST_VOL_DIR], [""], [The directory containing the multi-threaded wrapper VOL connectors])
 fi
 
+if test "X$MULTITHREAD" = "Xyes" -a "X$BUILD_MODE" = "Xdebug"; then
+  AC_DEFINE([HAVE_VIRTUAL_LOCK], [1], [Define if we enable the virtual lock])
+else
+  AC_DEFINE([HAVE_VIRTUAL_LOCK], [0], [Define if we enable the virtual lock])
+fi
+
 ## ----------------------------------------------------------------------
 ## Check for MONOTONIC_TIMER support (used in clock_gettime).  This has
 ## to be done after any POSIX defines to ensure that the test gets

--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -335,6 +335,8 @@ typedef struct H5CX_t {
     hbool_t vol_connector_prop_valid;         /* Whether property for VOL connector ID & info is valid */
     void   *vol_wrap_ctx;                     /* VOL connector's "wrap context" for creating IDs */
     hbool_t vol_wrap_ctx_valid; /* Whether VOL connector's "wrap context" for creating IDs is valid */
+
+    H5TS_vlock_t vlock; /* Virtual lock to verify thread-safe access to the context */
 } H5CX_t;
 
 /* Typedef for nodes on the API context stack */
@@ -790,6 +792,9 @@ H5CX__push_common(H5CX_node_t *cnode)
     cnode->ctx.fapl_id = H5P_FILE_ACCESS_DEFAULT;
     cnode->ctx.tag     = H5AC__INVALID_TAG;
     cnode->ctx.ring    = H5AC_RING_USER;
+#ifdef H5_HAVE_VIRTUAL_LOCK
+    H5TS_vlock_init(&cnode->ctx.vlock);
+#endif
 
     /* Push context node onto stack */
     cnode->next = *head;
@@ -880,6 +885,8 @@ H5CX_retrieve_state(H5CX_state_t **api_state)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
     assert(api_state);
+
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     /* Allocate & clear API context state */
     if (NULL == (*api_state = H5FL_CALLOC(H5CX_state_t)))
@@ -983,6 +990,8 @@ H5CX_retrieve_state(H5CX_state_t **api_state)
 #endif /* H5_HAVE_PARALLEL */
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* Cleanup on error */
     if (ret_value < 0) {
         if (*api_state) {
@@ -1022,6 +1031,8 @@ H5CX_restore_state(const H5CX_state_t *api_state)
     assert(head && *head);
     assert(api_state);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Restore the DCPL info */
     (*head)->ctx.dcpl_id = api_state->dcpl_id;
     (*head)->ctx.dcpl    = NULL;
@@ -1054,6 +1065,8 @@ H5CX_restore_state(const H5CX_state_t *api_state)
     /* Restore parallel I/O settings */
     (*head)->ctx.coll_metadata_read = api_state->coll_metadata_read;
 #endif /* H5_HAVE_PARALLEL */
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5CX_restore_state() */
@@ -1143,8 +1156,12 @@ H5CX_is_def_dxpl(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* Set return value */
     is_def_dxpl = ((*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT);
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(is_def_dxpl)
 } /* end H5CX_is_def_dxpl() */
@@ -1169,8 +1186,12 @@ H5CX_set_dxpl(hid_t dxpl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context's DXPL to a new value */
     (*head)->ctx.dxpl_id = dxpl_id;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_dxpl() */
@@ -1195,8 +1216,12 @@ H5CX_set_dcpl(hid_t dcpl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context's DCPL to a new value */
     (*head)->ctx.dcpl_id = dcpl_id;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_dcpl() */
@@ -1223,6 +1248,8 @@ H5CX_set_libver_bounds(H5F_t *f)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context value */
     (*head)->ctx.low_bound  = (f == NULL) ? H5F_LIBVER_LATEST : H5F_LOW_BOUND(f);
     (*head)->ctx.high_bound = (f == NULL) ? H5F_LIBVER_LATEST : H5F_HIGH_BOUND(f);
@@ -1230,6 +1257,8 @@ H5CX_set_libver_bounds(H5F_t *f)
     /* Mark the values as valid */
     (*head)->ctx.low_bound_valid  = TRUE;
     (*head)->ctx.high_bound_valid = TRUE;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_libver_bounds() */
@@ -1254,8 +1283,12 @@ H5CX_set_lcpl(hid_t lcpl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context's LCPL to a new value */
     (*head)->ctx.lcpl_id = lcpl_id;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_lcpl() */
@@ -1280,8 +1313,12 @@ H5CX_set_lapl(hid_t lapl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context's LAPL to a new value */
     (*head)->ctx.lapl_id = lapl_id;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_lapl() */
@@ -1319,6 +1356,8 @@ H5CX_set_apl(hid_t *acspl_id, const H5P_libclass_t *libclass,
     assert(libclass);
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
+
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     /* Set access plist to the default property list of the appropriate class if it's the generic default */
     if (H5P_DEFAULT == *acspl_id)
@@ -1404,6 +1443,7 @@ H5CX_set_apl(hid_t *acspl_id, const H5P_libclass_t *libclass,
 #endif    /* H5_HAVE_PARALLEL */
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_apl() */
 
@@ -1436,6 +1476,8 @@ H5CX_set_loc(hid_t
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set collective metadata read flag */
     (*head)->ctx.coll_metadata_read = TRUE;
 
@@ -1456,6 +1498,7 @@ H5CX_set_loc(hid_t
     } /* end if */
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
     FUNC_LEAVE_NOAPI(ret_value)
 #else  /* H5_HAVE_PARALLEL */
     FUNC_ENTER_NOAPI_NOINIT_NOERR
@@ -1485,11 +1528,15 @@ H5CX_set_vol_wrap_ctx(void *vol_wrap_ctx)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context value */
     (*head)->ctx.vol_wrap_ctx = vol_wrap_ctx;
 
     /* Mark the value as valid */
     (*head)->ctx.vol_wrap_ctx_valid = TRUE;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_vol_wrap_ctx() */
@@ -1515,11 +1562,15 @@ H5CX_set_vol_connector_prop(const H5VL_connector_prop_t *vol_connector_prop)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context value */
     H5MM_memcpy(&(*head)->ctx.vol_connector_prop, vol_connector_prop, sizeof(H5VL_connector_prop_t));
 
     /* Mark the value as valid */
     (*head)->ctx.vol_connector_prop_valid = TRUE;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_vol_connector_prop() */
@@ -1545,8 +1596,12 @@ H5CX_get_dxpl(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* Set return value */
     dxpl_id = (*head)->ctx.dxpl_id;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(dxpl_id)
 } /* end H5CX_get_dxpl() */
@@ -1572,8 +1627,12 @@ H5CX_get_lapl(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* Set return value */
     lapl_id = (*head)->ctx.lapl_id;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(lapl_id)
 } /* end H5CX_get_lapl() */
@@ -1599,6 +1658,8 @@ H5CX_get_vol_wrap_ctx(void **vol_wrap_ctx)
     assert(vol_wrap_ctx);
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* No error is expected at this point.  But in case an application calls H5VLwrap_register
      * which doesn't reset the API context and there is no context, returns a relevant error here
      */
@@ -1614,6 +1675,8 @@ H5CX_get_vol_wrap_ctx(void **vol_wrap_ctx)
         *vol_wrap_ctx = (*head)->ctx.vol_wrap_ctx;
     else
         *vol_wrap_ctx = NULL;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1641,12 +1704,16 @@ H5CX_get_vol_connector_prop(H5VL_connector_prop_t *vol_connector_prop)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* Check for value that was set */
     if ((*head)->ctx.vol_connector_prop_valid)
         /* Get the value */
         H5MM_memcpy(vol_connector_prop, &(*head)->ctx.vol_connector_prop, sizeof(H5VL_connector_prop_t));
     else
         memset(vol_connector_prop, 0, sizeof(H5VL_connector_prop_t));
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vol_connector_prop() */
@@ -1672,8 +1739,12 @@ H5CX_get_tag(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* Set return value */
     tag = (*head)->ctx.tag;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(tag)
 } /* end H5CX_get_tag() */
@@ -1699,8 +1770,12 @@ H5CX_get_ring(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* Set return value */
     ring = (*head)->ctx.ring;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ring)
 } /* end H5CX_get_ring() */
@@ -1728,8 +1803,12 @@ H5CX_get_coll_metadata_read(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* Set return value */
     coll_md_read = (*head)->ctx.coll_metadata_read;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(coll_md_read)
 } /* end H5CX_get_coll_metadata_read() */
@@ -1759,9 +1838,13 @@ H5CX_get_mpi_coll_datatypes(MPI_Datatype *btype, MPI_Datatype *ftype)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* Set the API context values */
     *btype = (*head)->ctx.btype;
     *ftype = (*head)->ctx.ftype;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpi_coll_datatypes() */
@@ -1787,8 +1870,12 @@ H5CX_get_mpi_file_flushing(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* Set return value */
     flushing = (*head)->ctx.mpi_file_flushing;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(flushing)
 } /* end H5CX_get_mpi_file_flushing() */
@@ -1815,8 +1902,12 @@ H5CX_get_mpio_rank0_bcast(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     /* Set return value */
     do_rank0_bcast = (*head)->ctx.rank0_bcast;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(do_rank0_bcast)
 } /* end H5CX_get_mpio_rank0_bcast() */
@@ -1845,6 +1936,8 @@ H5CX_get_btree_split_ratios(double split_ratio[3])
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_BTREE_SPLIT_RATIO_NAME,
                              btree_split_ratio)
 
@@ -1852,6 +1945,8 @@ H5CX_get_btree_split_ratios(double split_ratio[3])
     H5MM_memcpy(split_ratio, &(*head)->ctx.btree_split_ratio, sizeof((*head)->ctx.btree_split_ratio));
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_btree_split_ratios() */
 
@@ -1878,12 +1973,16 @@ H5CX_get_max_temp_buf(size_t *max_temp_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MAX_TEMP_BUF_NAME, max_temp_buf)
 
     /* Get the value */
     *max_temp_buf = (*head)->ctx.max_temp_buf;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_max_temp_buf() */
 
@@ -1910,12 +2009,16 @@ H5CX_get_tconv_buf(void **tconv_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_TCONV_BUF_NAME, tconv_buf)
 
     /* Get the value */
     *tconv_buf = (*head)->ctx.tconv_buf;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_tconv_buf() */
 
@@ -1942,12 +2045,16 @@ H5CX_get_bkgr_buf(void **bkgr_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_BKGR_BUF_NAME, bkgr_buf)
 
     /* Get the value */
     *bkgr_buf = (*head)->ctx.bkgr_buf;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_bkgr_buf() */
 
@@ -1974,12 +2081,16 @@ H5CX_get_bkgr_buf_type(H5T_bkg_t *bkgr_buf_type)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_BKGR_BUF_TYPE_NAME, bkgr_buf_type)
 
     /* Get the value */
     *bkgr_buf_type = (*head)->ctx.bkgr_buf_type;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_bkgr_buf_type() */
 
@@ -2006,12 +2117,16 @@ H5CX_get_vec_size(size_t *vec_size)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_HYPER_VECTOR_SIZE_NAME, vec_size)
 
     /* Get the value */
     *vec_size = (*head)->ctx.vec_size;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vec_size() */
 
@@ -2040,12 +2155,16 @@ H5CX_get_io_xfer_mode(H5FD_mpio_xfer_t *io_xfer_mode)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_IO_XFER_MODE_NAME, io_xfer_mode)
 
     /* Get the value */
     *io_xfer_mode = (*head)->ctx.io_xfer_mode;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_io_xfer_mode() */
 
@@ -2072,12 +2191,16 @@ H5CX_get_mpio_coll_opt(H5FD_mpio_collective_opt_t *mpio_coll_opt)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_COLLECTIVE_OPT_NAME, mpio_coll_opt)
 
     /* Get the value */
     *mpio_coll_opt = (*head)->ctx.mpio_coll_opt;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_coll_opt() */
 
@@ -2104,6 +2227,8 @@ H5CX_get_mpio_local_no_coll_cause(uint32_t *mpio_local_no_coll_cause)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID_SET(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_MPIO_LOCAL_NO_COLLECTIVE_CAUSE_NAME,
                                  mpio_local_no_coll_cause)
 
@@ -2111,6 +2236,8 @@ H5CX_get_mpio_local_no_coll_cause(uint32_t *mpio_local_no_coll_cause)
     *mpio_local_no_coll_cause = (*head)->ctx.mpio_local_no_coll_cause;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_local_no_coll_cause() */
 
@@ -2137,6 +2264,8 @@ H5CX_get_mpio_global_no_coll_cause(uint32_t *mpio_global_no_coll_cause)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID_SET(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_MPIO_GLOBAL_NO_COLLECTIVE_CAUSE_NAME,
                                  mpio_global_no_coll_cause)
 
@@ -2144,6 +2273,8 @@ H5CX_get_mpio_global_no_coll_cause(uint32_t *mpio_global_no_coll_cause)
     *mpio_global_no_coll_cause = (*head)->ctx.mpio_global_no_coll_cause;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_global_no_coll_cause() */
 
@@ -2170,6 +2301,8 @@ H5CX_get_mpio_chunk_opt_mode(H5FD_mpio_chunk_opt_t *mpio_chunk_opt_mode)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_CHUNK_OPT_HARD_NAME,
                              mpio_chunk_opt_mode)
 
@@ -2177,6 +2310,8 @@ H5CX_get_mpio_chunk_opt_mode(H5FD_mpio_chunk_opt_t *mpio_chunk_opt_mode)
     *mpio_chunk_opt_mode = (*head)->ctx.mpio_chunk_opt_mode;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_chunk_opt_mode() */
 
@@ -2203,6 +2338,8 @@ H5CX_get_mpio_chunk_opt_num(unsigned *mpio_chunk_opt_num)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_CHUNK_OPT_NUM_NAME,
                              mpio_chunk_opt_num)
 
@@ -2210,6 +2347,8 @@ H5CX_get_mpio_chunk_opt_num(unsigned *mpio_chunk_opt_num)
     *mpio_chunk_opt_num = (*head)->ctx.mpio_chunk_opt_num;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_chunk_opt_num() */
 
@@ -2236,6 +2375,8 @@ H5CX_get_mpio_chunk_opt_ratio(unsigned *mpio_chunk_opt_ratio)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_CHUNK_OPT_RATIO_NAME,
                              mpio_chunk_opt_ratio)
 
@@ -2243,6 +2384,8 @@ H5CX_get_mpio_chunk_opt_ratio(unsigned *mpio_chunk_opt_ratio)
     *mpio_chunk_opt_ratio = (*head)->ctx.mpio_chunk_opt_ratio;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_chunk_opt_ratio() */
 #endif /* H5_HAVE_PARALLEL */
@@ -2270,12 +2413,16 @@ H5CX_get_err_detect(H5Z_EDC_t *err_detect)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_EDC_NAME, err_detect)
 
     /* Get the value */
     *err_detect = (*head)->ctx.err_detect;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_err_detect() */
 
@@ -2302,12 +2449,16 @@ H5CX_get_filter_cb(H5Z_cb_t *filter_cb)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_FILTER_CB_NAME, filter_cb)
 
     /* Get the value */
     *filter_cb = (*head)->ctx.filter_cb;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_filter_cb() */
 
@@ -2333,6 +2484,8 @@ H5CX_get_data_transform(H5Z_data_xform_t **data_transform)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
+
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.data_transform_valid) {
@@ -2363,6 +2516,8 @@ H5CX_get_data_transform(H5Z_data_xform_t **data_transform)
     *data_transform = (*head)->ctx.data_transform;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_data_transform() */
 
@@ -2388,6 +2543,8 @@ H5CX_get_vlen_alloc_info(H5T_vlen_alloc_info_t *vl_alloc_info)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
+
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.vl_alloc_info_valid) {
@@ -2425,6 +2582,8 @@ H5CX_get_vlen_alloc_info(H5T_vlen_alloc_info_t *vl_alloc_info)
     *vl_alloc_info = (*head)->ctx.vl_alloc_info;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vlen_alloc_info() */
 
@@ -2451,12 +2610,16 @@ H5CX_get_dt_conv_cb(H5T_conv_cb_t *dt_conv_cb)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_CONV_CB_NAME, dt_conv_cb)
 
     /* Get the value */
     *dt_conv_cb = (*head)->ctx.dt_conv_cb;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_dt_conv_cb() */
 
@@ -2483,6 +2646,8 @@ H5CX_get_selection_io_mode(H5D_selection_io_mode_t *selection_io_mode)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_SELECTION_IO_MODE_NAME,
                              selection_io_mode)
 
@@ -2490,6 +2655,8 @@ H5CX_get_selection_io_mode(H5D_selection_io_mode_t *selection_io_mode)
     *selection_io_mode = (*head)->ctx.selection_io_mode;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_selection_io_mode() */
 
@@ -2517,6 +2684,8 @@ H5CX_get_no_selection_io_cause(uint32_t *no_selection_io_cause)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID_SET(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_NO_SELECTION_IO_CAUSE_NAME,
                                  no_selection_io_cause)
 
@@ -2524,6 +2693,8 @@ H5CX_get_no_selection_io_cause(uint32_t *no_selection_io_cause)
     *no_selection_io_cause = (*head)->ctx.no_selection_io_cause;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_no_selection_io_cause() */
 
@@ -2550,12 +2721,16 @@ H5CX_get_modify_write_buf(hbool_t *modify_write_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MODIFY_WRITE_BUF_NAME, modify_write_buf)
 
     /* Get the value */
     *modify_write_buf = (*head)->ctx.modify_write_buf;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_selection_io_mode() */
 
@@ -2582,12 +2757,16 @@ H5CX_get_encoding(H5T_cset_t *encoding)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.lcpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(lcpl, H5P_LINK_CREATE_DEFAULT, H5P_STRCRT_CHAR_ENCODING_NAME, encoding)
 
     /* Get the value */
     *encoding = (*head)->ctx.encoding;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_encoding() */
 
@@ -2614,6 +2793,8 @@ H5CX_get_intermediate_group(unsigned *crt_intermed_group)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.lcpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(lcpl, H5P_LINK_CREATE_DEFAULT, H5L_CRT_INTERMEDIATE_GROUP_NAME,
                              intermediate_group)
 
@@ -2621,6 +2802,8 @@ H5CX_get_intermediate_group(unsigned *crt_intermed_group)
     *crt_intermed_group = (*head)->ctx.intermediate_group;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_create_intermediate_group() */
 
@@ -2647,12 +2830,16 @@ H5CX_get_nlinks(size_t *nlinks)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(lapl, H5P_LINK_ACCESS_DEFAULT, H5L_ACS_NLINKS_NAME, nlinks)
 
     /* Get the value */
     *nlinks = (*head)->ctx.nlinks;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_nlinks() */
 
@@ -2680,6 +2867,8 @@ H5CX_get_libver_bounds(H5F_libver_t *low_bound, H5F_libver_t *high_bound)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.fapl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(fapl, H5P_FILE_ACCESS_DEFAULT, H5F_ACS_LIBVER_LOW_BOUND_NAME, low_bound)
     H5CX_RETRIEVE_PROP_VALID(fapl, H5P_FILE_ACCESS_DEFAULT, H5F_ACS_LIBVER_HIGH_BOUND_NAME, high_bound)
 
@@ -2688,6 +2877,8 @@ H5CX_get_libver_bounds(H5F_libver_t *low_bound, H5F_libver_t *high_bound)
     *high_bound = (*head)->ctx.high_bound;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_libver_bounds() */
 
@@ -2715,6 +2906,8 @@ H5CX_get_dset_min_ohdr_flag(hbool_t *dset_min_ohdr_flag)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dcpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dcpl, H5P_DATASET_CREATE_DEFAULT, H5D_CRT_MIN_DSET_HDR_SIZE_NAME,
                              do_min_dset_ohdr)
 
@@ -2722,6 +2915,8 @@ H5CX_get_dset_min_ohdr_flag(hbool_t *dset_min_ohdr_flag)
     *dset_min_ohdr_flag = (*head)->ctx.do_min_dset_ohdr;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_dset_min_ohdr_flag() */
 
@@ -2747,6 +2942,8 @@ H5CX_get_ext_file_prefix(const char **extfile_prefix)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dapl_id);
+
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.extfile_prefix_valid) {
@@ -2777,6 +2974,8 @@ H5CX_get_ext_file_prefix(const char **extfile_prefix)
     *extfile_prefix = (*head)->ctx.extfile_prefix;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_ext_file_prefix() */
 
@@ -2802,6 +3001,8 @@ H5CX_get_vds_prefix(const char **vds_prefix)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dapl_id);
+
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.vds_prefix_valid) {
@@ -2832,6 +3033,8 @@ H5CX_get_vds_prefix(const char **vds_prefix)
     *vds_prefix = (*head)->ctx.vds_prefix;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vds_prefix() */
 
@@ -2855,7 +3058,11 @@ H5CX_set_tag(haddr_t tag)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     (*head)->ctx.tag = tag;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_tag() */
@@ -2880,7 +3087,11 @@ H5CX_set_ring(H5AC_ring_t ring)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     (*head)->ctx.ring = ring;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_ring() */
@@ -2907,7 +3118,11 @@ H5CX_set_coll_metadata_read(hbool_t cmdr)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     (*head)->ctx.coll_metadata_read = cmdr;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_coll_metadata_read() */
@@ -2936,9 +3151,13 @@ H5CX_set_mpi_coll_datatypes(MPI_Datatype btype, MPI_Datatype ftype)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context values */
     (*head)->ctx.btype = btype;
     (*head)->ctx.ftype = ftype;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_mpi_coll_datatypes() */
@@ -2964,11 +3183,15 @@ H5CX_set_io_xfer_mode(H5FD_mpio_xfer_t io_xfer_mode)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context value */
     (*head)->ctx.io_xfer_mode = io_xfer_mode;
 
     /* Mark the value as valid */
     (*head)->ctx.io_xfer_mode_valid = TRUE;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_io_xfer_mode() */
@@ -2994,11 +3217,15 @@ H5CX_set_mpio_coll_opt(H5FD_mpio_collective_opt_t mpio_coll_opt)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context value */
     (*head)->ctx.mpio_coll_opt = mpio_coll_opt;
 
     /* Mark the value as valid */
     (*head)->ctx.mpio_coll_opt_valid = TRUE;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_mpio_coll_opt() */
@@ -3023,7 +3250,11 @@ H5CX_set_mpi_file_flushing(hbool_t flushing)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     (*head)->ctx.mpi_file_flushing = flushing;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpi_file_flushing() */
@@ -3049,7 +3280,11 @@ H5CX_set_mpio_rank0_bcast(hbool_t rank0_bcast)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     (*head)->ctx.rank0_bcast = rank0_bcast;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_rank0_bcast() */
@@ -3076,6 +3311,8 @@ H5CX_set_vlen_alloc_info(H5MM_allocate_t alloc_func, void *alloc_info, H5MM_free
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context value */
     (*head)->ctx.vl_alloc_info.alloc_func = alloc_func;
     (*head)->ctx.vl_alloc_info.alloc_info = alloc_info;
@@ -3084,6 +3321,8 @@ H5CX_set_vlen_alloc_info(H5MM_allocate_t alloc_func, void *alloc_info, H5MM_free
 
     /* Mark the value as valid */
     (*head)->ctx.vl_alloc_info_valid = TRUE;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_vlen_alloc_info() */
@@ -3109,11 +3348,15 @@ H5CX_set_nlinks(size_t nlinks)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Set the API context value */
     (*head)->ctx.nlinks = nlinks;
 
     /* Mark the value as valid */
     (*head)->ctx.nlinks_valid = TRUE;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_nlinks() */
@@ -3141,9 +3384,13 @@ H5CX_set_mpio_actual_chunk_opt(H5D_mpio_actual_chunk_opt_mode_t mpio_actual_chun
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Cache the value for later, marking it to set in DXPL when context popped */
     (*head)->ctx.mpio_actual_chunk_opt     = mpio_actual_chunk_opt;
     (*head)->ctx.mpio_actual_chunk_opt_set = TRUE;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_actual_chunk_opt() */
@@ -3169,9 +3416,13 @@ H5CX_set_mpio_actual_io_mode(H5D_mpio_actual_io_mode_t mpio_actual_io_mode)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* Cache the value for later, marking it to set in DXPL when context popped */
     (*head)->ctx.mpio_actual_io_mode     = mpio_actual_io_mode;
     (*head)->ctx.mpio_actual_io_mode_set = TRUE;
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_actual_chunk_opt() */
@@ -3197,12 +3448,16 @@ H5CX_set_mpio_local_no_coll_cause(uint32_t mpio_local_no_coll_cause)
     assert(head && *head);
     assert((*head)->ctx.dxpl_id != H5P_DEFAULT);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* If we're using the default DXPL, don't modify it */
     if ((*head)->ctx.dxpl_id != H5P_DATASET_XFER_DEFAULT) {
         /* Cache the value for later, marking it to set in DXPL when context popped */
         (*head)->ctx.mpio_local_no_coll_cause     = mpio_local_no_coll_cause;
         (*head)->ctx.mpio_local_no_coll_cause_set = TRUE;
     } /* end if */
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_local_no_coll_cause() */
@@ -3228,12 +3483,16 @@ H5CX_set_mpio_global_no_coll_cause(uint32_t mpio_global_no_coll_cause)
     assert(head && *head);
     assert((*head)->ctx.dxpl_id != H5P_DEFAULT);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* If we're using the default DXPL, don't modify it */
     if ((*head)->ctx.dxpl_id != H5P_DATASET_XFER_DEFAULT) {
         /* Cache the value for later, marking it to set in DXPL when context popped */
         (*head)->ctx.mpio_global_no_coll_cause     = mpio_global_no_coll_cause;
         (*head)->ctx.mpio_global_no_coll_cause_set = TRUE;
     } /* end if */
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_global_no_coll_cause() */
@@ -3264,9 +3523,13 @@ H5CX_test_set_mpio_coll_chunk_link_hard(int mpio_coll_chunk_link_hard)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_HARD_NAME, mpio_coll_chunk_link_hard)
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_link_hard() */
 
@@ -3294,9 +3557,13 @@ H5CX_test_set_mpio_coll_chunk_multi_hard(int mpio_coll_chunk_multi_hard)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_HARD_NAME, mpio_coll_chunk_multi_hard)
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_multi_hard() */
 
@@ -3324,9 +3591,13 @@ H5CX_test_set_mpio_coll_chunk_link_num_true(int mpio_coll_chunk_link_num_true)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_NUM_TRUE_NAME, mpio_coll_chunk_link_num_true)
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_link_num_true() */
 
@@ -3355,9 +3626,13 @@ H5CX_test_set_mpio_coll_chunk_link_num_false(int mpio_coll_chunk_link_num_false)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_NUM_FALSE_NAME, mpio_coll_chunk_link_num_false)
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_link_num_false() */
 
@@ -3386,9 +3661,13 @@ H5CX_test_set_mpio_coll_chunk_multi_ratio_coll(int mpio_coll_chunk_multi_ratio_c
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_RATIO_COLL_NAME, mpio_coll_chunk_multi_ratio_coll)
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_multi_ratio_coll() */
 
@@ -3417,9 +3696,13 @@ H5CX_test_set_mpio_coll_chunk_multi_ratio_ind(int mpio_coll_chunk_multi_ratio_in
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_RATIO_IND_NAME, mpio_coll_chunk_multi_ratio_ind)
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_multi_ratio_ind() */
 
@@ -3447,9 +3730,13 @@ H5CX_test_set_mpio_coll_rank0_bcast(hbool_t mpio_coll_rank0_bcast)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_RANK0_BCAST_NAME, mpio_coll_rank0_bcast)
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_rank0_bcast() */
 #endif /* H5_HAVE_INSTRUMENTED_LIBRARY */
@@ -3477,12 +3764,16 @@ H5CX_set_no_selection_io_cause(uint32_t no_selection_io_cause)
     assert(head && *head);
     assert((*head)->ctx.dxpl_id != H5P_DEFAULT);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+
     /* If we're using the default DXPL, don't modify it */
     if ((*head)->ctx.dxpl_id != H5P_DATASET_XFER_DEFAULT) {
         /* Cache the value for later, marking it to set in DXPL when context popped */
         (*head)->ctx.no_selection_io_cause     = no_selection_io_cause;
         (*head)->ctx.no_selection_io_cause_set = TRUE;
     } /* end if */
+
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_no_selectiion_io_cause() */
@@ -3510,12 +3801,16 @@ H5CX_get_ohdr_flags(uint8_t *ohdr_flags)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dcpl_id);
 
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     H5CX_RETRIEVE_PROP_VALID(dcpl, H5P_DATASET_CREATE_DEFAULT, H5O_CRT_OHDR_FLAGS_NAME, ohdr_flags)
 
     /* Get the value */
     *ohdr_flags = (*head)->ctx.ohdr_flags;
 
 done:
+    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* End H5CX_get_ohdr_flags() */
 
@@ -3539,6 +3834,9 @@ H5CX__pop_common(hbool_t update_dxpl_props)
     /* Sanity check */
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
+
+    /* Unmatched H5TS_vlock_acquire() because the context is soon to be released */
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
 
     /* Check for cached DXPL properties to return to application */
     if (update_dxpl_props) {

--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -428,6 +428,24 @@ typedef struct H5CX_fapl_cache_t {
 #if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
 static H5CX_node_t **H5CX__get_context(void);
 #endif /* H5_HAVE_THREADSAFE or H5_HAVE_MULTITHREAD */
+
+#ifdef H5_HAVE_VIRTUAL_LOCK
+static void H5CX__vlock_init(H5CX_t *ctx);
+static void H5CX__vlock_acquire(H5CX_t *ctx, H5TS_vlock_op_type_t op_type);
+static void H5CX__vlock_release(H5CX_t *ctx, H5TS_vlock_op_type_t op_type);
+
+#define H5CX_VLOCK_INIT(ctx) H5CX__vlock_init(ctx)
+#define H5CX_VLOCK_ACQUIRE(ctx, op_type) H5CX__vlock_acquire(ctx, op_type)
+#define H5CX_VLOCK_RELEASE(ctx, op_type) H5CX__vlock_release(ctx, op_type)
+
+#else /* H5_HAVE_VIRTUAL_LOCK */
+
+#define H5CX_VLOCK_INIT(ctx)
+#define H5CX_VLOCK_ACQUIRE(ctx, op_type)
+#define H5CX_VLOCK_RELEASE(ctx, op_type)
+
+#endif /* H5_HAVE_VIRTUAL_LOCK */
+
 static void         H5CX__push_common(H5CX_node_t *cnode);
 static H5CX_node_t *H5CX__pop_common(hbool_t update_dxpl_props);
 
@@ -792,9 +810,8 @@ H5CX__push_common(H5CX_node_t *cnode)
     cnode->ctx.fapl_id = H5P_FILE_ACCESS_DEFAULT;
     cnode->ctx.tag     = H5AC__INVALID_TAG;
     cnode->ctx.ring    = H5AC_RING_USER;
-#ifdef H5_HAVE_VIRTUAL_LOCK
-    H5TS_vlock_init(&cnode->ctx.vlock);
-#endif
+
+    H5CX_VLOCK_INIT(&cnode->ctx);
 
     /* Push context node onto stack */
     cnode->next = *head;
@@ -886,7 +903,7 @@ H5CX_retrieve_state(H5CX_state_t **api_state)
     assert(head && *head);
     assert(api_state);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Allocate & clear API context state */
     if (NULL == (*api_state = H5FL_CALLOC(H5CX_state_t)))
@@ -990,7 +1007,7 @@ H5CX_retrieve_state(H5CX_state_t **api_state)
 #endif /* H5_HAVE_PARALLEL */
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Cleanup on error */
     if (ret_value < 0) {
@@ -1031,7 +1048,7 @@ H5CX_restore_state(const H5CX_state_t *api_state)
     assert(head && *head);
     assert(api_state);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Restore the DCPL info */
     (*head)->ctx.dcpl_id = api_state->dcpl_id;
@@ -1066,7 +1083,7 @@ H5CX_restore_state(const H5CX_state_t *api_state)
     (*head)->ctx.coll_metadata_read = api_state->coll_metadata_read;
 #endif /* H5_HAVE_PARALLEL */
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5CX_restore_state() */
@@ -1156,12 +1173,12 @@ H5CX_is_def_dxpl(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Set return value */
     is_def_dxpl = ((*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT);
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(is_def_dxpl)
 } /* end H5CX_is_def_dxpl() */
@@ -1186,12 +1203,12 @@ H5CX_set_dxpl(hid_t dxpl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context's DXPL to a new value */
     (*head)->ctx.dxpl_id = dxpl_id;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_dxpl() */
@@ -1216,12 +1233,12 @@ H5CX_set_dcpl(hid_t dcpl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context's DCPL to a new value */
     (*head)->ctx.dcpl_id = dcpl_id;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_dcpl() */
@@ -1248,7 +1265,7 @@ H5CX_set_libver_bounds(H5F_t *f)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context value */
     (*head)->ctx.low_bound  = (f == NULL) ? H5F_LIBVER_LATEST : H5F_LOW_BOUND(f);
@@ -1258,7 +1275,7 @@ H5CX_set_libver_bounds(H5F_t *f)
     (*head)->ctx.low_bound_valid  = TRUE;
     (*head)->ctx.high_bound_valid = TRUE;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_libver_bounds() */
@@ -1283,12 +1300,12 @@ H5CX_set_lcpl(hid_t lcpl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context's LCPL to a new value */
     (*head)->ctx.lcpl_id = lcpl_id;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_lcpl() */
@@ -1313,12 +1330,12 @@ H5CX_set_lapl(hid_t lapl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context's LAPL to a new value */
     (*head)->ctx.lapl_id = lapl_id;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_lapl() */
@@ -1357,7 +1374,7 @@ H5CX_set_apl(hid_t *acspl_id, const H5P_libclass_t *libclass,
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set access plist to the default property list of the appropriate class if it's the generic default */
     if (H5P_DEFAULT == *acspl_id)
@@ -1443,7 +1460,7 @@ H5CX_set_apl(hid_t *acspl_id, const H5P_libclass_t *libclass,
 #endif    /* H5_HAVE_PARALLEL */
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_apl() */
 
@@ -1476,7 +1493,7 @@ H5CX_set_loc(hid_t
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set collective metadata read flag */
     (*head)->ctx.coll_metadata_read = TRUE;
@@ -1498,7 +1515,7 @@ H5CX_set_loc(hid_t
     } /* end if */
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
     FUNC_LEAVE_NOAPI(ret_value)
 #else  /* H5_HAVE_PARALLEL */
     FUNC_ENTER_NOAPI_NOINIT_NOERR
@@ -1528,7 +1545,7 @@ H5CX_set_vol_wrap_ctx(void *vol_wrap_ctx)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context value */
     (*head)->ctx.vol_wrap_ctx = vol_wrap_ctx;
@@ -1536,7 +1553,7 @@ H5CX_set_vol_wrap_ctx(void *vol_wrap_ctx)
     /* Mark the value as valid */
     (*head)->ctx.vol_wrap_ctx_valid = TRUE;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_vol_wrap_ctx() */
@@ -1562,7 +1579,7 @@ H5CX_set_vol_connector_prop(const H5VL_connector_prop_t *vol_connector_prop)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context value */
     H5MM_memcpy(&(*head)->ctx.vol_connector_prop, vol_connector_prop, sizeof(H5VL_connector_prop_t));
@@ -1570,7 +1587,7 @@ H5CX_set_vol_connector_prop(const H5VL_connector_prop_t *vol_connector_prop)
     /* Mark the value as valid */
     (*head)->ctx.vol_connector_prop_valid = TRUE;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_vol_connector_prop() */
@@ -1596,12 +1613,12 @@ H5CX_get_dxpl(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Set return value */
     dxpl_id = (*head)->ctx.dxpl_id;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(dxpl_id)
 } /* end H5CX_get_dxpl() */
@@ -1627,12 +1644,12 @@ H5CX_get_lapl(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Set return value */
     lapl_id = (*head)->ctx.lapl_id;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(lapl_id)
 } /* end H5CX_get_lapl() */
@@ -1667,7 +1684,7 @@ H5CX_get_vol_wrap_ctx(void **vol_wrap_ctx)
     if (!(*head))
         HGOTO_ERROR(H5E_CONTEXT, H5E_CANTGET, FAIL, "unable to get the current API context");
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Check for value that was set */
     if ((*head)->ctx.vol_wrap_ctx_valid)
@@ -1676,7 +1693,7 @@ H5CX_get_vol_wrap_ctx(void **vol_wrap_ctx)
     else
         *vol_wrap_ctx = NULL;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1704,7 +1721,7 @@ H5CX_get_vol_connector_prop(H5VL_connector_prop_t *vol_connector_prop)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Check for value that was set */
     if ((*head)->ctx.vol_connector_prop_valid)
@@ -1713,7 +1730,7 @@ H5CX_get_vol_connector_prop(H5VL_connector_prop_t *vol_connector_prop)
     else
         memset(vol_connector_prop, 0, sizeof(H5VL_connector_prop_t));
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vol_connector_prop() */
@@ -1739,12 +1756,12 @@ H5CX_get_tag(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Set return value */
     tag = (*head)->ctx.tag;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(tag)
 } /* end H5CX_get_tag() */
@@ -1770,12 +1787,12 @@ H5CX_get_ring(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Set return value */
     ring = (*head)->ctx.ring;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ring)
 } /* end H5CX_get_ring() */
@@ -1803,12 +1820,12 @@ H5CX_get_coll_metadata_read(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Set return value */
     coll_md_read = (*head)->ctx.coll_metadata_read;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(coll_md_read)
 } /* end H5CX_get_coll_metadata_read() */
@@ -1838,13 +1855,13 @@ H5CX_get_mpi_coll_datatypes(MPI_Datatype *btype, MPI_Datatype *ftype)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Set the API context values */
     *btype = (*head)->ctx.btype;
     *ftype = (*head)->ctx.ftype;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpi_coll_datatypes() */
@@ -1870,12 +1887,12 @@ H5CX_get_mpi_file_flushing(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Set return value */
     flushing = (*head)->ctx.mpi_file_flushing;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(flushing)
 } /* end H5CX_get_mpi_file_flushing() */
@@ -1902,12 +1919,12 @@ H5CX_get_mpio_rank0_bcast(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Set return value */
     do_rank0_bcast = (*head)->ctx.rank0_bcast;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(do_rank0_bcast)
 } /* end H5CX_get_mpio_rank0_bcast() */
@@ -1936,7 +1953,7 @@ H5CX_get_btree_split_ratios(double split_ratio[3])
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_BTREE_SPLIT_RATIO_NAME,
                              btree_split_ratio)
@@ -1945,7 +1962,7 @@ H5CX_get_btree_split_ratios(double split_ratio[3])
     H5MM_memcpy(split_ratio, &(*head)->ctx.btree_split_ratio, sizeof((*head)->ctx.btree_split_ratio));
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_btree_split_ratios() */
@@ -1973,7 +1990,7 @@ H5CX_get_max_temp_buf(size_t *max_temp_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MAX_TEMP_BUF_NAME, max_temp_buf)
 
@@ -1981,7 +1998,7 @@ H5CX_get_max_temp_buf(size_t *max_temp_buf)
     *max_temp_buf = (*head)->ctx.max_temp_buf;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_max_temp_buf() */
@@ -2009,7 +2026,7 @@ H5CX_get_tconv_buf(void **tconv_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_TCONV_BUF_NAME, tconv_buf)
 
@@ -2017,7 +2034,7 @@ H5CX_get_tconv_buf(void **tconv_buf)
     *tconv_buf = (*head)->ctx.tconv_buf;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_tconv_buf() */
@@ -2045,7 +2062,7 @@ H5CX_get_bkgr_buf(void **bkgr_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_BKGR_BUF_NAME, bkgr_buf)
 
@@ -2053,7 +2070,7 @@ H5CX_get_bkgr_buf(void **bkgr_buf)
     *bkgr_buf = (*head)->ctx.bkgr_buf;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_bkgr_buf() */
@@ -2081,7 +2098,7 @@ H5CX_get_bkgr_buf_type(H5T_bkg_t *bkgr_buf_type)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_BKGR_BUF_TYPE_NAME, bkgr_buf_type)
 
@@ -2089,7 +2106,7 @@ H5CX_get_bkgr_buf_type(H5T_bkg_t *bkgr_buf_type)
     *bkgr_buf_type = (*head)->ctx.bkgr_buf_type;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_bkgr_buf_type() */
@@ -2117,7 +2134,7 @@ H5CX_get_vec_size(size_t *vec_size)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_HYPER_VECTOR_SIZE_NAME, vec_size)
 
@@ -2125,7 +2142,7 @@ H5CX_get_vec_size(size_t *vec_size)
     *vec_size = (*head)->ctx.vec_size;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vec_size() */
@@ -2155,7 +2172,7 @@ H5CX_get_io_xfer_mode(H5FD_mpio_xfer_t *io_xfer_mode)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_IO_XFER_MODE_NAME, io_xfer_mode)
 
@@ -2163,7 +2180,7 @@ H5CX_get_io_xfer_mode(H5FD_mpio_xfer_t *io_xfer_mode)
     *io_xfer_mode = (*head)->ctx.io_xfer_mode;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_io_xfer_mode() */
@@ -2191,7 +2208,7 @@ H5CX_get_mpio_coll_opt(H5FD_mpio_collective_opt_t *mpio_coll_opt)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_COLLECTIVE_OPT_NAME, mpio_coll_opt)
 
@@ -2199,7 +2216,7 @@ H5CX_get_mpio_coll_opt(H5FD_mpio_collective_opt_t *mpio_coll_opt)
     *mpio_coll_opt = (*head)->ctx.mpio_coll_opt;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_coll_opt() */
@@ -2227,7 +2244,7 @@ H5CX_get_mpio_local_no_coll_cause(uint32_t *mpio_local_no_coll_cause)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID_SET(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_MPIO_LOCAL_NO_COLLECTIVE_CAUSE_NAME,
                                  mpio_local_no_coll_cause)
@@ -2236,7 +2253,7 @@ H5CX_get_mpio_local_no_coll_cause(uint32_t *mpio_local_no_coll_cause)
     *mpio_local_no_coll_cause = (*head)->ctx.mpio_local_no_coll_cause;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_local_no_coll_cause() */
@@ -2264,7 +2281,7 @@ H5CX_get_mpio_global_no_coll_cause(uint32_t *mpio_global_no_coll_cause)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID_SET(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_MPIO_GLOBAL_NO_COLLECTIVE_CAUSE_NAME,
                                  mpio_global_no_coll_cause)
@@ -2273,7 +2290,7 @@ H5CX_get_mpio_global_no_coll_cause(uint32_t *mpio_global_no_coll_cause)
     *mpio_global_no_coll_cause = (*head)->ctx.mpio_global_no_coll_cause;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_global_no_coll_cause() */
@@ -2301,7 +2318,7 @@ H5CX_get_mpio_chunk_opt_mode(H5FD_mpio_chunk_opt_t *mpio_chunk_opt_mode)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_CHUNK_OPT_HARD_NAME,
                              mpio_chunk_opt_mode)
@@ -2310,7 +2327,7 @@ H5CX_get_mpio_chunk_opt_mode(H5FD_mpio_chunk_opt_t *mpio_chunk_opt_mode)
     *mpio_chunk_opt_mode = (*head)->ctx.mpio_chunk_opt_mode;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_chunk_opt_mode() */
@@ -2338,7 +2355,7 @@ H5CX_get_mpio_chunk_opt_num(unsigned *mpio_chunk_opt_num)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_CHUNK_OPT_NUM_NAME,
                              mpio_chunk_opt_num)
@@ -2347,7 +2364,7 @@ H5CX_get_mpio_chunk_opt_num(unsigned *mpio_chunk_opt_num)
     *mpio_chunk_opt_num = (*head)->ctx.mpio_chunk_opt_num;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_chunk_opt_num() */
@@ -2375,7 +2392,7 @@ H5CX_get_mpio_chunk_opt_ratio(unsigned *mpio_chunk_opt_ratio)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_CHUNK_OPT_RATIO_NAME,
                              mpio_chunk_opt_ratio)
@@ -2384,7 +2401,7 @@ H5CX_get_mpio_chunk_opt_ratio(unsigned *mpio_chunk_opt_ratio)
     *mpio_chunk_opt_ratio = (*head)->ctx.mpio_chunk_opt_ratio;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_chunk_opt_ratio() */
@@ -2413,7 +2430,7 @@ H5CX_get_err_detect(H5Z_EDC_t *err_detect)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_EDC_NAME, err_detect)
 
@@ -2421,7 +2438,7 @@ H5CX_get_err_detect(H5Z_EDC_t *err_detect)
     *err_detect = (*head)->ctx.err_detect;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_err_detect() */
@@ -2449,7 +2466,7 @@ H5CX_get_filter_cb(H5Z_cb_t *filter_cb)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_FILTER_CB_NAME, filter_cb)
 
@@ -2457,7 +2474,7 @@ H5CX_get_filter_cb(H5Z_cb_t *filter_cb)
     *filter_cb = (*head)->ctx.filter_cb;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_filter_cb() */
@@ -2485,7 +2502,7 @@ H5CX_get_data_transform(H5Z_data_xform_t **data_transform)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.data_transform_valid) {
@@ -2516,7 +2533,7 @@ H5CX_get_data_transform(H5Z_data_xform_t **data_transform)
     *data_transform = (*head)->ctx.data_transform;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_data_transform() */
@@ -2544,7 +2561,7 @@ H5CX_get_vlen_alloc_info(H5T_vlen_alloc_info_t *vl_alloc_info)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.vl_alloc_info_valid) {
@@ -2582,7 +2599,7 @@ H5CX_get_vlen_alloc_info(H5T_vlen_alloc_info_t *vl_alloc_info)
     *vl_alloc_info = (*head)->ctx.vl_alloc_info;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vlen_alloc_info() */
@@ -2610,7 +2627,7 @@ H5CX_get_dt_conv_cb(H5T_conv_cb_t *dt_conv_cb)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_CONV_CB_NAME, dt_conv_cb)
 
@@ -2618,7 +2635,7 @@ H5CX_get_dt_conv_cb(H5T_conv_cb_t *dt_conv_cb)
     *dt_conv_cb = (*head)->ctx.dt_conv_cb;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_dt_conv_cb() */
@@ -2646,7 +2663,7 @@ H5CX_get_selection_io_mode(H5D_selection_io_mode_t *selection_io_mode)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_SELECTION_IO_MODE_NAME,
                              selection_io_mode)
@@ -2655,7 +2672,7 @@ H5CX_get_selection_io_mode(H5D_selection_io_mode_t *selection_io_mode)
     *selection_io_mode = (*head)->ctx.selection_io_mode;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_selection_io_mode() */
@@ -2684,7 +2701,7 @@ H5CX_get_no_selection_io_cause(uint32_t *no_selection_io_cause)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID_SET(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_NO_SELECTION_IO_CAUSE_NAME,
                                  no_selection_io_cause)
@@ -2693,7 +2710,7 @@ H5CX_get_no_selection_io_cause(uint32_t *no_selection_io_cause)
     *no_selection_io_cause = (*head)->ctx.no_selection_io_cause;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_no_selection_io_cause() */
@@ -2721,7 +2738,7 @@ H5CX_get_modify_write_buf(hbool_t *modify_write_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MODIFY_WRITE_BUF_NAME, modify_write_buf)
 
@@ -2729,7 +2746,7 @@ H5CX_get_modify_write_buf(hbool_t *modify_write_buf)
     *modify_write_buf = (*head)->ctx.modify_write_buf;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_selection_io_mode() */
@@ -2757,7 +2774,7 @@ H5CX_get_encoding(H5T_cset_t *encoding)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.lcpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(lcpl, H5P_LINK_CREATE_DEFAULT, H5P_STRCRT_CHAR_ENCODING_NAME, encoding)
 
@@ -2765,7 +2782,7 @@ H5CX_get_encoding(H5T_cset_t *encoding)
     *encoding = (*head)->ctx.encoding;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_encoding() */
@@ -2793,7 +2810,7 @@ H5CX_get_intermediate_group(unsigned *crt_intermed_group)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.lcpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(lcpl, H5P_LINK_CREATE_DEFAULT, H5L_CRT_INTERMEDIATE_GROUP_NAME,
                              intermediate_group)
@@ -2802,7 +2819,7 @@ H5CX_get_intermediate_group(unsigned *crt_intermed_group)
     *crt_intermed_group = (*head)->ctx.intermediate_group;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_create_intermediate_group() */
@@ -2830,7 +2847,7 @@ H5CX_get_nlinks(size_t *nlinks)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(lapl, H5P_LINK_ACCESS_DEFAULT, H5L_ACS_NLINKS_NAME, nlinks)
 
@@ -2838,7 +2855,7 @@ H5CX_get_nlinks(size_t *nlinks)
     *nlinks = (*head)->ctx.nlinks;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_nlinks() */
@@ -2867,7 +2884,7 @@ H5CX_get_libver_bounds(H5F_libver_t *low_bound, H5F_libver_t *high_bound)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.fapl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(fapl, H5P_FILE_ACCESS_DEFAULT, H5F_ACS_LIBVER_LOW_BOUND_NAME, low_bound)
     H5CX_RETRIEVE_PROP_VALID(fapl, H5P_FILE_ACCESS_DEFAULT, H5F_ACS_LIBVER_HIGH_BOUND_NAME, high_bound)
@@ -2877,7 +2894,7 @@ H5CX_get_libver_bounds(H5F_libver_t *low_bound, H5F_libver_t *high_bound)
     *high_bound = (*head)->ctx.high_bound;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_libver_bounds() */
@@ -2906,7 +2923,7 @@ H5CX_get_dset_min_ohdr_flag(hbool_t *dset_min_ohdr_flag)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dcpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dcpl, H5P_DATASET_CREATE_DEFAULT, H5D_CRT_MIN_DSET_HDR_SIZE_NAME,
                              do_min_dset_ohdr)
@@ -2915,7 +2932,7 @@ H5CX_get_dset_min_ohdr_flag(hbool_t *dset_min_ohdr_flag)
     *dset_min_ohdr_flag = (*head)->ctx.do_min_dset_ohdr;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_dset_min_ohdr_flag() */
@@ -2943,7 +2960,7 @@ H5CX_get_ext_file_prefix(const char **extfile_prefix)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dapl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.extfile_prefix_valid) {
@@ -2974,7 +2991,7 @@ H5CX_get_ext_file_prefix(const char **extfile_prefix)
     *extfile_prefix = (*head)->ctx.extfile_prefix;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_ext_file_prefix() */
@@ -3002,7 +3019,7 @@ H5CX_get_vds_prefix(const char **vds_prefix)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dapl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.vds_prefix_valid) {
@@ -3033,7 +3050,7 @@ H5CX_get_vds_prefix(const char **vds_prefix)
     *vds_prefix = (*head)->ctx.vds_prefix;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vds_prefix() */
@@ -3058,11 +3075,11 @@ H5CX_set_tag(haddr_t tag)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     (*head)->ctx.tag = tag;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_tag() */
@@ -3087,11 +3104,11 @@ H5CX_set_ring(H5AC_ring_t ring)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     (*head)->ctx.ring = ring;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_ring() */
@@ -3118,11 +3135,11 @@ H5CX_set_coll_metadata_read(hbool_t cmdr)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     (*head)->ctx.coll_metadata_read = cmdr;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_coll_metadata_read() */
@@ -3151,13 +3168,13 @@ H5CX_set_mpi_coll_datatypes(MPI_Datatype btype, MPI_Datatype ftype)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context values */
     (*head)->ctx.btype = btype;
     (*head)->ctx.ftype = ftype;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_mpi_coll_datatypes() */
@@ -3183,7 +3200,7 @@ H5CX_set_io_xfer_mode(H5FD_mpio_xfer_t io_xfer_mode)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context value */
     (*head)->ctx.io_xfer_mode = io_xfer_mode;
@@ -3191,7 +3208,7 @@ H5CX_set_io_xfer_mode(H5FD_mpio_xfer_t io_xfer_mode)
     /* Mark the value as valid */
     (*head)->ctx.io_xfer_mode_valid = TRUE;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_io_xfer_mode() */
@@ -3217,7 +3234,7 @@ H5CX_set_mpio_coll_opt(H5FD_mpio_collective_opt_t mpio_coll_opt)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context value */
     (*head)->ctx.mpio_coll_opt = mpio_coll_opt;
@@ -3225,7 +3242,7 @@ H5CX_set_mpio_coll_opt(H5FD_mpio_collective_opt_t mpio_coll_opt)
     /* Mark the value as valid */
     (*head)->ctx.mpio_coll_opt_valid = TRUE;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_mpio_coll_opt() */
@@ -3250,11 +3267,11 @@ H5CX_set_mpi_file_flushing(hbool_t flushing)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     (*head)->ctx.mpi_file_flushing = flushing;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpi_file_flushing() */
@@ -3280,11 +3297,11 @@ H5CX_set_mpio_rank0_bcast(hbool_t rank0_bcast)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     (*head)->ctx.rank0_bcast = rank0_bcast;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_rank0_bcast() */
@@ -3311,7 +3328,7 @@ H5CX_set_vlen_alloc_info(H5MM_allocate_t alloc_func, void *alloc_info, H5MM_free
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context value */
     (*head)->ctx.vl_alloc_info.alloc_func = alloc_func;
@@ -3322,7 +3339,7 @@ H5CX_set_vlen_alloc_info(H5MM_allocate_t alloc_func, void *alloc_info, H5MM_free
     /* Mark the value as valid */
     (*head)->ctx.vl_alloc_info_valid = TRUE;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_vlen_alloc_info() */
@@ -3348,7 +3365,7 @@ H5CX_set_nlinks(size_t nlinks)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Set the API context value */
     (*head)->ctx.nlinks = nlinks;
@@ -3356,7 +3373,7 @@ H5CX_set_nlinks(size_t nlinks)
     /* Mark the value as valid */
     (*head)->ctx.nlinks_valid = TRUE;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_nlinks() */
@@ -3384,13 +3401,13 @@ H5CX_set_mpio_actual_chunk_opt(H5D_mpio_actual_chunk_opt_mode_t mpio_actual_chun
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Cache the value for later, marking it to set in DXPL when context popped */
     (*head)->ctx.mpio_actual_chunk_opt     = mpio_actual_chunk_opt;
     (*head)->ctx.mpio_actual_chunk_opt_set = TRUE;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_actual_chunk_opt() */
@@ -3416,13 +3433,13 @@ H5CX_set_mpio_actual_io_mode(H5D_mpio_actual_io_mode_t mpio_actual_io_mode)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Cache the value for later, marking it to set in DXPL when context popped */
     (*head)->ctx.mpio_actual_io_mode     = mpio_actual_io_mode;
     (*head)->ctx.mpio_actual_io_mode_set = TRUE;
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_actual_chunk_opt() */
@@ -3448,7 +3465,7 @@ H5CX_set_mpio_local_no_coll_cause(uint32_t mpio_local_no_coll_cause)
     assert(head && *head);
     assert((*head)->ctx.dxpl_id != H5P_DEFAULT);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* If we're using the default DXPL, don't modify it */
     if ((*head)->ctx.dxpl_id != H5P_DATASET_XFER_DEFAULT) {
@@ -3457,7 +3474,7 @@ H5CX_set_mpio_local_no_coll_cause(uint32_t mpio_local_no_coll_cause)
         (*head)->ctx.mpio_local_no_coll_cause_set = TRUE;
     } /* end if */
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_local_no_coll_cause() */
@@ -3483,7 +3500,7 @@ H5CX_set_mpio_global_no_coll_cause(uint32_t mpio_global_no_coll_cause)
     assert(head && *head);
     assert((*head)->ctx.dxpl_id != H5P_DEFAULT);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* If we're using the default DXPL, don't modify it */
     if ((*head)->ctx.dxpl_id != H5P_DATASET_XFER_DEFAULT) {
@@ -3492,7 +3509,7 @@ H5CX_set_mpio_global_no_coll_cause(uint32_t mpio_global_no_coll_cause)
         (*head)->ctx.mpio_global_no_coll_cause_set = TRUE;
     } /* end if */
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_global_no_coll_cause() */
@@ -3523,12 +3540,12 @@ H5CX_test_set_mpio_coll_chunk_link_hard(int mpio_coll_chunk_link_hard)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_HARD_NAME, mpio_coll_chunk_link_hard)
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_link_hard() */
@@ -3557,12 +3574,12 @@ H5CX_test_set_mpio_coll_chunk_multi_hard(int mpio_coll_chunk_multi_hard)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_HARD_NAME, mpio_coll_chunk_multi_hard)
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_multi_hard() */
@@ -3591,12 +3608,12 @@ H5CX_test_set_mpio_coll_chunk_link_num_true(int mpio_coll_chunk_link_num_true)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_NUM_TRUE_NAME, mpio_coll_chunk_link_num_true)
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_link_num_true() */
@@ -3626,12 +3643,12 @@ H5CX_test_set_mpio_coll_chunk_link_num_false(int mpio_coll_chunk_link_num_false)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_NUM_FALSE_NAME, mpio_coll_chunk_link_num_false)
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_link_num_false() */
@@ -3661,12 +3678,12 @@ H5CX_test_set_mpio_coll_chunk_multi_ratio_coll(int mpio_coll_chunk_multi_ratio_c
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_RATIO_COLL_NAME, mpio_coll_chunk_multi_ratio_coll)
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_multi_ratio_coll() */
@@ -3696,12 +3713,12 @@ H5CX_test_set_mpio_coll_chunk_multi_ratio_ind(int mpio_coll_chunk_multi_ratio_in
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_RATIO_IND_NAME, mpio_coll_chunk_multi_ratio_ind)
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_multi_ratio_ind() */
@@ -3730,12 +3747,12 @@ H5CX_test_set_mpio_coll_rank0_bcast(hbool_t mpio_coll_rank0_bcast)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_RANK0_BCAST_NAME, mpio_coll_rank0_bcast)
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_rank0_bcast() */
@@ -3764,7 +3781,7 @@ H5CX_set_no_selection_io_cause(uint32_t no_selection_io_cause)
     assert(head && *head);
     assert((*head)->ctx.dxpl_id != H5P_DEFAULT);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* If we're using the default DXPL, don't modify it */
     if ((*head)->ctx.dxpl_id != H5P_DATASET_XFER_DEFAULT) {
@@ -3773,7 +3790,7 @@ H5CX_set_no_selection_io_cause(uint32_t no_selection_io_cause)
         (*head)->ctx.no_selection_io_cause_set = TRUE;
     } /* end if */
 
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_no_selectiion_io_cause() */
@@ -3801,7 +3818,7 @@ H5CX_get_ohdr_flags(uint8_t *ohdr_flags)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dcpl_id);
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     H5CX_RETRIEVE_PROP_VALID(dcpl, H5P_DATASET_CREATE_DEFAULT, H5O_CRT_OHDR_FLAGS_NAME, ohdr_flags)
 
@@ -3809,7 +3826,7 @@ H5CX_get_ohdr_flags(uint8_t *ohdr_flags)
     *ohdr_flags = (*head)->ctx.ohdr_flags;
 
 done:
-    H5TS_vlock_release(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* End H5CX_get_ohdr_flags() */
@@ -3836,7 +3853,7 @@ H5CX__pop_common(hbool_t update_dxpl_props)
     assert(head && *head);
 
     /* Unmatched H5TS_vlock_acquire() because the context is soon to be released */
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
 
     /* Check for cached DXPL properties to return to application */
     if (update_dxpl_props) {
@@ -3893,3 +3910,58 @@ H5CX_pop(hbool_t update_dxpl_props)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_pop() */
+
+#ifdef H5_HAVE_VIRTUAL_LOCK
+
+/*-------------------------------------------------------------------------
+ * Function:    H5CX__vlock_init
+ *
+ * Purpose:     Initializes the virtual lock for the context.
+ * 
+ *-------------------------------------------------------------------------
+ */
+static void H5CX__vlock_init(H5CX_t *ctx) {
+    assert(ctx);
+
+    FUNC_ENTER_PACKAGE_NAMECHECK_ONLY
+
+    H5TS_vlock_init(&ctx->vlock);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    H5CX__vlock_acquire
+ *
+ * Purpose:     Acquires the virtual lock for the context.
+ * 
+ *-------------------------------------------------------------------------
+ */
+static void H5CX__vlock_acquire(H5CX_t *ctx, H5TS_vlock_op_type_t op_type) {
+    assert(ctx);
+
+    FUNC_ENTER_PACKAGE_NAMECHECK_ONLY
+
+    H5TS_vlock_acquire(&ctx->vlock, op_type);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    H5CX__vlock_release
+ *
+ * Purpose:     Releases the virtual lock for the context.
+ *
+ *-------------------------------------------------------------------------
+ */
+static void H5CX__vlock_release(H5CX_t *ctx, H5TS_vlock_op_type_t op_type) {
+    assert(ctx);
+
+    FUNC_ENTER_PACKAGE_NAMECHECK_ONLY
+
+    H5TS_vlock_release(&ctx->vlock, op_type);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
+}
+
+#endif

--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -336,7 +336,9 @@ typedef struct H5CX_t {
     void   *vol_wrap_ctx;                     /* VOL connector's "wrap context" for creating IDs */
     hbool_t vol_wrap_ctx_valid; /* Whether VOL connector's "wrap context" for creating IDs is valid */
 
+#if H5_HAVE_VIRTUAL_LOCK
     H5TS_vlock_t vlock; /* Virtual lock to verify thread-safe access to the context */
+#endif
 } H5CX_t;
 
 /* Typedef for nodes on the API context stack */
@@ -429,20 +431,24 @@ typedef struct H5CX_fapl_cache_t {
 static H5CX_node_t **H5CX__get_context(void);
 #endif /* H5_HAVE_THREADSAFE or H5_HAVE_MULTITHREAD */
 
-#ifdef H5_HAVE_VIRTUAL_LOCK
+#if H5_HAVE_VIRTUAL_LOCK
 static void H5CX__vlock_init(H5CX_t *ctx);
 static void H5CX__vlock_acquire(H5CX_t *ctx, H5TS_vlock_op_type_t op_type);
 static void H5CX__vlock_release(H5CX_t *ctx, H5TS_vlock_op_type_t op_type);
 
 #define H5CX_VLOCK_INIT(ctx) H5CX__vlock_init(ctx)
-#define H5CX_VLOCK_ACQUIRE(ctx, op_type) H5CX__vlock_acquire(ctx, op_type)
-#define H5CX_VLOCK_RELEASE(ctx, op_type) H5CX__vlock_release(ctx, op_type)
+#define H5CX_VLOCK_ACQUIRE_W(ctx) H5CX__vlock_acquire(ctx, H5TS_VLOCK_WRITER)
+#define H5CX_VLOCK_ACQUIRE_R(ctx) H5CX__vlock_acquire(ctx, H5TS_VLOCK_READER)
+#define H5CX_VLOCK_RELEASE_W(ctx) H5CX__vlock_release(ctx, H5TS_VLOCK_WRITER)
+#define H5CX_VLOCK_RELEASE_R(ctx) H5CX__vlock_release(ctx, H5TS_VLOCK_READER)
 
 #else /* H5_HAVE_VIRTUAL_LOCK */
 
 #define H5CX_VLOCK_INIT(ctx)
-#define H5CX_VLOCK_ACQUIRE(ctx, op_type)
-#define H5CX_VLOCK_RELEASE(ctx, op_type)
+#define H5CX_VLOCK_ACQUIRE_W(ctx)
+#define H5CX_VLOCK_ACQUIRE_R(ctx)
+#define H5CX_VLOCK_RELEASE_W(ctx)
+#define H5CX_VLOCK_RELEASE_R(ctx)
 
 #endif /* H5_HAVE_VIRTUAL_LOCK */
 
@@ -903,7 +909,7 @@ H5CX_retrieve_state(H5CX_state_t **api_state)
     assert(head && *head);
     assert(api_state);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Allocate & clear API context state */
     if (NULL == (*api_state = H5FL_CALLOC(H5CX_state_t)))
@@ -1007,7 +1013,7 @@ H5CX_retrieve_state(H5CX_state_t **api_state)
 #endif /* H5_HAVE_PARALLEL */
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     /* Cleanup on error */
     if (ret_value < 0) {
@@ -1048,7 +1054,7 @@ H5CX_restore_state(const H5CX_state_t *api_state)
     assert(head && *head);
     assert(api_state);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Restore the DCPL info */
     (*head)->ctx.dcpl_id = api_state->dcpl_id;
@@ -1083,7 +1089,7 @@ H5CX_restore_state(const H5CX_state_t *api_state)
     (*head)->ctx.coll_metadata_read = api_state->coll_metadata_read;
 #endif /* H5_HAVE_PARALLEL */
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5CX_restore_state() */
@@ -1173,12 +1179,12 @@ H5CX_is_def_dxpl(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Set return value */
     is_def_dxpl = ((*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT);
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(is_def_dxpl)
 } /* end H5CX_is_def_dxpl() */
@@ -1203,12 +1209,12 @@ H5CX_set_dxpl(hid_t dxpl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context's DXPL to a new value */
     (*head)->ctx.dxpl_id = dxpl_id;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_dxpl() */
@@ -1233,12 +1239,12 @@ H5CX_set_dcpl(hid_t dcpl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context's DCPL to a new value */
     (*head)->ctx.dcpl_id = dcpl_id;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_dcpl() */
@@ -1265,7 +1271,7 @@ H5CX_set_libver_bounds(H5F_t *f)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context value */
     (*head)->ctx.low_bound  = (f == NULL) ? H5F_LIBVER_LATEST : H5F_LOW_BOUND(f);
@@ -1275,7 +1281,7 @@ H5CX_set_libver_bounds(H5F_t *f)
     (*head)->ctx.low_bound_valid  = TRUE;
     (*head)->ctx.high_bound_valid = TRUE;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_libver_bounds() */
@@ -1300,12 +1306,12 @@ H5CX_set_lcpl(hid_t lcpl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context's LCPL to a new value */
     (*head)->ctx.lcpl_id = lcpl_id;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_lcpl() */
@@ -1330,12 +1336,12 @@ H5CX_set_lapl(hid_t lapl_id)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context's LAPL to a new value */
     (*head)->ctx.lapl_id = lapl_id;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_lapl() */
@@ -1374,7 +1380,7 @@ H5CX_set_apl(hid_t *acspl_id, const H5P_libclass_t *libclass,
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set access plist to the default property list of the appropriate class if it's the generic default */
     if (H5P_DEFAULT == *acspl_id)
@@ -1460,7 +1466,7 @@ H5CX_set_apl(hid_t *acspl_id, const H5P_libclass_t *libclass,
 #endif    /* H5_HAVE_PARALLEL */
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_apl() */
 
@@ -1493,7 +1499,7 @@ H5CX_set_loc(hid_t
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set collective metadata read flag */
     (*head)->ctx.coll_metadata_read = TRUE;
@@ -1515,7 +1521,7 @@ H5CX_set_loc(hid_t
     } /* end if */
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
     FUNC_LEAVE_NOAPI(ret_value)
 #else  /* H5_HAVE_PARALLEL */
     FUNC_ENTER_NOAPI_NOINIT_NOERR
@@ -1545,7 +1551,7 @@ H5CX_set_vol_wrap_ctx(void *vol_wrap_ctx)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context value */
     (*head)->ctx.vol_wrap_ctx = vol_wrap_ctx;
@@ -1553,7 +1559,7 @@ H5CX_set_vol_wrap_ctx(void *vol_wrap_ctx)
     /* Mark the value as valid */
     (*head)->ctx.vol_wrap_ctx_valid = TRUE;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_vol_wrap_ctx() */
@@ -1579,7 +1585,7 @@ H5CX_set_vol_connector_prop(const H5VL_connector_prop_t *vol_connector_prop)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context value */
     H5MM_memcpy(&(*head)->ctx.vol_connector_prop, vol_connector_prop, sizeof(H5VL_connector_prop_t));
@@ -1587,7 +1593,7 @@ H5CX_set_vol_connector_prop(const H5VL_connector_prop_t *vol_connector_prop)
     /* Mark the value as valid */
     (*head)->ctx.vol_connector_prop_valid = TRUE;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_vol_connector_prop() */
@@ -1613,12 +1619,12 @@ H5CX_get_dxpl(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Set return value */
     dxpl_id = (*head)->ctx.dxpl_id;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(dxpl_id)
 } /* end H5CX_get_dxpl() */
@@ -1644,12 +1650,12 @@ H5CX_get_lapl(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Set return value */
     lapl_id = (*head)->ctx.lapl_id;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(lapl_id)
 } /* end H5CX_get_lapl() */
@@ -1684,7 +1690,7 @@ H5CX_get_vol_wrap_ctx(void **vol_wrap_ctx)
     if (!(*head))
         HGOTO_ERROR(H5E_CONTEXT, H5E_CANTGET, FAIL, "unable to get the current API context");
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Check for value that was set */
     if ((*head)->ctx.vol_wrap_ctx_valid)
@@ -1693,7 +1699,7 @@ H5CX_get_vol_wrap_ctx(void **vol_wrap_ctx)
     else
         *vol_wrap_ctx = NULL;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1721,7 +1727,7 @@ H5CX_get_vol_connector_prop(H5VL_connector_prop_t *vol_connector_prop)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Check for value that was set */
     if ((*head)->ctx.vol_connector_prop_valid)
@@ -1730,7 +1736,7 @@ H5CX_get_vol_connector_prop(H5VL_connector_prop_t *vol_connector_prop)
     else
         memset(vol_connector_prop, 0, sizeof(H5VL_connector_prop_t));
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vol_connector_prop() */
@@ -1756,12 +1762,12 @@ H5CX_get_tag(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Set return value */
     tag = (*head)->ctx.tag;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(tag)
 } /* end H5CX_get_tag() */
@@ -1787,12 +1793,12 @@ H5CX_get_ring(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Set return value */
     ring = (*head)->ctx.ring;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ring)
 } /* end H5CX_get_ring() */
@@ -1820,12 +1826,12 @@ H5CX_get_coll_metadata_read(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Set return value */
     coll_md_read = (*head)->ctx.coll_metadata_read;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(coll_md_read)
 } /* end H5CX_get_coll_metadata_read() */
@@ -1855,13 +1861,13 @@ H5CX_get_mpi_coll_datatypes(MPI_Datatype *btype, MPI_Datatype *ftype)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Set the API context values */
     *btype = (*head)->ctx.btype;
     *ftype = (*head)->ctx.ftype;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpi_coll_datatypes() */
@@ -1887,12 +1893,12 @@ H5CX_get_mpi_file_flushing(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Set return value */
     flushing = (*head)->ctx.mpi_file_flushing;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(flushing)
 } /* end H5CX_get_mpi_file_flushing() */
@@ -1919,12 +1925,12 @@ H5CX_get_mpio_rank0_bcast(void)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Set return value */
     do_rank0_bcast = (*head)->ctx.rank0_bcast;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(do_rank0_bcast)
 } /* end H5CX_get_mpio_rank0_bcast() */
@@ -1953,7 +1959,7 @@ H5CX_get_btree_split_ratios(double split_ratio[3])
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_BTREE_SPLIT_RATIO_NAME,
                              btree_split_ratio)
@@ -1962,7 +1968,7 @@ H5CX_get_btree_split_ratios(double split_ratio[3])
     H5MM_memcpy(split_ratio, &(*head)->ctx.btree_split_ratio, sizeof((*head)->ctx.btree_split_ratio));
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_btree_split_ratios() */
@@ -1990,7 +1996,7 @@ H5CX_get_max_temp_buf(size_t *max_temp_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MAX_TEMP_BUF_NAME, max_temp_buf)
 
@@ -1998,7 +2004,7 @@ H5CX_get_max_temp_buf(size_t *max_temp_buf)
     *max_temp_buf = (*head)->ctx.max_temp_buf;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_max_temp_buf() */
@@ -2026,7 +2032,7 @@ H5CX_get_tconv_buf(void **tconv_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_TCONV_BUF_NAME, tconv_buf)
 
@@ -2034,7 +2040,7 @@ H5CX_get_tconv_buf(void **tconv_buf)
     *tconv_buf = (*head)->ctx.tconv_buf;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_tconv_buf() */
@@ -2062,7 +2068,7 @@ H5CX_get_bkgr_buf(void **bkgr_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_BKGR_BUF_NAME, bkgr_buf)
 
@@ -2070,7 +2076,7 @@ H5CX_get_bkgr_buf(void **bkgr_buf)
     *bkgr_buf = (*head)->ctx.bkgr_buf;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_bkgr_buf() */
@@ -2098,7 +2104,7 @@ H5CX_get_bkgr_buf_type(H5T_bkg_t *bkgr_buf_type)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_BKGR_BUF_TYPE_NAME, bkgr_buf_type)
 
@@ -2106,7 +2112,7 @@ H5CX_get_bkgr_buf_type(H5T_bkg_t *bkgr_buf_type)
     *bkgr_buf_type = (*head)->ctx.bkgr_buf_type;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_bkgr_buf_type() */
@@ -2134,7 +2140,7 @@ H5CX_get_vec_size(size_t *vec_size)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_HYPER_VECTOR_SIZE_NAME, vec_size)
 
@@ -2142,7 +2148,7 @@ H5CX_get_vec_size(size_t *vec_size)
     *vec_size = (*head)->ctx.vec_size;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vec_size() */
@@ -2172,7 +2178,7 @@ H5CX_get_io_xfer_mode(H5FD_mpio_xfer_t *io_xfer_mode)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_IO_XFER_MODE_NAME, io_xfer_mode)
 
@@ -2180,7 +2186,7 @@ H5CX_get_io_xfer_mode(H5FD_mpio_xfer_t *io_xfer_mode)
     *io_xfer_mode = (*head)->ctx.io_xfer_mode;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_io_xfer_mode() */
@@ -2208,7 +2214,7 @@ H5CX_get_mpio_coll_opt(H5FD_mpio_collective_opt_t *mpio_coll_opt)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_COLLECTIVE_OPT_NAME, mpio_coll_opt)
 
@@ -2216,7 +2222,7 @@ H5CX_get_mpio_coll_opt(H5FD_mpio_collective_opt_t *mpio_coll_opt)
     *mpio_coll_opt = (*head)->ctx.mpio_coll_opt;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_coll_opt() */
@@ -2244,7 +2250,7 @@ H5CX_get_mpio_local_no_coll_cause(uint32_t *mpio_local_no_coll_cause)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID_SET(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_MPIO_LOCAL_NO_COLLECTIVE_CAUSE_NAME,
                                  mpio_local_no_coll_cause)
@@ -2253,7 +2259,7 @@ H5CX_get_mpio_local_no_coll_cause(uint32_t *mpio_local_no_coll_cause)
     *mpio_local_no_coll_cause = (*head)->ctx.mpio_local_no_coll_cause;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_local_no_coll_cause() */
@@ -2281,7 +2287,7 @@ H5CX_get_mpio_global_no_coll_cause(uint32_t *mpio_global_no_coll_cause)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID_SET(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_MPIO_GLOBAL_NO_COLLECTIVE_CAUSE_NAME,
                                  mpio_global_no_coll_cause)
@@ -2290,7 +2296,7 @@ H5CX_get_mpio_global_no_coll_cause(uint32_t *mpio_global_no_coll_cause)
     *mpio_global_no_coll_cause = (*head)->ctx.mpio_global_no_coll_cause;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_global_no_coll_cause() */
@@ -2318,7 +2324,7 @@ H5CX_get_mpio_chunk_opt_mode(H5FD_mpio_chunk_opt_t *mpio_chunk_opt_mode)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_CHUNK_OPT_HARD_NAME,
                              mpio_chunk_opt_mode)
@@ -2327,7 +2333,7 @@ H5CX_get_mpio_chunk_opt_mode(H5FD_mpio_chunk_opt_t *mpio_chunk_opt_mode)
     *mpio_chunk_opt_mode = (*head)->ctx.mpio_chunk_opt_mode;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_chunk_opt_mode() */
@@ -2355,7 +2361,7 @@ H5CX_get_mpio_chunk_opt_num(unsigned *mpio_chunk_opt_num)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_CHUNK_OPT_NUM_NAME,
                              mpio_chunk_opt_num)
@@ -2364,7 +2370,7 @@ H5CX_get_mpio_chunk_opt_num(unsigned *mpio_chunk_opt_num)
     *mpio_chunk_opt_num = (*head)->ctx.mpio_chunk_opt_num;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_chunk_opt_num() */
@@ -2392,7 +2398,7 @@ H5CX_get_mpio_chunk_opt_ratio(unsigned *mpio_chunk_opt_ratio)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MPIO_CHUNK_OPT_RATIO_NAME,
                              mpio_chunk_opt_ratio)
@@ -2401,7 +2407,7 @@ H5CX_get_mpio_chunk_opt_ratio(unsigned *mpio_chunk_opt_ratio)
     *mpio_chunk_opt_ratio = (*head)->ctx.mpio_chunk_opt_ratio;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_mpio_chunk_opt_ratio() */
@@ -2430,7 +2436,7 @@ H5CX_get_err_detect(H5Z_EDC_t *err_detect)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_EDC_NAME, err_detect)
 
@@ -2438,7 +2444,7 @@ H5CX_get_err_detect(H5Z_EDC_t *err_detect)
     *err_detect = (*head)->ctx.err_detect;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_err_detect() */
@@ -2466,7 +2472,7 @@ H5CX_get_filter_cb(H5Z_cb_t *filter_cb)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_FILTER_CB_NAME, filter_cb)
 
@@ -2474,7 +2480,7 @@ H5CX_get_filter_cb(H5Z_cb_t *filter_cb)
     *filter_cb = (*head)->ctx.filter_cb;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_filter_cb() */
@@ -2502,7 +2508,7 @@ H5CX_get_data_transform(H5Z_data_xform_t **data_transform)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.data_transform_valid) {
@@ -2533,7 +2539,7 @@ H5CX_get_data_transform(H5Z_data_xform_t **data_transform)
     *data_transform = (*head)->ctx.data_transform;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_data_transform() */
@@ -2561,7 +2567,7 @@ H5CX_get_vlen_alloc_info(H5T_vlen_alloc_info_t *vl_alloc_info)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.vl_alloc_info_valid) {
@@ -2599,7 +2605,7 @@ H5CX_get_vlen_alloc_info(H5T_vlen_alloc_info_t *vl_alloc_info)
     *vl_alloc_info = (*head)->ctx.vl_alloc_info;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vlen_alloc_info() */
@@ -2627,7 +2633,7 @@ H5CX_get_dt_conv_cb(H5T_conv_cb_t *dt_conv_cb)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_CONV_CB_NAME, dt_conv_cb)
 
@@ -2635,7 +2641,7 @@ H5CX_get_dt_conv_cb(H5T_conv_cb_t *dt_conv_cb)
     *dt_conv_cb = (*head)->ctx.dt_conv_cb;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_dt_conv_cb() */
@@ -2663,7 +2669,7 @@ H5CX_get_selection_io_mode(H5D_selection_io_mode_t *selection_io_mode)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_SELECTION_IO_MODE_NAME,
                              selection_io_mode)
@@ -2672,7 +2678,7 @@ H5CX_get_selection_io_mode(H5D_selection_io_mode_t *selection_io_mode)
     *selection_io_mode = (*head)->ctx.selection_io_mode;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_selection_io_mode() */
@@ -2701,7 +2707,7 @@ H5CX_get_no_selection_io_cause(uint32_t *no_selection_io_cause)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID_SET(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_NO_SELECTION_IO_CAUSE_NAME,
                                  no_selection_io_cause)
@@ -2710,7 +2716,7 @@ H5CX_get_no_selection_io_cause(uint32_t *no_selection_io_cause)
     *no_selection_io_cause = (*head)->ctx.no_selection_io_cause;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_no_selection_io_cause() */
@@ -2738,7 +2744,7 @@ H5CX_get_modify_write_buf(hbool_t *modify_write_buf)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dxpl, H5P_DATASET_XFER_DEFAULT, H5D_XFER_MODIFY_WRITE_BUF_NAME, modify_write_buf)
 
@@ -2746,7 +2752,7 @@ H5CX_get_modify_write_buf(hbool_t *modify_write_buf)
     *modify_write_buf = (*head)->ctx.modify_write_buf;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_selection_io_mode() */
@@ -2774,7 +2780,7 @@ H5CX_get_encoding(H5T_cset_t *encoding)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.lcpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(lcpl, H5P_LINK_CREATE_DEFAULT, H5P_STRCRT_CHAR_ENCODING_NAME, encoding)
 
@@ -2782,7 +2788,7 @@ H5CX_get_encoding(H5T_cset_t *encoding)
     *encoding = (*head)->ctx.encoding;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_encoding() */
@@ -2810,7 +2816,7 @@ H5CX_get_intermediate_group(unsigned *crt_intermed_group)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.lcpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(lcpl, H5P_LINK_CREATE_DEFAULT, H5L_CRT_INTERMEDIATE_GROUP_NAME,
                              intermediate_group)
@@ -2819,7 +2825,7 @@ H5CX_get_intermediate_group(unsigned *crt_intermed_group)
     *crt_intermed_group = (*head)->ctx.intermediate_group;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_create_intermediate_group() */
@@ -2847,7 +2853,7 @@ H5CX_get_nlinks(size_t *nlinks)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dxpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(lapl, H5P_LINK_ACCESS_DEFAULT, H5L_ACS_NLINKS_NAME, nlinks)
 
@@ -2855,7 +2861,7 @@ H5CX_get_nlinks(size_t *nlinks)
     *nlinks = (*head)->ctx.nlinks;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_nlinks() */
@@ -2884,7 +2890,7 @@ H5CX_get_libver_bounds(H5F_libver_t *low_bound, H5F_libver_t *high_bound)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.fapl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(fapl, H5P_FILE_ACCESS_DEFAULT, H5F_ACS_LIBVER_LOW_BOUND_NAME, low_bound)
     H5CX_RETRIEVE_PROP_VALID(fapl, H5P_FILE_ACCESS_DEFAULT, H5F_ACS_LIBVER_HIGH_BOUND_NAME, high_bound)
@@ -2894,7 +2900,7 @@ H5CX_get_libver_bounds(H5F_libver_t *low_bound, H5F_libver_t *high_bound)
     *high_bound = (*head)->ctx.high_bound;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_libver_bounds() */
@@ -2923,7 +2929,7 @@ H5CX_get_dset_min_ohdr_flag(hbool_t *dset_min_ohdr_flag)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dcpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dcpl, H5P_DATASET_CREATE_DEFAULT, H5D_CRT_MIN_DSET_HDR_SIZE_NAME,
                              do_min_dset_ohdr)
@@ -2932,7 +2938,7 @@ H5CX_get_dset_min_ohdr_flag(hbool_t *dset_min_ohdr_flag)
     *dset_min_ohdr_flag = (*head)->ctx.do_min_dset_ohdr;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_dset_min_ohdr_flag() */
@@ -2960,7 +2966,7 @@ H5CX_get_ext_file_prefix(const char **extfile_prefix)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dapl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.extfile_prefix_valid) {
@@ -2991,7 +2997,7 @@ H5CX_get_ext_file_prefix(const char **extfile_prefix)
     *extfile_prefix = (*head)->ctx.extfile_prefix;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_ext_file_prefix() */
@@ -3019,7 +3025,7 @@ H5CX_get_vds_prefix(const char **vds_prefix)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dapl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     /* Check if the value has been retrieved already */
     if (!(*head)->ctx.vds_prefix_valid) {
@@ -3050,7 +3056,7 @@ H5CX_get_vds_prefix(const char **vds_prefix)
     *vds_prefix = (*head)->ctx.vds_prefix;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_get_vds_prefix() */
@@ -3075,11 +3081,11 @@ H5CX_set_tag(haddr_t tag)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     (*head)->ctx.tag = tag;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_tag() */
@@ -3104,11 +3110,11 @@ H5CX_set_ring(H5AC_ring_t ring)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     (*head)->ctx.ring = ring;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_ring() */
@@ -3135,11 +3141,11 @@ H5CX_set_coll_metadata_read(hbool_t cmdr)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     (*head)->ctx.coll_metadata_read = cmdr;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_coll_metadata_read() */
@@ -3168,13 +3174,13 @@ H5CX_set_mpi_coll_datatypes(MPI_Datatype btype, MPI_Datatype ftype)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context values */
     (*head)->ctx.btype = btype;
     (*head)->ctx.ftype = ftype;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_mpi_coll_datatypes() */
@@ -3200,7 +3206,7 @@ H5CX_set_io_xfer_mode(H5FD_mpio_xfer_t io_xfer_mode)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context value */
     (*head)->ctx.io_xfer_mode = io_xfer_mode;
@@ -3208,7 +3214,7 @@ H5CX_set_io_xfer_mode(H5FD_mpio_xfer_t io_xfer_mode)
     /* Mark the value as valid */
     (*head)->ctx.io_xfer_mode_valid = TRUE;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_io_xfer_mode() */
@@ -3234,7 +3240,7 @@ H5CX_set_mpio_coll_opt(H5FD_mpio_collective_opt_t mpio_coll_opt)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context value */
     (*head)->ctx.mpio_coll_opt = mpio_coll_opt;
@@ -3242,7 +3248,7 @@ H5CX_set_mpio_coll_opt(H5FD_mpio_collective_opt_t mpio_coll_opt)
     /* Mark the value as valid */
     (*head)->ctx.mpio_coll_opt_valid = TRUE;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_mpio_coll_opt() */
@@ -3267,11 +3273,11 @@ H5CX_set_mpi_file_flushing(hbool_t flushing)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     (*head)->ctx.mpi_file_flushing = flushing;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpi_file_flushing() */
@@ -3297,11 +3303,11 @@ H5CX_set_mpio_rank0_bcast(hbool_t rank0_bcast)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     (*head)->ctx.rank0_bcast = rank0_bcast;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_rank0_bcast() */
@@ -3328,7 +3334,7 @@ H5CX_set_vlen_alloc_info(H5MM_allocate_t alloc_func, void *alloc_info, H5MM_free
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context value */
     (*head)->ctx.vl_alloc_info.alloc_func = alloc_func;
@@ -3339,7 +3345,7 @@ H5CX_set_vlen_alloc_info(H5MM_allocate_t alloc_func, void *alloc_info, H5MM_free
     /* Mark the value as valid */
     (*head)->ctx.vl_alloc_info_valid = TRUE;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_vlen_alloc_info() */
@@ -3365,7 +3371,7 @@ H5CX_set_nlinks(size_t nlinks)
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
     assert(head && *head);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Set the API context value */
     (*head)->ctx.nlinks = nlinks;
@@ -3373,7 +3379,7 @@ H5CX_set_nlinks(size_t nlinks)
     /* Mark the value as valid */
     (*head)->ctx.nlinks_valid = TRUE;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_set_nlinks() */
@@ -3401,13 +3407,13 @@ H5CX_set_mpio_actual_chunk_opt(H5D_mpio_actual_chunk_opt_mode_t mpio_actual_chun
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Cache the value for later, marking it to set in DXPL when context popped */
     (*head)->ctx.mpio_actual_chunk_opt     = mpio_actual_chunk_opt;
     (*head)->ctx.mpio_actual_chunk_opt_set = TRUE;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_actual_chunk_opt() */
@@ -3433,13 +3439,13 @@ H5CX_set_mpio_actual_io_mode(H5D_mpio_actual_io_mode_t mpio_actual_io_mode)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Cache the value for later, marking it to set in DXPL when context popped */
     (*head)->ctx.mpio_actual_io_mode     = mpio_actual_io_mode;
     (*head)->ctx.mpio_actual_io_mode_set = TRUE;
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_actual_chunk_opt() */
@@ -3465,7 +3471,7 @@ H5CX_set_mpio_local_no_coll_cause(uint32_t mpio_local_no_coll_cause)
     assert(head && *head);
     assert((*head)->ctx.dxpl_id != H5P_DEFAULT);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* If we're using the default DXPL, don't modify it */
     if ((*head)->ctx.dxpl_id != H5P_DATASET_XFER_DEFAULT) {
@@ -3474,7 +3480,7 @@ H5CX_set_mpio_local_no_coll_cause(uint32_t mpio_local_no_coll_cause)
         (*head)->ctx.mpio_local_no_coll_cause_set = TRUE;
     } /* end if */
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_local_no_coll_cause() */
@@ -3500,7 +3506,7 @@ H5CX_set_mpio_global_no_coll_cause(uint32_t mpio_global_no_coll_cause)
     assert(head && *head);
     assert((*head)->ctx.dxpl_id != H5P_DEFAULT);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* If we're using the default DXPL, don't modify it */
     if ((*head)->ctx.dxpl_id != H5P_DATASET_XFER_DEFAULT) {
@@ -3509,7 +3515,7 @@ H5CX_set_mpio_global_no_coll_cause(uint32_t mpio_global_no_coll_cause)
         (*head)->ctx.mpio_global_no_coll_cause_set = TRUE;
     } /* end if */
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_mpio_global_no_coll_cause() */
@@ -3540,12 +3546,12 @@ H5CX_test_set_mpio_coll_chunk_link_hard(int mpio_coll_chunk_link_hard)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_HARD_NAME, mpio_coll_chunk_link_hard)
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_link_hard() */
@@ -3574,12 +3580,12 @@ H5CX_test_set_mpio_coll_chunk_multi_hard(int mpio_coll_chunk_multi_hard)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_HARD_NAME, mpio_coll_chunk_multi_hard)
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_multi_hard() */
@@ -3608,12 +3614,12 @@ H5CX_test_set_mpio_coll_chunk_link_num_true(int mpio_coll_chunk_link_num_true)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_NUM_TRUE_NAME, mpio_coll_chunk_link_num_true)
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_link_num_true() */
@@ -3643,12 +3649,12 @@ H5CX_test_set_mpio_coll_chunk_link_num_false(int mpio_coll_chunk_link_num_false)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_LINK_NUM_FALSE_NAME, mpio_coll_chunk_link_num_false)
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_link_num_false() */
@@ -3678,12 +3684,12 @@ H5CX_test_set_mpio_coll_chunk_multi_ratio_coll(int mpio_coll_chunk_multi_ratio_c
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_RATIO_COLL_NAME, mpio_coll_chunk_multi_ratio_coll)
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_multi_ratio_coll() */
@@ -3713,12 +3719,12 @@ H5CX_test_set_mpio_coll_chunk_multi_ratio_ind(int mpio_coll_chunk_multi_ratio_in
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_CHUNK_MULTI_RATIO_IND_NAME, mpio_coll_chunk_multi_ratio_ind)
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_chunk_multi_ratio_ind() */
@@ -3747,12 +3753,12 @@ H5CX_test_set_mpio_coll_rank0_bcast(hbool_t mpio_coll_rank0_bcast)
     assert(head && *head);
     assert(!((*head)->ctx.dxpl_id == H5P_DEFAULT || (*head)->ctx.dxpl_id == H5P_DATASET_XFER_DEFAULT));
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     H5CX_TEST_SET_PROP(H5D_XFER_COLL_RANK0_BCAST_NAME, mpio_coll_rank0_bcast)
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_test_set_mpio_coll_rank0_bcast() */
@@ -3781,7 +3787,7 @@ H5CX_set_no_selection_io_cause(uint32_t no_selection_io_cause)
     assert(head && *head);
     assert((*head)->ctx.dxpl_id != H5P_DEFAULT);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* If we're using the default DXPL, don't modify it */
     if ((*head)->ctx.dxpl_id != H5P_DATASET_XFER_DEFAULT) {
@@ -3790,7 +3796,7 @@ H5CX_set_no_selection_io_cause(uint32_t no_selection_io_cause)
         (*head)->ctx.no_selection_io_cause_set = TRUE;
     } /* end if */
 
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_RELEASE_W(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI_VOID
 } /* end H5CX_set_no_selectiion_io_cause() */
@@ -3818,7 +3824,7 @@ H5CX_get_ohdr_flags(uint8_t *ohdr_flags)
     assert(head && *head);
     assert(H5P_DEFAULT != (*head)->ctx.dcpl_id);
 
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_ACQUIRE_R(&(*head)->ctx);
 
     H5CX_RETRIEVE_PROP_VALID(dcpl, H5P_DATASET_CREATE_DEFAULT, H5O_CRT_OHDR_FLAGS_NAME, ohdr_flags)
 
@@ -3826,7 +3832,7 @@ H5CX_get_ohdr_flags(uint8_t *ohdr_flags)
     *ohdr_flags = (*head)->ctx.ohdr_flags;
 
 done:
-    H5CX_VLOCK_RELEASE(&(*head)->ctx, H5TS_VLOCK_READER);
+    H5CX_VLOCK_RELEASE_R(&(*head)->ctx);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* End H5CX_get_ohdr_flags() */
@@ -3853,7 +3859,7 @@ H5CX__pop_common(hbool_t update_dxpl_props)
     assert(head && *head);
 
     /* Unmatched H5TS_vlock_acquire() because the context is soon to be released */
-    H5CX_VLOCK_ACQUIRE(&(*head)->ctx, H5TS_VLOCK_WRITER);
+    H5CX_VLOCK_ACQUIRE_W(&(*head)->ctx);
 
     /* Check for cached DXPL properties to return to application */
     if (update_dxpl_props) {
@@ -3911,7 +3917,7 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5CX_pop() */
 
-#ifdef H5_HAVE_VIRTUAL_LOCK
+#if H5_HAVE_VIRTUAL_LOCK
 
 /*-------------------------------------------------------------------------
  * Function:    H5CX__vlock_init

--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -1658,8 +1658,6 @@ H5CX_get_vol_wrap_ctx(void **vol_wrap_ctx)
     assert(vol_wrap_ctx);
     head = H5CX_get_my_context(); /* Get the pointer to the head of the API context, for this thread */
 
-    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
-
     /* No error is expected at this point.  But in case an application calls H5VLwrap_register
      * which doesn't reset the API context and there is no context, returns a relevant error here
      */
@@ -1668,6 +1666,8 @@ H5CX_get_vol_wrap_ctx(void **vol_wrap_ctx)
 
     if (!(*head))
         HGOTO_ERROR(H5E_CONTEXT, H5E_CANTGET, FAIL, "unable to get the current API context");
+
+    H5TS_vlock_acquire(&(*head)->ctx.vlock, H5TS_VLOCK_READER);
 
     /* Check for value that was set */
     if ((*head)->ctx.vol_wrap_ctx_valid)

--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -444,11 +444,11 @@ static void H5CX__vlock_release(H5CX_t *ctx, H5TS_vlock_op_type_t op_type);
 
 #else /* H5_HAVE_VIRTUAL_LOCK */
 
-#define H5CX_VLOCK_INIT(ctx)
-#define H5CX_VLOCK_ACQUIRE_W(ctx)
-#define H5CX_VLOCK_ACQUIRE_R(ctx)
-#define H5CX_VLOCK_RELEASE_W(ctx)
-#define H5CX_VLOCK_RELEASE_R(ctx)
+#define H5CX_VLOCK_INIT(ctx) (void) ctx
+#define H5CX_VLOCK_ACQUIRE_W(ctx) (void) ctx
+#define H5CX_VLOCK_ACQUIRE_R(ctx) (void) ctx
+#define H5CX_VLOCK_RELEASE_W(ctx) (void) ctx
+#define H5CX_VLOCK_RELEASE_R(ctx) (void) ctx
 
 #endif /* H5_HAVE_VIRTUAL_LOCK */
 

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -1687,7 +1687,7 @@ H5D__open_oid(H5D_t *dataset, hid_t dapl_id)
     /* Get the type and space */
     if (NULL == (dataset->shared->type = (H5T_t *)H5O_msg_read(&(dataset->oloc), H5O_DTYPE_ID, NULL)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to load type info from dataset header");
-
+    H5T_VLOCK_INIT(dataset->shared->type);
     if (H5T_set_loc(dataset->shared->type, H5F_VOL_OBJ(dataset->oloc.file), H5T_LOC_DISK) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "invalid datatype location");
 

--- a/src/H5Ocopy.c
+++ b/src/H5Ocopy.c
@@ -1256,7 +1256,7 @@ H5O__copy_search_comm_dt_check(H5O_loc_t *obj_oloc, H5O_copy_search_comm_dt_ud_t
         /* Read the destination datatype */
         if (NULL == (key->dt = (H5T_t *)H5O_msg_read(obj_oloc, H5O_DTYPE_ID, NULL)))
             HGOTO_ERROR(H5E_OHDR, H5E_CANTGET, FAIL, "can't read DTYPE message");
-
+        H5T_VLOCK_INIT(key->dt);
         /* Get destination object fileno */
         H5F_GET_FILENO(obj_oloc->file, key->fileno);
 
@@ -1281,7 +1281,7 @@ H5O__copy_search_comm_dt_check(H5O_loc_t *obj_oloc, H5O_copy_search_comm_dt_ud_t
         /* Read the destination datatype */
         if (NULL == (key->dt = (H5T_t *)H5O_msg_read(obj_oloc, H5O_DTYPE_ID, NULL)))
             HGOTO_ERROR(H5E_OHDR, H5E_CANTGET, FAIL, "can't read DTYPE message");
-
+        H5T_VLOCK_INIT(key->dt);
         /* Check if the datatype is committed and search the skip list if so */
         if (H5T_is_named(key->dt)) {
             /* Get datatype object fileno */
@@ -1424,7 +1424,7 @@ H5O__copy_search_comm_dt(H5F_t *file_src, H5O_t *oh_src, H5O_loc_t *oloc_dst /*i
     /* Read the source datatype */
     if (NULL == (key->dt = (H5T_t *)H5O_msg_read_oh(file_src, oh_src, H5O_DTYPE_ID, NULL)))
         HGOTO_ERROR(H5E_OHDR, H5E_CANTGET, FAIL, "can't read DTYPE message");
-
+    H5T_VLOCK_INIT(key->dt);
     /* Get destination object fileno */
     H5F_GET_FILENO(oloc_dst->file, key->fileno);
 
@@ -1588,6 +1588,7 @@ H5O__copy_insert_comm_dt(H5F_t *file_src, H5O_t *oh_src, H5O_loc_t *oloc_dst, H5
      * object could be changed in the post-copy. */
     if (NULL == (key->dt = (H5T_t *)H5O_msg_read_oh(file_src, oh_src, H5O_DTYPE_ID, NULL)))
         HGOTO_ERROR(H5E_OHDR, H5E_CANTGET, FAIL, "can't read DTYPE message");
+    H5T_VLOCK_INIT(key->dt);
 
     /* Get destination object fileno */
     H5F_GET_FILENO(oloc_dst->file, key->fileno);

--- a/src/H5Ofill.c
+++ b/src/H5Ofill.c
@@ -365,6 +365,8 @@ H5O__fill_old_decode(H5F_t *f, H5O_t *open_oh, unsigned H5_ATTR_UNUSED mesg_flag
         if (exists) {
             if (NULL == (dt = (H5T_t *)H5O_msg_read_oh(f, open_oh, H5O_DTYPE_ID, NULL)))
                 HGOTO_ERROR(H5E_SYM, H5E_CANTGET, NULL, "can't read DTYPE message");
+            H5T_VLOCK_INIT(dt);
+
             /* Verify size */
             if (fill->size != (ssize_t)H5T_GET_SIZE(dt))
                 HGOTO_ERROR(H5E_SYM, H5E_CANTGET, NULL, "inconsistent fill value size");

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -1933,7 +1933,9 @@ H5Sextent_equal(hid_t space1_id, hid_t space2_id)
     if (NULL == (ds2 = (H5S_t *)H5I_object_verify(space2_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
 
-    H5S_VLOCK_ACQUIRE_R(ds2);
+    /* Avoid double locking if a space is being compared to itself */
+    if (memcmp(ds1, ds2, sizeof(H5S_t) != 0))
+        H5S_VLOCK_ACQUIRE_R(ds2);
 
     /* Check dataspaces for extent's equality */
     if ((ret_value = H5S_extent_equal((const H5S_t*) ds1, (const H5S_t*) ds2)) < 0)
@@ -1942,7 +1944,7 @@ H5Sextent_equal(hid_t space1_id, hid_t space2_id)
 done:
     if (ds1)
         H5S_VLOCK_RELEASE_R(ds1);
-    if (ds2)
+    if (ds2 && (memcmp(ds1, ds2, sizeof(H5S_t) != 0)))
         H5S_VLOCK_RELEASE_R(ds2);
 
     FUNC_LEAVE_API(ret_value)

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -1949,3 +1949,69 @@ H5S_set_version(H5F_t *f, H5S_t *ds)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5S_set_version() */
+
+#if H5_HAVE_VIRTUAL_LOCK
+/*-------------------------------------------------------------------------
+ * Function:    H5S_vlock_init
+ *
+ * Purpose:     Initialize a virtual lock on a dataspace
+ *
+ *              The virtual lock exists to to verify
+ *              the assumption of exclusive access to a dataspace object.
+ *
+ *-------------------------------------------------------------------------
+ */
+void
+H5S_vlock_init(H5S_t *space) {
+    assert(space);
+
+    FUNC_ENTER_NOAPI_NAMECHECK_ONLY
+
+    H5TS_vlock_init(&space->vlock);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    H5S_vlock_acquire
+ *
+ * Purpose:     Acquire a virtual lock on a dataspace
+ *
+ *              The virtual lock exists to to verify
+ *              the assumption of exclusive access to a dataspace object.
+ *
+ *-------------------------------------------------------------------------
+ */
+void
+H5S_vlock_acquire(H5S_t *space, H5TS_vlock_op_type_t op_type) {
+    assert(space);
+
+    FUNC_ENTER_NOAPI_NAMECHECK_ONLY
+
+    H5TS_vlock_acquire(&space->vlock, op_type);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    H5S_vlock_release
+ *
+ * Purpose:     Release a virtual lock on a dataspace
+ *
+ *              The virtual lock exists to to verify
+ *              the assumption of exclusive access to a dataspace object.
+ *
+ * -------------------------------------------------------------------------
+ */
+void
+H5S_vlock_release(H5S_t *space, H5TS_vlock_op_type_t op_type) {
+    assert(space);
+
+    FUNC_ENTER_NOAPI_NAMECHECK_ONLY
+
+    H5TS_vlock_release(&space->vlock, op_type);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
+}
+
+#endif /* H5_HAVE_VIRTUAL_LOCK */

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -218,6 +218,9 @@ H5S__close_cb(void *_space, void H5_ATTR_UNUSED **request)
     /* Sanity check */
     assert(space);
 
+    /* Acquire write-lock before destroying the dataspace */
+    H5S_VLOCK_ACQUIRE_W(space);
+
     /* Close the dataspace object */
     if (H5S_close(space) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CLOSEERROR, FAIL, "unable to close dataspace");
@@ -292,6 +295,8 @@ H5S_create(H5S_class_t type)
     if (H5O_msg_reset_share(H5O_SDSPACE_ID, &(new_ds->extent.sh_loc)) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTRESET, NULL, "unable to reset shared component info");
 
+    H5S_VLOCK_INIT(new_ds);
+
     /* Set return value */
     ret_value = new_ds;
 
@@ -337,11 +342,16 @@ H5Screate(H5S_class_t type)
     if (NULL == (new_ds = H5S_create(type)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCREATE, FAIL, "unable to create dataspace");
 
+    H5S_VLOCK_ACQUIRE_R(new_ds);
+
     /* Register */
     if ((ret_value = H5I_register(H5I_DATASPACE, new_ds, TRUE)) < 0)
         HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, FAIL, "unable to register dataspace ID");
 
 done:
+    if (new_ds)
+        H5S_VLOCK_RELEASE_R(new_ds);
+
     if (ret_value < 0)
         if (new_ds && H5S_close(new_ds) < 0)
             HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, FAIL, "unable to release dataspace");
@@ -470,15 +480,25 @@ H5Scopy(hid_t space_id)
     if (NULL == (src = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a dataspace");
 
+    H5S_VLOCK_ACQUIRE_R(src);
+
     /* Copy */
     if (NULL == (dst = H5S_copy(src, FALSE, TRUE)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, H5I_INVALID_HID, "unable to copy dataspace");
+
+    H5S_VLOCK_ACQUIRE_R(dst);
 
     /* Register */
     if ((ret_value = H5I_register(H5I_DATASPACE, dst, TRUE)) < 0)
         HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register dataspace ID");
 
 done:
+    if (src)
+        H5S_VLOCK_RELEASE_R(src);
+
+    if (dst)
+        H5S_VLOCK_RELEASE_R(dst);
+
     if (ret_value < 0)
         if (dst && H5S_close(dst) < 0)
             HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, H5I_INVALID_HID, "unable to release dataspace");
@@ -508,14 +528,22 @@ H5Sextent_copy(hid_t dst_id, hid_t src_id)
     /* Check args */
     if (NULL == (src = (H5S_t *)H5I_object_verify(src_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
+    H5S_VLOCK_ACQUIRE_R(src);
+
     if (NULL == (dst = (H5S_t *)H5I_object_verify(dst_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
+    H5S_VLOCK_ACQUIRE_W(dst);
 
     /* Copy */
     if (H5S_extent_copy(dst, src) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCOPY, FAIL, "can't copy extent");
 
 done:
+    if (src)
+        H5S_VLOCK_RELEASE_R(src);
+    if (dst)
+        H5S_VLOCK_RELEASE_W(dst);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sextent_copy() */
 
@@ -644,6 +672,8 @@ H5S_copy(const H5S_t *src, hbool_t share_selection, hbool_t copy_max)
     if (NULL == (dst = H5FL_CALLOC(H5S_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
+    H5S_VLOCK_ACQUIRE_W(dst);
+
     /* Copy the source dataspace's extent */
     if (H5S__extent_copy_real(&(dst->extent), &(src->extent), copy_max) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCOPY, NULL, "can't copy extent");
@@ -656,6 +686,9 @@ H5S_copy(const H5S_t *src, hbool_t share_selection, hbool_t copy_max)
     ret_value = dst;
 
 done:
+    if (dst)
+        H5S_VLOCK_RELEASE_W(dst);
+
     if (NULL == ret_value)
         if (dst)
             dst = H5FL_FREE(H5S_t, dst);
@@ -717,9 +750,14 @@ H5Sget_simple_extent_npoints(hid_t space_id)
     if (NULL == (ds = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
 
+    H5S_VLOCK_ACQUIRE_R(ds);
+
     ret_value = (hssize_t)H5S_GET_EXTENT_NPOINTS(ds);
 
 done:
+    if (ds)
+        H5S_VLOCK_RELEASE_R(ds);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sget_simple_extent_npoints() */
 
@@ -807,9 +845,14 @@ H5Sget_simple_extent_ndims(hid_t space_id)
     if (NULL == (ds = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, (-1), "not a dataspace");
 
+    H5S_VLOCK_ACQUIRE_R(ds);
+
     ret_value = (int)H5S_GET_EXTENT_NDIMS(ds);
 
 done:
+    if (ds)
+        H5S_VLOCK_RELEASE_R(ds);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sget_simple_extent_ndims() */
 
@@ -882,9 +925,14 @@ H5Sget_simple_extent_dims(hid_t space_id, hsize_t dims[] /*out*/, hsize_t maxdim
     if (NULL == (ds = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, (-1), "not a dataspace");
 
+    H5S_VLOCK_ACQUIRE_R(ds);
+
     ret_value = H5S_get_simple_extent_dims(ds, dims, maxdims);
 
 done:
+    if (ds)
+        H5S_VLOCK_RELEASE_R(ds);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sget_simple_extent_dims() */
 
@@ -1053,6 +1101,8 @@ H5S_read(const H5O_loc_t *loc)
     if (NULL == (ds = H5FL_CALLOC(H5S_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
+    H5S_VLOCK_ACQUIRE_W(ds);
+
     if (NULL == H5O_msg_read(loc, H5O_SDSPACE_ID, &(ds->extent)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, NULL, "unable to load dataspace info from dataset header");
 
@@ -1064,6 +1114,9 @@ H5S_read(const H5O_loc_t *loc)
     ret_value = ds;
 
 done:
+    if (ds)
+        H5S_VLOCK_RELEASE_W(ds);
+
     if (ret_value == NULL)
         if (ds != NULL)
             ds = H5FL_FREE(H5S_t, ds);
@@ -1129,9 +1182,14 @@ H5Sis_simple(hid_t space_id)
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "not a dataspace");
 
+    H5S_VLOCK_ACQUIRE_R(space);
+
     ret_value = H5S__is_simple(space);
 
 done:
+    if (space)
+        H5S_VLOCK_RELEASE_R(space);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sis_simple() */
 
@@ -1174,6 +1232,9 @@ H5Sset_extent_simple(hid_t space_id, int rank, const hsize_t dims[/*rank*/], con
     /* Check args */
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "not a dataspace");
+    
+    H5S_VLOCK_ACQUIRE_W(space);
+
     if (rank > 0 && dims == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no dimensions specified");
     if (rank < 0 || rank > H5S_MAX_RANK)
@@ -1197,6 +1258,9 @@ H5Sset_extent_simple(hid_t space_id, int rank, const hsize_t dims[/*rank*/], con
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, FAIL, "unable to set simple extent");
 
 done:
+    if (space)
+        H5S_VLOCK_RELEASE_W(space);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sset_extent_simple() */
 
@@ -1323,11 +1387,16 @@ H5Screate_simple(int rank, const hsize_t dims[/*rank*/], const hsize_t maxdims[/
     if (NULL == (space = H5S_create_simple((unsigned)rank, dims, maxdims)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCREATE, H5I_INVALID_HID, "can't create simple dataspace");
 
+    H5S_VLOCK_ACQUIRE_R(space);
+
     /* Register */
     if ((ret_value = H5I_register(H5I_DATASPACE, space, TRUE)) < 0)
         HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register dataspace ID");
 
 done:
+    if (space)
+        H5S_VLOCK_RELEASE_R(space);
+
     if (ret_value < 0)
         if (space && H5S_close(space) < 0)
             HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, H5I_INVALID_HID, "unable to release dataspace");
@@ -1358,10 +1427,16 @@ H5S_create_simple(unsigned rank, const hsize_t dims[/*rank*/], const hsize_t max
     /* Create the space and set the extent */
     if (NULL == (ret_value = H5S_create(H5S_SIMPLE)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCREATE, NULL, "can't create simple dataspace");
+    
+    H5S_VLOCK_ACQUIRE_W(ret_value);
+
     if (H5S_set_extent_simple(ret_value, rank, dims, maxdims) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, NULL, "can't set dimensions");
 
 done:
+    if(ret_value)
+        H5S_VLOCK_RELEASE_W(ret_value);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5S_create_simple() */
 
@@ -1391,6 +1466,8 @@ H5Sencode2(hid_t obj_id, void *buf, size_t *nalloc, hid_t fapl_id)
     if (NULL == (dspace = (H5S_t *)H5I_object_verify(obj_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
 
+    H5S_VLOCK_ACQUIRE_W(dspace);
+
     /* Verify access property list and set up collective metadata if appropriate */
     if (H5CX_set_apl(&fapl_id, H5P_CLS_FACC, H5I_INVALID_HID, TRUE) < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, H5I_INVALID_HID, "can't set access property list info");
@@ -1399,6 +1476,9 @@ H5Sencode2(hid_t obj_id, void *buf, size_t *nalloc, hid_t fapl_id)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTENCODE, FAIL, "can't encode dataspace");
 
 done:
+    if (dspace)
+        H5S_VLOCK_RELEASE_W(dspace);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sencode2() */
 
@@ -1502,11 +1582,16 @@ H5Sdecode(const void *buf)
     if ((ds = H5S_decode((const unsigned char **)&buf)) == NULL)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTDECODE, H5I_INVALID_HID, "can't decode object");
 
+    H5S_VLOCK_ACQUIRE_W(ds);
+
     /* Register the type and return the ID */
     if ((ret_value = H5I_register(H5I_DATASPACE, ds, TRUE)) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register dataspace");
 
 done:
+    if (ds)
+        H5S_VLOCK_RELEASE_W(ds);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sdecode() */
 
@@ -1563,6 +1648,7 @@ H5S_decode(const unsigned char **p)
     if (NULL == (ds = H5FL_CALLOC(H5S_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                     "memory allocation failed for dataspace conversion path table");
+    H5S_VLOCK_ACQUIRE_W(ds);
     if (NULL == H5O_msg_copy(H5O_SDSPACE_ID, extent, &(ds->extent)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCOPY, NULL, "can't copy object");
     if (H5S__extent_release(extent) < 0)
@@ -1583,6 +1669,9 @@ H5S_decode(const unsigned char **p)
     ret_value = ds;
 
 done:
+    if (ds)
+        H5S_VLOCK_RELEASE_W(ds);
+
     /* Release fake file structure */
     if (f && H5F_fake_free(f) < 0)
         HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, NULL, "unable to release fake file struct");
@@ -1643,9 +1732,14 @@ H5Sget_simple_extent_type(hid_t sid)
     if (NULL == (space = (H5S_t *)H5I_object_verify(sid, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5S_NO_CLASS, "not a dataspace");
 
+    H5S_VLOCK_ACQUIRE_R(space);
+
     ret_value = H5S_GET_EXTENT_TYPE(space);
 
 done:
+    if (space)
+        H5S_VLOCK_RELEASE_R(space);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sget_simple_extent_type() */
 
@@ -1676,6 +1770,8 @@ H5Sset_extent_none(hid_t space_id)
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "not a dataspace");
 
+    H5S_VLOCK_ACQUIRE_W(space);
+
     /* Clear the previous extent from the dataspace */
     if (H5S__extent_release(&space->extent) < 0)
         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTDELETE, FAIL, "can't release previous dataspace");
@@ -1683,6 +1779,9 @@ H5Sset_extent_none(hid_t space_id)
     space->extent.type = H5S_NULL;
 
 done:
+    if (space)
+        H5S_VLOCK_RELEASE_W(space);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sset_extent_none() */
 
@@ -1814,23 +1913,34 @@ done:
 htri_t
 H5Sextent_equal(hid_t space1_id, hid_t space2_id)
 {
-    const H5S_t *ds1; /* Dataspaces to compare */
-    const H5S_t *ds2;
+    H5S_t *ds1; /* Dataspaces to compare */
+    H5S_t *ds2;
     htri_t       ret_value;
 
     FUNC_ENTER_API(FAIL)
     H5TRACE2("t", "ii", space1_id, space2_id);
 
     /* check args */
-    if (NULL == (ds1 = (const H5S_t *)H5I_object_verify(space1_id, H5I_DATASPACE)) ||
-        NULL == (ds2 = (const H5S_t *)H5I_object_verify(space2_id, H5I_DATASPACE)))
+    if (NULL == (ds1 = (H5S_t *)H5I_object_verify(space1_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
 
+    H5S_VLOCK_ACQUIRE_R(ds1);
+
+    if (NULL == (ds2 = (H5S_t *)H5I_object_verify(space2_id, H5I_DATASPACE)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
+
+    H5S_VLOCK_ACQUIRE_R(ds2);
+
     /* Check dataspaces for extent's equality */
-    if ((ret_value = H5S_extent_equal(ds1, ds2)) < 0)
+    if ((ret_value = H5S_extent_equal((const H5S_t*) ds1, (const H5S_t*) ds2)) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCOMPARE, FAIL, "dataspace comparison failed");
 
 done:
+    if (ds1)
+        H5S_VLOCK_RELEASE_R(ds1);
+    if (ds2)
+        H5S_VLOCK_RELEASE_R(ds2);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sextent_equal() */
 

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -1933,8 +1933,8 @@ H5Sextent_equal(hid_t space1_id, hid_t space2_id)
     if (NULL == (ds2 = (H5S_t *)H5I_object_verify(space2_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
 
-    /* Avoid double locking if a space is being compared to itself */
-    if (memcmp(ds1, ds2, sizeof(H5S_t) != 0))
+    /* Avoid double-locking if a space is being compared to itself */
+    if (ds1 != ds2)
         H5S_VLOCK_ACQUIRE_R(ds2);
 
     /* Check dataspaces for extent's equality */
@@ -1944,7 +1944,7 @@ H5Sextent_equal(hid_t space1_id, hid_t space2_id)
 done:
     if (ds1)
         H5S_VLOCK_RELEASE_R(ds1);
-    if (ds2 && (memcmp(ds1, ds2, sizeof(H5S_t) != 0)))
+    if (ds2 && ds1 != ds2)
         H5S_VLOCK_RELEASE_R(ds2);
 
     FUNC_LEAVE_API(ret_value)

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -518,8 +518,8 @@ done:
 herr_t
 H5Sextent_copy(hid_t dst_id, hid_t src_id)
 {
-    H5S_t *src;
-    H5S_t *dst;
+    H5S_t *src = NULL;
+    H5S_t *dst = NULL;
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
@@ -672,6 +672,7 @@ H5S_copy(const H5S_t *src, hbool_t share_selection, hbool_t copy_max)
     if (NULL == (dst = H5FL_CALLOC(H5S_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
+    H5S_VLOCK_INIT(dst);
     H5S_VLOCK_ACQUIRE_W(dst);
 
     /* Copy the source dataspace's extent */
@@ -740,7 +741,7 @@ H5S_get_simple_extent_npoints(const H5S_t *ds)
 hssize_t
 H5Sget_simple_extent_npoints(hid_t space_id)
 {
-    H5S_t   *ds;
+    H5S_t   *ds = NULL;
     hssize_t ret_value;
 
     FUNC_ENTER_API(FAIL)
@@ -835,7 +836,7 @@ done:
 int
 H5Sget_simple_extent_ndims(hid_t space_id)
 {
-    H5S_t *ds;
+    H5S_t *ds = NULL;
     int    ret_value = -1;
 
     FUNC_ENTER_API((-1))
@@ -915,7 +916,7 @@ done:
 int
 H5Sget_simple_extent_dims(hid_t space_id, hsize_t dims[] /*out*/, hsize_t maxdims[] /*out*/)
 {
-    H5S_t *ds;
+    H5S_t *ds = NULL;
     int    ret_value = -1;
 
     FUNC_ENTER_API((-1))
@@ -1101,6 +1102,7 @@ H5S_read(const H5O_loc_t *loc)
     if (NULL == (ds = H5FL_CALLOC(H5S_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
+    H5S_VLOCK_INIT(ds);
     H5S_VLOCK_ACQUIRE_W(ds);
 
     if (NULL == H5O_msg_read(loc, H5O_SDSPACE_ID, &(ds->extent)))
@@ -1172,7 +1174,7 @@ H5S__is_simple(const H5S_t *sdim)
 htri_t
 H5Sis_simple(hid_t space_id)
 {
-    H5S_t *space;     /* Dataspace to check */
+    H5S_t *space = NULL; /* Dataspace to check */
     htri_t ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -1222,7 +1224,7 @@ done:
 herr_t
 H5Sset_extent_simple(hid_t space_id, int rank, const hsize_t dims[/*rank*/], const hsize_t max[/*rank*/])
 {
-    H5S_t *space;               /* Dataspace to modify */
+    H5S_t *space = NULL;        /* Dataspace to modify */
     int    u;                   /* Local counting variable */
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -1456,7 +1458,7 @@ done:
 herr_t
 H5Sencode2(hid_t obj_id, void *buf, size_t *nalloc, hid_t fapl_id)
 {
-    H5S_t *dspace;
+    H5S_t *dspace = NULL;
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
@@ -1570,7 +1572,7 @@ done:
 hid_t
 H5Sdecode(const void *buf)
 {
-    H5S_t *ds;
+    H5S_t *ds = NULL;
     hid_t  ret_value;
 
     FUNC_ENTER_API(H5I_INVALID_HID)
@@ -1611,7 +1613,7 @@ H5S_t *
 H5S_decode(const unsigned char **p)
 {
     H5F_t               *f = NULL;         /* Fake file structure*/
-    H5S_t               *ds;               /* Decoded dataspace */
+    H5S_t               *ds = NULL;        /* Decoded dataspace */
     H5S_extent_t        *extent;           /* Extent of decoded dataspace */
     const unsigned char *pp = (*p);        /* Local pointer for decoding */
     size_t               extent_size;      /* size of the extent message*/
@@ -1648,7 +1650,9 @@ H5S_decode(const unsigned char **p)
     if (NULL == (ds = H5FL_CALLOC(H5S_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                     "memory allocation failed for dataspace conversion path table");
+    H5S_VLOCK_INIT(ds);
     H5S_VLOCK_ACQUIRE_W(ds);
+
     if (NULL == H5O_msg_copy(H5O_SDSPACE_ID, extent, &(ds->extent)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCOPY, NULL, "can't copy object");
     if (H5S__extent_release(extent) < 0)
@@ -1722,7 +1726,7 @@ H5S_get_simple_extent_type(const H5S_t *space)
 H5S_class_t
 H5Sget_simple_extent_type(hid_t sid)
 {
-    H5S_t      *space;
+    H5S_t      *space = NULL;
     H5S_class_t ret_value; /* Return value */
 
     FUNC_ENTER_API(H5S_NO_CLASS)
@@ -1760,7 +1764,7 @@ done:
 herr_t
 H5Sset_extent_none(hid_t space_id)
 {
-    H5S_t *space;               /* Dataspace to modify */
+    H5S_t *space = NULL;        /* Dataspace to modify */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -1913,8 +1917,8 @@ done:
 htri_t
 H5Sextent_equal(hid_t space1_id, hid_t space2_id)
 {
-    H5S_t *ds1; /* Dataspaces to compare */
-    H5S_t *ds2;
+    H5S_t *ds1 = NULL; /* Dataspaces to compare */
+    H5S_t *ds2 = NULL;
     htri_t       ret_value;
 
     FUNC_ENTER_API(FAIL)

--- a/src/H5Sall.c
+++ b/src/H5Sall.c
@@ -643,6 +643,8 @@ H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hboo
     if (!*space) {
         if (NULL == (tmp_space = H5S_create(H5S_SIMPLE)))
             HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCREATE, FAIL, "can't create dataspace");
+         
+         H5S_VLOCK_ACQUIRE_W(tmp_space);
     } /* end if */
     else
         tmp_space = *space;
@@ -669,6 +671,9 @@ H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hboo
         *space = tmp_space;
 
 done:
+   if (!*space && tmp_space)
+      H5S_VLOCK_RELEASE_W(tmp_space);
+
     /* Free temporary space if not passed to caller (only happens on error) */
     if (!*space && tmp_space)
         if (H5S_close(tmp_space) < 0)
@@ -1161,10 +1166,15 @@ H5Sselect_all(hid_t spaceid)
     if (NULL == (space = (H5S_t *)H5I_object_verify(spaceid, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
 
+    H5S_VLOCK_ACQUIRE_W(space);
+
     /* Call internal routine to do the work */
     if (H5S_select_all(space, TRUE) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTDELETE, FAIL, "can't change selection");
 
 done:
+    if (space)
+      H5S_VLOCK_RELEASE_W(space);
+    
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sselect_all() */

--- a/src/H5Sall.c
+++ b/src/H5Sall.c
@@ -1156,7 +1156,7 @@ done:
 herr_t
 H5Sselect_all(hid_t spaceid)
 {
-    H5S_t *space;               /* Dataspace to modify selection of */
+    H5S_t *space = NULL;        /* Dataspace to modify selection of */
     herr_t ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)

--- a/src/H5Sdeprec.c
+++ b/src/H5Sdeprec.c
@@ -92,6 +92,8 @@ H5Sencode1(hid_t obj_id, void *buf, size_t *nalloc)
     if (NULL == (dspace = (H5S_t *)H5I_object_verify(obj_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
 
+    H5S_VLOCK_ACQUIRE_W(dspace);
+
     /* Verify access property list and set up collective metadata if appropriate */
     if (H5CX_set_apl(&temp_fapl_id, H5P_CLS_FACC, H5I_INVALID_HID, TRUE) < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, H5I_INVALID_HID, "can't set access property list info");
@@ -101,6 +103,8 @@ H5Sencode1(hid_t obj_id, void *buf, size_t *nalloc)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTENCODE, FAIL, "can't encode dataspace");
 
 done:
+    H5S_VLOCK_RELEASE_W(dspace);
+
     FUNC_LEAVE_API(ret_value)
 } /* H5Sencode1() */
 #endif /* H5_NO_DEPRECATED_SYMBOLS */

--- a/src/H5Sdeprec.c
+++ b/src/H5Sdeprec.c
@@ -81,7 +81,7 @@
 herr_t
 H5Sencode1(hid_t obj_id, void *buf, size_t *nalloc)
 {
-    H5S_t *dspace;
+    H5S_t *dspace       = NULL;
     hid_t  temp_fapl_id = H5P_DEFAULT;
     herr_t ret_value    = SUCCEED;
 

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -10784,7 +10784,9 @@ H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
     H5S_VLOCK_ACQUIRE_R(space1);
     if (NULL == (space2 = (H5S_t *)H5I_object_verify(space2_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a dataspace");
-    H5S_VLOCK_ACQUIRE_R(space2);
+    /* Avoid locking if the two dataspaces are the same */
+    if (memcmp(space1, space2, sizeof(H5S_t)) != 0)
+        H5S_VLOCK_ACQUIRE_R(space2);
     if (!(op >= H5S_SELECT_OR && op <= H5S_SELECT_NOTA))
         HGOTO_ERROR(H5E_ARGS, H5E_UNSUPPORTED, H5I_INVALID_HID, "invalid selection operation");
 
@@ -10820,7 +10822,7 @@ H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
 done:
     if (space1)
         H5S_VLOCK_RELEASE_R(space1);
-    if (space2)
+    if (space2 && (memcmp(space1, space2, sizeof(H5S_t)) != 0))
         H5S_VLOCK_RELEASE_R(space2);
     if (new_space)
         H5S_VLOCK_RELEASE_R(new_space);
@@ -10924,7 +10926,9 @@ H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
     H5S_VLOCK_ACQUIRE_W(space1);
     if (NULL == (space2 = (H5S_t *)H5I_object_verify(space2_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
-    H5S_VLOCK_ACQUIRE_W(space2);
+    /* Avoid locking if the two dataspaces are the same */
+    if (memcmp(space1, space2, sizeof(H5S_t)) != 0)
+        H5S_VLOCK_ACQUIRE_W(space2);
     if (!(op >= H5S_SELECT_OR && op <= H5S_SELECT_NOTA))
         HGOTO_ERROR(H5E_ARGS, H5E_UNSUPPORTED, FAIL, "invalid selection operation");
 
@@ -10969,7 +10973,7 @@ H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
 done:
     if (space1)
         H5S_VLOCK_RELEASE_W(space1);
-    if (space2)
+    if (space2 && (memcmp(space1, space2, sizeof(H5S_t)) != 0))
         H5S_VLOCK_RELEASE_W(space2);
     FUNC_LEAVE_API(ret_value)
 } /* end H5Smodify_select() */

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -3487,6 +3487,9 @@ H5Sget_select_hyper_nblocks(hid_t spaceid)
     /* Check args */
     if (NULL == (space = (H5S_t *)H5I_object_verify(spaceid, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
+    
+    H5S_VLOCK_ACQUIRE_R(space);
+
     if (H5S_GET_SELECT_TYPE(space) != H5S_SEL_HYPERSLABS)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a hyperslab selection");
     if (space->select.sel_info.hslab->unlim_dim >= 0)
@@ -3496,6 +3499,9 @@ H5Sget_select_hyper_nblocks(hid_t spaceid)
     ret_value = (hssize_t)H5S__get_select_hyper_nblocks(space, TRUE);
 
 done:
+    if (space)
+        H5S_VLOCK_RELEASE_R(space);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sget_select_hyper_nblocks() */
 
@@ -4245,6 +4251,8 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
     if (!*space) {
         if (NULL == (tmp_space = H5S_create(H5S_SIMPLE)))
             HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCREATE, FAIL, "can't create dataspace");
+
+        H5S_VLOCK_ACQUIRE_W(tmp_space);
     } /* end if */
     else
         tmp_space = *space;
@@ -4491,6 +4499,9 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, hb
         *space = tmp_space;
 
 done:
+    if (!*space && tmp_space)
+        H5S_VLOCK_RELEASE_W(tmp_space);
+
     /* Free temporary space if not passed to caller (only happens on error) */
     if (!*space && tmp_space)
         if (H5S_close(tmp_space) < 0)
@@ -4828,6 +4839,7 @@ H5Sget_select_hyper_blocklist(hid_t spaceid, hsize_t startblock, hsize_t numbloc
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid pointer");
     if (NULL == (space = (H5S_t *)H5I_object_verify(spaceid, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
+    H5S_VLOCK_ACQUIRE_R(space);
     if (H5S_GET_SELECT_TYPE(space) != H5S_SEL_HYPERSLABS)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a hyperslab selection");
     if (space->select.sel_info.hslab->unlim_dim >= 0)
@@ -4840,6 +4852,9 @@ H5Sget_select_hyper_blocklist(hid_t spaceid, hsize_t startblock, hsize_t numbloc
         ret_value = SUCCEED; /* Successfully got 0 blocks... */
 
 done:
+    if (space)
+        H5S_VLOCK_RELEASE_R(space);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sget_select_hyper_blocklist() */
 
@@ -10305,6 +10320,7 @@ H5Sselect_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_t start[], con
     /* Check args */
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
+    H5S_VLOCK_ACQUIRE_W(space);
     if (H5S_SCALAR == H5S_GET_EXTENT_TYPE(space))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "hyperslab doesn't support H5S_SCALAR space");
     if (H5S_NULL == H5S_GET_EXTENT_TYPE(space))
@@ -10326,6 +10342,8 @@ H5Sselect_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_t start[], con
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, FAIL, "unable to set hyperslab selection");
 
 done:
+    if (space)
+        H5S_VLOCK_RELEASE_W(space);
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sselect_hyperslab() */
 
@@ -10630,6 +10648,7 @@ H5Scombine_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_t start[], co
     /* Check args */
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a dataspace");
+    H5S_VLOCK_ACQUIRE_R(space);
     if (start == NULL || count == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "hyperslab not specified");
     if (!(op >= H5S_SELECT_SET && op <= H5S_SELECT_NOTA))
@@ -10639,11 +10658,18 @@ H5Scombine_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_t start[], co
     if (H5S_combine_hyperslab(space, op, start, stride, count, block, &new_space) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, H5I_INVALID_HID, "unable to set hyperslab selection");
 
+    H5S_VLOCK_ACQUIRE_R(new_space);
+
     /* Register */
     if ((ret_value = H5I_register(H5I_DATASPACE, new_space, TRUE)) < 0)
         HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register dataspace ID");
 
 done:
+    if (space)
+        H5S_VLOCK_RELEASE_R(space);
+    if (new_space)
+        H5S_VLOCK_RELEASE_R(new_space);
+
     if (ret_value < 0 && new_space)
         H5S_close(new_space);
 
@@ -10701,6 +10727,8 @@ H5S__combine_select(H5S_t *space1, H5S_seloper_t op, H5S_t *space2)
             HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCLIP, NULL, "can't clip hyperslab information");
     } /* end else */
 
+    H5S_VLOCK_ACQUIRE_W(new_space);
+
     /* Set unlim_dim */
     new_space->select.sel_info.hslab->unlim_dim = -1;
 
@@ -10708,6 +10736,9 @@ H5S__combine_select(H5S_t *space1, H5S_seloper_t op, H5S_t *space2)
     ret_value = new_space;
 
 done:
+    if (new_space)
+        H5S_VLOCK_RELEASE_W(new_space);
+
     if (ret_value == NULL && new_space)
         H5S_close(new_space);
 
@@ -10750,8 +10781,10 @@ H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
     /* Check args */
     if (NULL == (space1 = (H5S_t *)H5I_object_verify(space1_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a dataspace");
+    H5S_VLOCK_ACQUIRE_R(space1);
     if (NULL == (space2 = (H5S_t *)H5I_object_verify(space2_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a dataspace");
+    H5S_VLOCK_ACQUIRE_R(space2);
     if (!(op >= H5S_SELECT_OR && op <= H5S_SELECT_NOTA))
         HGOTO_ERROR(H5E_ARGS, H5E_UNSUPPORTED, H5I_INVALID_HID, "invalid selection operation");
 
@@ -10778,11 +10811,19 @@ H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
     if (NULL == (new_space = H5S__combine_select(space1, op, space2)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, H5I_INVALID_HID, "unable to create hyperslab selection");
 
+    H5S_VLOCK_ACQUIRE_R(new_space);
+
     /* Register */
     if ((ret_value = H5I_register(H5I_DATASPACE, new_space, TRUE)) < 0)
         HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register dataspace ID");
 
 done:
+    if (space1)
+        H5S_VLOCK_RELEASE_R(space1);
+    if (space2)
+        H5S_VLOCK_RELEASE_R(space2);
+    if (new_space)
+        H5S_VLOCK_RELEASE_R(new_space);
     if (ret_value < 0 && new_space)
         H5S_close(new_space);
 
@@ -10880,8 +10921,10 @@ H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
     /* Check args */
     if (NULL == (space1 = (H5S_t *)H5I_object_verify(space1_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
+    H5S_VLOCK_ACQUIRE_W(space1);
     if (NULL == (space2 = (H5S_t *)H5I_object_verify(space2_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
+    H5S_VLOCK_ACQUIRE_W(space2);
     if (!(op >= H5S_SELECT_OR && op <= H5S_SELECT_NOTA))
         HGOTO_ERROR(H5E_ARGS, H5E_UNSUPPORTED, FAIL, "invalid selection operation");
 
@@ -10924,6 +10967,10 @@ H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, FAIL, "unable to modify hyperslab selection");
 
 done:
+    if (space1)
+        H5S_VLOCK_RELEASE_W(space1);
+    if (space2)
+        H5S_VLOCK_RELEASE_W(space2);
     FUNC_LEAVE_API(ret_value)
 } /* end H5Smodify_select() */
 
@@ -12272,6 +12319,7 @@ H5S_hyper_get_unlim_block(const H5S_t *space, hsize_t block_index)
     /* Create output space, copy extent */
     if (NULL == (space_out = H5S_create(H5S_SIMPLE)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCREATE, NULL, "unable to create output dataspace");
+    H5S_VLOCK_ACQUIRE_W(space_out);
     if (H5S__extent_copy_real(&space_out->extent, &space->extent, TRUE) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCOPY, NULL, "unable to copy destination space extent");
 
@@ -12283,6 +12331,9 @@ H5S_hyper_get_unlim_block(const H5S_t *space, hsize_t block_index)
     ret_value = space_out;
 
 done:
+    if (space_out)
+        H5S_VLOCK_RELEASE_W(space_out);
+
     /* Free space on error */
     if (!ret_value)
         if (space_out && H5S_close(space_out) < 0)
@@ -12387,12 +12438,16 @@ H5Sis_regular_hyperslab(hid_t spaceid)
     /* Check args */
     if (NULL == (space = (H5S_t *)H5I_object_verify(spaceid, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
+    H5S_VLOCK_ACQUIRE_R(space);
     if (H5S_GET_SELECT_TYPE(space) != H5S_SEL_HYPERSLABS)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a hyperslab selection");
 
     ret_value = H5S__hyper_is_regular(space);
 
 done:
+    if (space)
+        H5S_VLOCK_RELEASE_R(space);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sis_regular_hyperslab() */
 
@@ -12436,6 +12491,7 @@ H5Sget_regular_hyperslab(hid_t spaceid, hsize_t start[] /*out*/, hsize_t stride[
     /* Check args */
     if (NULL == (space = (H5S_t *)H5I_object_verify(spaceid, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
+    H5S_VLOCK_ACQUIRE_R(space);
     if (H5S_GET_SELECT_TYPE(space) != H5S_SEL_HYPERSLABS)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a hyperslab selection");
     if (TRUE != H5S__hyper_is_regular(space))
@@ -12456,5 +12512,8 @@ H5Sget_regular_hyperslab(hid_t spaceid, hsize_t start[] /*out*/, hsize_t stride[
             block[u] = space->select.sel_info.hslab->diminfo.app[u].block;
 
 done:
+    if (space)
+        H5S_VLOCK_RELEASE_R(space);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Sget_regular_hyperslab() */

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -10784,8 +10784,8 @@ H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
     H5S_VLOCK_ACQUIRE_R(space1);
     if (NULL == (space2 = (H5S_t *)H5I_object_verify(space2_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a dataspace");
-    /* Avoid locking if the two dataspaces are the same */
-    if (memcmp(space1, space2, sizeof(H5S_t)) != 0)
+    /* Avoid double-locking the same dataspace twice */
+    if (space1 != space2)
         H5S_VLOCK_ACQUIRE_R(space2);
     if (!(op >= H5S_SELECT_OR && op <= H5S_SELECT_NOTA))
         HGOTO_ERROR(H5E_ARGS, H5E_UNSUPPORTED, H5I_INVALID_HID, "invalid selection operation");
@@ -10822,7 +10822,7 @@ H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
 done:
     if (space1)
         H5S_VLOCK_RELEASE_R(space1);
-    if (space2 && (memcmp(space1, space2, sizeof(H5S_t)) != 0))
+    if (space2 && space1 != space2)
         H5S_VLOCK_RELEASE_R(space2);
     if (new_space)
         H5S_VLOCK_RELEASE_R(new_space);
@@ -10926,8 +10926,8 @@ H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
     H5S_VLOCK_ACQUIRE_W(space1);
     if (NULL == (space2 = (H5S_t *)H5I_object_verify(space2_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a dataspace");
-    /* Avoid locking if the two dataspaces are the same */
-    if (memcmp(space1, space2, sizeof(H5S_t)) != 0)
+    /* Avoid double-locking the same dataspace twice */
+    if (space1 != space2)
         H5S_VLOCK_ACQUIRE_W(space2);
     if (!(op >= H5S_SELECT_OR && op <= H5S_SELECT_NOTA))
         HGOTO_ERROR(H5E_ARGS, H5E_UNSUPPORTED, FAIL, "invalid selection operation");
@@ -10973,7 +10973,7 @@ H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
 done:
     if (space1)
         H5S_VLOCK_RELEASE_W(space1);
-    if (space2 && (memcmp(space1, space2, sizeof(H5S_t)) != 0))
+    if (space2 && space1 != space2)
         H5S_VLOCK_RELEASE_W(space2);
     FUNC_LEAVE_API(ret_value)
 } /* end H5Smodify_select() */

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -3478,7 +3478,7 @@ H5S__get_select_hyper_nblocks(const H5S_t *space, hbool_t app_ref)
 hssize_t
 H5Sget_select_hyper_nblocks(hid_t spaceid)
 {
-    H5S_t   *space;     /* Dataspace to modify selection of */
+    H5S_t   *space = NULL;    /* Dataspace to modify selection of */
     hssize_t ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
@@ -4828,7 +4828,7 @@ herr_t
 H5Sget_select_hyper_blocklist(hid_t spaceid, hsize_t startblock, hsize_t numblocks,
                               hsize_t buf[/*numblocks*/] /*out*/)
 {
-    H5S_t *space;     /* Dataspace to modify selection of */
+    H5S_t *space = NULL;    /* Dataspace to modify selection of */
     herr_t ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
@@ -10311,7 +10311,7 @@ herr_t
 H5Sselect_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_t start[], const hsize_t stride[],
                     const hsize_t count[], const hsize_t block[])
 {
-    H5S_t *space;               /* Dataspace to modify selection of */
+    H5S_t *space = NULL;        /* Dataspace to modify selection of */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -10638,7 +10638,7 @@ hid_t
 H5Scombine_hyperslab(hid_t space_id, H5S_seloper_t op, const hsize_t start[], const hsize_t stride[],
                      const hsize_t count[], const hsize_t block[])
 {
-    H5S_t *space;            /* Dataspace to modify selection of */
+    H5S_t *space = NULL;     /* Dataspace to modify selection of */
     H5S_t *new_space = NULL; /* New dataspace created */
     hid_t  ret_value;        /* Return value */
 
@@ -10770,8 +10770,8 @@ done:
 hid_t
 H5Scombine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
 {
-    H5S_t *space1;           /* First Dataspace */
-    H5S_t *space2;           /* Second Dataspace */
+    H5S_t *space1 = NULL;    /* First Dataspace */
+    H5S_t *space2 = NULL;    /* Second Dataspace */
     H5S_t *new_space = NULL; /* New Dataspace */
     hid_t  ret_value;        /* Return value */
 
@@ -10911,8 +10911,8 @@ done:
 herr_t
 H5Smodify_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id)
 {
-    H5S_t *space1;              /* First Dataspace */
-    H5S_t *space2;              /* Second Dataspace */
+    H5S_t *space1 = NULL;       /* First Dataspace */
+    H5S_t *space2 = NULL;       /* Second Dataspace */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -12429,7 +12429,7 @@ H5S_hyper_get_first_inc_block(const H5S_t *space, hsize_t clip_size, hbool_t *pa
 htri_t
 H5Sis_regular_hyperslab(hid_t spaceid)
 {
-    H5S_t *space;     /* Dataspace to query */
+    H5S_t *space = NULL; /* Dataspace to query */
     htri_t ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -12481,7 +12481,7 @@ herr_t
 H5Sget_regular_hyperslab(hid_t spaceid, hsize_t start[] /*out*/, hsize_t stride[] /*out*/,
                          hsize_t count[] /*out*/, hsize_t block[] /*out*/)
 {
-    H5S_t   *space;               /* Dataspace to query */
+    H5S_t   *space = NULL;        /* Dataspace to query */
     unsigned u;                   /* Local index variable */
     herr_t   ret_value = SUCCEED; /* Return value */
 

--- a/src/H5Spkg.h
+++ b/src/H5Spkg.h
@@ -327,6 +327,9 @@ typedef struct {
 struct H5S_t {
     H5S_extent_t extent; /* Dataspace extent (must stay first) */
     H5S_select_t select; /* Dataspace selection */
+#if H5_HAVE_VIRTUAL_LOCK
+    H5TS_vlock_t vlock;
+#endif
 };
 
 /* Selection iteration methods */

--- a/src/H5Sprivate.h
+++ b/src/H5Sprivate.h
@@ -317,10 +317,10 @@ H5_DLL void H5S_vlock_release(H5S_t *space, H5TS_vlock_op_type_t op_type);
 
 #else /* H5_HAVE_VIRTUAL_LOCK */
 #define H5S_VLOCK_INIT(space)
-#define H5S_VLOCK_ACQUIRE_W
-#define H5S_VLOCK_ACQUIRE_R
-#define H5S_VLOCK_RELEASE_W
-#define H5S_VLOCK_RELEASE_R
+#define H5S_VLOCK_ACQUIRE_W(dt) (void) dt
+#define H5S_VLOCK_ACQUIRE_R(dt) (void) dt
+#define H5S_VLOCK_RELEASE_W(dt) (void) dt
+#define H5S_VLOCK_RELEASE_R(dt) (void) dt
 #endif /* H5_HAVE_VIRTUAL_LOCK */
 
 #endif /* H5Sprivate_H */

--- a/src/H5Sprivate.h
+++ b/src/H5Sprivate.h
@@ -304,4 +304,23 @@ H5_DLL herr_t H5S_mpio_space_type(H5S_t *space, size_t elmt_size,
                                   hbool_t do_permute, hsize_t **permute_map, hbool_t *is_permuted);
 #endif /* H5_HAVE_PARALLEL */
 
+#if H5_HAVE_VIRTUAL_LOCK
+H5_DLL void H5S_vlock_init(H5S_t *space);
+H5_DLL void H5S_vlock_acquire(H5S_t *space, H5TS_vlock_op_type_t op_type);
+H5_DLL void H5S_vlock_release(H5S_t *space, H5TS_vlock_op_type_t op_type);
+
+#define H5S_VLOCK_INIT(space) H5S_vlock_init(space)
+#define H5S_VLOCK_ACQUIRE_W(space) H5S_vlock_acquire(space, H5TS_VLOCK_WRITER)
+#define H5S_VLOCK_ACQUIRE_R(space) H5S_vlock_acquire(space, H5TS_VLOCK_READER)
+#define H5S_VLOCK_RELEASE_W(space) H5S_vlock_release(space, H5TS_VLOCK_WRITER)
+#define H5S_VLOCK_RELEASE_R(space) H5S_vlock_release(space, H5TS_VLOCK_READER)
+
+#else /* H5_HAVE_VIRTUAL_LOCK */
+#define H5S_VLOCK_INIT(space)
+#define H5S_VLOCK_ACQUIRE_W
+#define H5S_VLOCK_ACQUIRE_R
+#define H5S_VLOCK_RELEASE_W
+#define H5S_VLOCK_RELEASE_R
+#endif /* H5_HAVE_VIRTUAL_LOCK */
+
 #endif /* H5Sprivate_H */

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -6102,3 +6102,68 @@ H5T_own_vol_obj(H5T_t *dt, H5VL_object_t *vol_obj)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T_own_vol_obj() */
+
+#if H5_HAVE_VIRTUAL_LOCK
+/*-------------------------------------------------------------------------
+ * Function:    H5T_vlock_init
+ *
+ * Purpose:     Initialize a virtual lock on a datatype
+ *
+ *              The virtual lock exists to to verify
+ *              the assumption of exclusive access to a datatype object.
+ *
+ *-------------------------------------------------------------------------
+ */
+void
+H5T_vlock_init(H5T_t *dt) {
+    assert(dt);
+
+    FUNC_ENTER_NOAPI_NAMECHECK_ONLY
+
+    H5TS_vlock_init(&dt->vlock);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    H5T_vlock_acquire
+ *
+ * Purpose:     Acquire a virtual lock on a datatype
+ *
+ *              The virtual lock exists to to verify
+ *              the assumption of exclusive access to a datatype object.
+ *
+ *-------------------------------------------------------------------------
+ */
+void
+H5T_vlock_acquire(H5T_t *dt, H5TS_vlock_op_type_t op_type) {
+    assert(dt);
+
+    FUNC_ENTER_NOAPI_NAMECHECK_ONLY
+
+    H5TS_vlock_acquire(&dt->vlock, op_type);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    H5T_vlock_release
+ *
+ * Purpose:     Release a virtual lock on a datatype
+ *
+ *              The virtual lock exists to to verify
+ *              the assumption of exclusive access to a datatype object.
+ *
+ * -------------------------------------------------------------------------
+ */
+void
+H5T_vlock_release(H5T_t *dt, H5TS_vlock_op_type_t op_type) {
+    assert(dt);
+
+    FUNC_ENTER_NOAPI_NAMECHECK_ONLY
+
+    H5TS_vlock_release(&dt->vlock, op_type);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
+}
+#endif

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -2041,8 +2041,8 @@ H5Tequal(hid_t type1_id, hid_t type2_id)
     if (NULL == (dt2 = (H5T_t *)H5I_object_verify(type2_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
-    /* Avoid double locking if the IDs refer to the same datatype */
-    if (memcmp(dt1, dt2, sizeof(H5T_t)) != 0)
+    /* Avoid double-locking if the IDs refer to the same datatype */
+    if (dt1 != dt2)
         H5T_VLOCK_ACQUIRE_R(dt2);
 
     ret_value = (0 == H5T_cmp(dt1, dt2, FALSE)) ? TRUE : FALSE;
@@ -2050,7 +2050,7 @@ H5Tequal(hid_t type1_id, hid_t type2_id)
 done:
     if (dt1)
         H5T_VLOCK_RELEASE_R(dt1);
-    if (dt2 && memcmp(dt1, dt2, sizeof(H5T_t)) != 0)
+    if (dt2 && dt1 != dt2)
         H5T_VLOCK_RELEASE_R(dt2);
 
     FUNC_LEAVE_API(ret_value)
@@ -2755,8 +2755,8 @@ H5Tregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t dst_id, H5T_c
     H5T_VLOCK_ACQUIRE_R(src);
     if (NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
-    /* Avoid double virtual-locking the same datatype */
-    if (memcmp(src, dst, sizeof(H5T_t)) != 0)
+    /* Avoid double-locking the same datatype twice */
+    if (src != dst)
         H5T_VLOCK_ACQUIRE_R(dst);
     if (!func)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no conversion function specified");
@@ -2772,7 +2772,7 @@ H5Tregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t dst_id, H5T_c
 done:
     if (src)
         H5T_VLOCK_RELEASE_R(src);
-    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+    if (dst && src != dst)
         H5T_VLOCK_RELEASE_R(dst);
 
     FUNC_LEAVE_API(ret_value)
@@ -2908,7 +2908,7 @@ H5Tunregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t dst_id, H5T
     if (dst_id > 0 && (NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE))))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "dst is not a data type");
     /* Avoid double-locking the same datatype twice */
-    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+    if (dst && src != dst)
         H5T_VLOCK_ACQUIRE_R(dst);
     if (H5T__unregister(pers, name, src, dst, func) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDELETE, FAIL, "internal unregister function failed");
@@ -2916,7 +2916,7 @@ H5Tunregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t dst_id, H5T
 done:
     if (src)
         H5T_VLOCK_RELEASE_R(src);
-    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+    if (dst && src != dst)
         H5T_VLOCK_RELEASE_R(dst);
 
     FUNC_LEAVE_API(ret_value)
@@ -2954,7 +2954,7 @@ H5Tfind(hid_t src_id, hid_t dst_id, H5T_cdata_t **pcdata /*out*/)
     if (NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a data type");
     /* Avoid double-locking the same datatype twice */
-    if (memcmp(src, dst, sizeof(H5T_t)) != 0)
+    if (src != dst)
         H5T_VLOCK_ACQUIRE_R(dst);
     if (!pcdata)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "no address to receive cdata pointer");
@@ -2972,7 +2972,7 @@ H5Tfind(hid_t src_id, hid_t dst_id, H5T_cdata_t **pcdata /*out*/)
 done:
     if (src)
         H5T_VLOCK_RELEASE_R(src);
-    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+    if (dst && src != dst)
         H5T_VLOCK_RELEASE_R(dst);
 
     FUNC_LEAVE_API(ret_value)
@@ -3008,7 +3008,7 @@ H5Tcompiler_conv(hid_t src_id, hid_t dst_id)
     if (NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
     /* Avoid double-locking the same datatype twice */
-    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+    if (dst && src != dst)
         H5T_VLOCK_ACQUIRE_R(dst);
     /* Find it */
     if ((ret_value = H5T__compiler_conv(src, dst)) < 0)
@@ -3017,7 +3017,7 @@ H5Tcompiler_conv(hid_t src_id, hid_t dst_id)
 done:
     if (src)
         H5T_VLOCK_RELEASE_R(src);
-    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+    if (dst && src != dst)
         H5T_VLOCK_RELEASE_R(dst);
 
     FUNC_LEAVE_API(ret_value)
@@ -3060,7 +3060,7 @@ H5Tconvert(hid_t src_id, hid_t dst_id, size_t nelmts, void *buf, void *backgroun
     if (NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
     /* Avoid double-locking the same datatype */
-    if (memcmp(src, dst, sizeof(H5T_t)) != 0)
+    if (src != dst)
         H5T_VLOCK_ACQUIRE_R(dst);
     if (H5P_DEFAULT == dxpl_id)
         dxpl_id = H5P_DATASET_XFER_DEFAULT;
@@ -3080,7 +3080,7 @@ H5Tconvert(hid_t src_id, hid_t dst_id, size_t nelmts, void *buf, void *backgroun
 done:
     if (src)
         H5T_VLOCK_RELEASE_R(src);
-    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+    if (dst && src != dst)
         H5T_VLOCK_RELEASE_R(dst);
 
     FUNC_LEAVE_API(ret_value)

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -596,7 +596,7 @@ static const H5I_class_t H5I_DATATYPE_CLS[1] = {{
 static herr_t
 H5T__init_inf(void)
 {
-    H5T_t        *dst_p;               /* Datatype type operate on */
+    H5T_t        *dst_p = NULL;        /* Datatype type operate on */
     H5T_atomic_t *dst;                 /* Datatype's atomic info   */
     uint8_t      *d;                   /* Pointer to value to set  */
     size_t        half_size;           /* Half the type size       */
@@ -1912,7 +1912,7 @@ done:
 herr_t
 H5Tclose(hid_t type_id)
 {
-    H5T_t *dt;                  /* Pointer to datatype to close */
+    H5T_t *dt = NULL;           /* Pointer to datatype to close */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -1955,7 +1955,7 @@ done:
 herr_t
 H5Tclose_async(const char *app_file, const char *app_func, unsigned app_line, hid_t type_id, hid_t es_id)
 {
-    H5T_t         *dt;                          /* Pointer to datatype to close */
+    H5T_t         *dt        = NULL;            /* Pointer to datatype to close */
     void          *token     = NULL;            /* Request token for async operation        */
     void         **token_ptr = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
     H5VL_object_t *vol_obj   = NULL;            /* VOL object of dset_id */
@@ -2025,8 +2025,8 @@ done:
 htri_t
 H5Tequal(hid_t type1_id, hid_t type2_id)
 {
-    const H5T_t *dt1;       /* Pointer to first datatype */
-    const H5T_t *dt2;       /* Pointer to second datatype */
+    H5T_t *dt1 = NULL;       /* Pointer to first datatype */
+    H5T_t *dt2 = NULL;       /* Pointer to second datatype */
     htri_t       ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -2074,7 +2074,7 @@ done:
 herr_t
 H5Tlock(hid_t type_id)
 {
-    H5T_t *dt;                  /* Datatype to operate on */
+    H5T_t *dt = NULL;           /* Datatype to operate on */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -2110,7 +2110,7 @@ done:
 H5T_class_t
 H5Tget_class(hid_t type_id)
 {
-    H5T_t      *dt;        /* Pointer to datatype */
+    H5T_t      *dt = NULL; /* Pointer to datatype */
     H5T_class_t ret_value; /* Return value */
 
     FUNC_ENTER_API(H5T_NO_CLASS)
@@ -2179,7 +2179,7 @@ H5T_get_class(const H5T_t *dt, htri_t internal)
 htri_t
 H5Tdetect_class(hid_t type, H5T_class_t cls)
 {
-    H5T_t *dt;        /* Datatype to query */
+    H5T_t *dt = NULL; /* Datatype to query */
     htri_t ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -2288,7 +2288,7 @@ done:
 htri_t
 H5Tis_variable_str(hid_t dtype_id)
 {
-    H5T_t *dt;        /* Datatype to query */
+    H5T_t *dt = NULL; /* Datatype to query */
     htri_t ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -2344,7 +2344,7 @@ H5T_is_variable_str(const H5T_t *dt)
 size_t
 H5Tget_size(hid_t type_id)
 {
-    H5T_t *dt;        /* Datatype to query */
+    H5T_t *dt = NULL; /* Datatype to query */
     size_t ret_value; /* Return value */
 
     FUNC_ENTER_API(0)
@@ -2390,7 +2390,7 @@ done:
 herr_t
 H5Tset_size(hid_t type_id, size_t size)
 {
-    H5T_t *dt;                  /* Datatype to modify */
+    H5T_t *dt = NULL;           /* Datatype to modify */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -2437,7 +2437,7 @@ done:
 hid_t
 H5Tget_super(hid_t type)
 {
-    H5T_t *dt;                          /* Datatype to query */
+    H5T_t *dt = NULL;                   /* Datatype to query */
     H5T_t *super     = NULL;            /* Supertype */
     hid_t  ret_value = H5I_INVALID_HID; /* Return value */
 
@@ -2737,8 +2737,8 @@ done:
 herr_t
 H5Tregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t dst_id, H5T_conv_t func)
 {
-    H5T_t          *src;                 /*source data type descriptor    */
-    H5T_t          *dst;                 /*destination data type desc     */
+    H5T_t          *src = NULL;          /*source data type descriptor    */
+    H5T_t          *dst = NULL;          /*destination data type desc     */
     H5T_conv_func_t conv_func;           /* Conversion function wrapper */
     herr_t          ret_value = SUCCEED; /*return value                   */
 
@@ -2939,7 +2939,7 @@ done:
 H5T_conv_t
 H5Tfind(hid_t src_id, hid_t dst_id, H5T_cdata_t **pcdata /*out*/)
 {
-    H5T_t      *src, *dst;
+    H5T_t      *src = NULL, *dst = NULL;
     H5T_path_t *path;
     H5T_conv_t  ret_value; /* Return value */
 
@@ -2994,7 +2994,7 @@ done:
 htri_t
 H5Tcompiler_conv(hid_t src_id, hid_t dst_id)
 {
-    H5T_t *src, *dst;
+    H5T_t *src = NULL, *dst = NULL;
     htri_t ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -3045,9 +3045,9 @@ done:
 herr_t
 H5Tconvert(hid_t src_id, hid_t dst_id, size_t nelmts, void *buf, void *background, hid_t dxpl_id)
 {
-    H5T_path_t *tpath;               /* type conversion info    */
-    H5T_t      *src, *dst;           /* unregistered types      */
-    herr_t      ret_value = SUCCEED; /* Return value            */
+    H5T_path_t *tpath;                   /* type conversion info    */
+    H5T_t      *src = NULL, *dst = NULL; /* unregistered types      */
+    herr_t      ret_value = SUCCEED;     /* Return value            */
 
     FUNC_ENTER_API(FAIL)
     H5TRACE6("e", "iiz*x*xi", src_id, dst_id, nelmts, buf, background, dxpl_id);
@@ -3100,7 +3100,7 @@ done:
 herr_t
 H5Treclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
 {
-    H5S_t *space;     /* Dataspace for iteration */
+    H5S_t *space = NULL;     /* Dataspace for iteration */
     herr_t ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -3111,7 +3111,7 @@ H5Treclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid argument");
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid dataspace");
-    H5T_VLOCK_ACQUIRE_R(space);
+    H5S_VLOCK_ACQUIRE_R(space);
     if (!(H5S_has_extent(space)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "dataspace does not have extent set");
 
@@ -3129,7 +3129,7 @@ H5Treclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
 
 done:
     if (space)
-        H5T_VLOCK_RELEASE_R(space);
+        H5S_VLOCK_RELEASE_R(space);
 
     FUNC_LEAVE_API(ret_value)
 } /* end H5Treclaim() */
@@ -3149,7 +3149,7 @@ done:
 herr_t
 H5Tencode(hid_t obj_id, void *buf, size_t *nalloc)
 {
-    H5T_t *dtype;
+    H5T_t *dtype = NULL;
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
@@ -3188,7 +3188,7 @@ done:
 hid_t
 H5Tdecode(const void *buf)
 {
-    H5T_t *dt;
+    H5T_t *dt = NULL;
     hid_t  ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -608,6 +608,8 @@ H5T__init_inf(void)
     /* Get the float datatype */
     if (NULL == (dst_p = (H5T_t *)H5I_object(H5T_NATIVE_FLOAT_g)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(dst_p);
+
     dst = &dst_p->shared->u.atomic;
 
     /* Check that we can re-order the bytes correctly */
@@ -646,9 +648,14 @@ H5T__init_inf(void)
         } /* end for */
     }     /* end if */
 
+    H5T_VLOCK_RELEASE_R(dst_p);
+
     /* Get the double datatype */
     if (NULL == (dst_p = (H5T_t *)H5I_object(H5T_NATIVE_DOUBLE_g)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    
+    H5T_VLOCK_ACQUIRE_R(dst_p);
+
     dst = &dst_p->shared->u.atomic;
 
     /* Check that we can re-order the bytes correctly */
@@ -688,6 +695,9 @@ H5T__init_inf(void)
     }     /* end if */
 
 done:
+    if (dst_p)
+        H5T_VLOCK_RELEASE_R(dst_p);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T__init_inf() */
 
@@ -1450,10 +1460,14 @@ H5T__unlock_cb(void *_dt, hid_t H5_ATTR_UNUSED id, void *_udata)
     assert(dt);
     assert(dt->shared);
 
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_STATE_IMMUTABLE == dt->shared->state) {
         dt->shared->state = H5T_STATE_RDONLY;
         (*n)++;
     } /* end if */
+
+    H5T_VLOCK_RELEASE_W(dt);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5T__unlock_cb() */
@@ -1759,11 +1773,16 @@ H5Tcreate(H5T_class_t type, size_t size)
     if (NULL == (dt = H5T__create(type, size)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to create type");
 
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     /* Get an ID for the datatype */
     if ((ret_value = H5I_register(H5I_DATATYPE, dt, TRUE)) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register datatype ID");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tcreate() */
 
@@ -1850,15 +1869,23 @@ H5Tcopy(hid_t obj_id)
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a datatype or dataset");
     } /* end switch */
 
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     /* Copy datatype */
     if (NULL == (new_dt = H5T_copy(dt, H5T_COPY_TRANSIENT)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, H5I_INVALID_HID, "unable to copy");
+
+    H5T_VLOCK_ACQUIRE_R(new_dt);
 
     /* Get an ID for the copied datatype */
     if ((ret_value = H5I_register(H5I_DATATYPE, new_dt, TRUE)) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register datatype atom");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+    if (new_dt)
+        H5T_VLOCK_RELEASE_R(new_dt);
 
     /* If we got a type ID from a passed-in dataset, we need to close that */
     if (dset_tid != H5I_INVALID_HID)
@@ -1894,14 +1921,25 @@ H5Tclose(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     if (H5T_STATE_IMMUTABLE == dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "immutable datatype");
+
+    /* Release virtual lock before datatype is potentially freed */
+    H5T_VLOCK_RELEASE_R(dt);
 
     /* When the reference count reaches zero the resources are freed */
     if (H5I_dec_app_ref(type_id) < 0)
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "problem freeing id");
 
 done:
+    /* TBD: If the dec_app_ref call fails after invalidating the datatype itself, 
+     * it may not be possible to correctly release the virtual lock here. */
+    if (dt && ret_value < 0)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tclose() */
 
@@ -1930,6 +1968,7 @@ H5Tclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(dt);
     if (H5T_STATE_IMMUTABLE == dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "immutable datatype");
 
@@ -1948,6 +1987,8 @@ H5Tclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
         token_ptr = &token;
     } /* end if */
 
+    /* Release virtual lock before datatype is potentially freed */
+    H5T_VLOCK_RELEASE_R(dt);
     /* When the reference count reaches zero the resources are freed */
     if (H5I_dec_app_ref_async(type_id, token_ptr) < 0)
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "problem freeing id");
@@ -1959,6 +2000,11 @@ H5Tclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
 done:
+    /* TBD: If the dec_app_ref call fails after invalidating the datatype itself,
+        * it may not be possible to correctly release the virtual lock here. */
+    if (dt && ret_value < 0)
+        H5T_VLOCK_RELEASE_R(dt);
+
     if (connector && H5VL_conn_dec_rc(connector) < 0)
         HDONE_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
 
@@ -1989,12 +2035,24 @@ H5Tequal(hid_t type1_id, hid_t type2_id)
     /* check args */
     if (NULL == (dt1 = (H5T_t *)H5I_object_verify(type1_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+
+    H5T_VLOCK_ACQUIRE_R(dt1);
+
     if (NULL == (dt2 = (H5T_t *)H5I_object_verify(type2_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+
+    /* Avoid double locking if the IDs refer to the same datatype */
+    if (memcmp(dt1, dt2, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_ACQUIRE_R(dt2);
 
     ret_value = (0 == H5T_cmp(dt1, dt2, FALSE)) ? TRUE : FALSE;
 
 done:
+    if (dt1)
+        H5T_VLOCK_RELEASE_R(dt1);
+    if (dt2 && memcmp(dt1, dt2, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_RELEASE_R(dt2);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tequal() */
 
@@ -2025,6 +2083,7 @@ H5Tlock(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
     if (H5T_STATE_NAMED == dt->shared->state || H5T_STATE_OPEN == dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to lock named datatype");
 
@@ -2032,6 +2091,8 @@ H5Tlock(hid_t type_id)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to lock transient datatype");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tlock() */
 
@@ -2059,10 +2120,15 @@ H5Tget_class(hid_t type_id)
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5T_NO_CLASS, "not a datatype");
 
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     /* Set return value */
     ret_value = H5T_get_class(dt, FALSE);
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tget_class() */
 
@@ -2122,6 +2188,7 @@ H5Tdetect_class(hid_t type, H5T_class_t cls)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5T_NO_CLASS, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(dt);
     if (!(cls > H5T_NO_CLASS && cls < H5T_NCLASSES))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5T_NO_CLASS, "not a datatype class");
 
@@ -2130,6 +2197,9 @@ H5Tdetect_class(hid_t type, H5T_class_t cls)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, H5T_NO_CLASS, "can't get datatype class");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tdetect_class() */
 
@@ -2228,11 +2298,16 @@ H5Tis_variable_str(hid_t dtype_id)
     if (NULL == (dt = (H5T_t *)H5I_object_verify(dtype_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     /* Set return value */
     if ((ret_value = H5T_is_variable_str(dt)) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL, "can't determine if datatype is VL-string");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tis_variable_str() */
 
@@ -2279,10 +2354,15 @@ H5Tget_size(hid_t type_id)
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, 0, "not a datatype");
 
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     /* size */
     ret_value = H5T_GET_SIZE(dt);
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tget_size() */
 
@@ -2319,6 +2399,7 @@ H5Tset_size(hid_t type_id, size_t size)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTINIT, FAIL, "datatype is read-only");
     if (size <= 0 && size != H5T_VARIABLE)
@@ -2335,6 +2416,9 @@ H5Tset_size(hid_t type_id, size_t size)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to set size for datatype");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tset_size() */
 
@@ -2362,12 +2446,19 @@ H5Tget_super(hid_t type)
 
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(dt);
     if (NULL == (super = H5T_get_super(dt)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, H5I_INVALID_HID, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(super);
     if ((ret_value = H5I_register(H5I_DATATYPE, super, TRUE)) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register parent datatype");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+    if (super)
+        H5T_VLOCK_RELEASE_R(super);
+
     if (H5I_INVALID_HID == ret_value)
         if (super && H5T_close_real(super) < 0)
             HDONE_ERROR(H5E_DATATYPE, H5E_CANTRELEASE, H5I_INVALID_HID,
@@ -2661,8 +2752,12 @@ H5Tregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t dst_id, H5T_c
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "conversion must have a name for debugging");
     if (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    H5T_VLOCK_ACQUIRE_R(src);
     if (NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    /* Avoid double virtual-locking the same datatype */
+    if (memcmp(src, dst, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_ACQUIRE_R(dst);
     if (!func)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no conversion function specified");
 
@@ -2675,6 +2770,11 @@ H5Tregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t dst_id, H5T_c
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "can't register conversion function");
 
 done:
+    if (src)
+        H5T_VLOCK_RELEASE_R(src);
+    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_RELEASE_R(dst);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tregister() */
 
@@ -2803,13 +2903,21 @@ H5Tunregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t dst_id, H5T
     /* Check arguments */
     if (src_id > 0 && (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE))))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "src is not a data type");
+    H5T_VLOCK_ACQUIRE_R(src);
     if (dst_id > 0 && (NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE))))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "dst is not a data type");
-
+    /* Avoid double-locking the same datatype twice */
+    if (memcmp(src, dst, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_ACQUIRE_R(dst);
     if (H5T__unregister(pers, name, src, dst, func) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDELETE, FAIL, "internal unregister function failed");
 
 done:
+    if (src)
+        H5T_VLOCK_RELEASE_R(src);
+    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_RELEASE_R(dst);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tunregister() */
 
@@ -2839,9 +2947,14 @@ H5Tfind(hid_t src_id, hid_t dst_id, H5T_cdata_t **pcdata /*out*/)
     H5TRACE3("TC", "iix", src_id, dst_id, pcdata);
 
     /* Check args */
-    if (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE)) ||
-        NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE)))
+    if (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a data type");
+    H5T_VLOCK_ACQUIRE_R(src);
+    if (NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a data type");
+    /* Avoid double-locking the same datatype twice */
+    if (memcmp(src, dst, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_ACQUIRE_R(dst);
     if (!pcdata)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "no address to receive cdata pointer");
 
@@ -2856,6 +2969,11 @@ H5Tfind(hid_t src_id, hid_t dst_id, H5T_cdata_t **pcdata /*out*/)
     ret_value = path->conv.u.app_func;
 
 done:
+    if (src)
+        H5T_VLOCK_RELEASE_R(src);
+    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_RELEASE_R(dst);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tfind() */
 
@@ -2883,15 +3001,24 @@ H5Tcompiler_conv(hid_t src_id, hid_t dst_id)
     H5TRACE2("t", "ii", src_id, dst_id);
 
     /* Check args */
-    if (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE)) ||
-        NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE)))
+    if (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
-
+    H5T_VLOCK_ACQUIRE_R(src);
+    if (NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    /* Avoid double-locking the same datatype twice */
+    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_ACQUIRE_R(dst);
     /* Find it */
     if ((ret_value = H5T__compiler_conv(src, dst)) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_NOTFOUND, FAIL, "conversion function not found");
 
 done:
+    if (src)
+        H5T_VLOCK_RELEASE_R(src);
+    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_RELEASE_R(dst);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tcompiler_conv() */
 
@@ -2926,9 +3053,14 @@ H5Tconvert(hid_t src_id, hid_t dst_id, size_t nelmts, void *buf, void *backgroun
     H5TRACE6("e", "iiz*x*xi", src_id, dst_id, nelmts, buf, background, dxpl_id);
 
     /* Check args */
-    if (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE)) ||
-        NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE)))
+    if (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE)))   
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    H5T_VLOCK_ACQUIRE_R(src);
+    if (NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    /* Avoid double-locking the same datatype */
+    if (memcmp(src, dst, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_ACQUIRE_R(dst);
     if (H5P_DEFAULT == dxpl_id)
         dxpl_id = H5P_DATASET_XFER_DEFAULT;
     else if (TRUE != H5P_isa_class(dxpl_id, H5P_DATASET_XFER))
@@ -2945,6 +3077,11 @@ H5Tconvert(hid_t src_id, hid_t dst_id, size_t nelmts, void *buf, void *backgroun
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "data type conversion failed");
 
 done:
+    if (src)
+        H5T_VLOCK_RELEASE_R(src);
+    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_RELEASE_R(dst);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tconvert() */
 
@@ -2974,6 +3111,7 @@ H5Treclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid argument");
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid dataspace");
+    H5T_VLOCK_ACQUIRE_R(space);
     if (!(H5S_has_extent(space)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "dataspace does not have extent set");
 
@@ -2990,6 +3128,9 @@ H5Treclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
     ret_value = H5T_reclaim(type_id, space, buf);
 
 done:
+    if (space)
+        H5T_VLOCK_RELEASE_R(space);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Treclaim() */
 
@@ -3017,6 +3158,7 @@ H5Tencode(hid_t obj_id, void *buf, size_t *nalloc)
     /* Check argument and retrieve object */
     if (NULL == (dtype = (H5T_t *)H5I_object_verify(obj_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(dtype);
     if (nalloc == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "NULL pointer for buffer size");
 
@@ -3025,6 +3167,9 @@ H5Tencode(hid_t obj_id, void *buf, size_t *nalloc)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTENCODE, FAIL, "can't encode datatype");
 
 done:
+    if (dtype)
+        H5T_VLOCK_RELEASE_R(dtype);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tencode() */
 
@@ -3062,11 +3207,16 @@ H5Tdecode(const void *buf)
     if (NULL == (dt = H5T_decode(SIZE_MAX, (const unsigned char *)buf)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDECODE, FAIL, "can't decode object");
 
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     /* Register the type and return the ID */
     if ((ret_value = H5I_register(H5I_DATATYPE, dt, TRUE)) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register data type");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tdecode() */
 
@@ -3163,6 +3313,8 @@ H5T_decode(size_t buf_size, const unsigned char *buf)
     if (NULL == (ret_value = (H5T_t *)H5O_msg_decode(f, NULL, H5O_DTYPE_ID, buf_size, buf)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDECODE, NULL, "can't decode object");
 
+    H5T_VLOCK_ACQUIRE_W(ret_value);
+
     /* Mark datatype as being in memory now */
     if (H5T_set_loc(ret_value, NULL, H5T_LOC_MEMORY) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "invalid datatype location");
@@ -3170,6 +3322,9 @@ H5T_decode(size_t buf_size, const unsigned char *buf)
     /* No VOL object */
     ret_value->vol_obj = NULL;
 done:
+    if (ret_value)
+        H5T_VLOCK_RELEASE_W(ret_value);
+
     /* Release fake file structure */
     if (f && H5F_fake_free(f) < 0)
         HDONE_ERROR(H5E_DATATYPE, H5E_CANTRELEASE, NULL, "unable to release fake file struct");
@@ -3195,6 +3350,8 @@ H5T__create(H5T_class_t type, size_t size)
 {
     H5T_t *dt        = NULL;
     H5T_t *ret_value = NULL;
+    H5T_t *origin_dt = NULL;
+    H5T_t *sub_t_obj = NULL;
 
     FUNC_ENTER_PACKAGE
 
@@ -3203,15 +3360,15 @@ H5T__create(H5T_class_t type, size_t size)
         case H5T_FLOAT:
         case H5T_TIME:
         case H5T_STRING: {
-            H5T_t *origin_dt = NULL;
-
             if (NULL == (origin_dt = (H5T_t *)H5I_object(H5T_C_S1)))
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, NULL, "can't get structure for string type");
+
+            H5T_VLOCK_ACQUIRE_R(origin_dt);
 
             /* Copy the default string datatype */
             if (NULL == (dt = H5T_copy(origin_dt, H5T_COPY_TRANSIENT)))
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "unable to copy");
-
+            H5T_VLOCK_ACQUIRE_W(dt);
             /* Modify the datatype */
             if (H5T__set_size(dt, size) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "unable to set size for string type");
@@ -3224,6 +3381,7 @@ H5T__create(H5T_class_t type, size_t size)
         case H5T_COMPOUND:
             if (NULL == (dt = H5T__alloc()))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
+            H5T_VLOCK_ACQUIRE_W(dt);
             dt->shared->type = type;
 
             if (type == H5T_COMPOUND) {
@@ -3238,7 +3396,6 @@ H5T__create(H5T_class_t type, size_t size)
 
         case H5T_ENUM: {
             hid_t  subtype;
-            H5T_t *sub_t_obj;
 
             if (sizeof(char) == size)
                 subtype = H5T_NATIVE_SCHAR_g;
@@ -3259,6 +3416,7 @@ H5T__create(H5T_class_t type, size_t size)
             dt->shared->type = type;
             if (NULL == (sub_t_obj = (H5T_t *)H5I_object(subtype)))
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, NULL, "unable to get datatype object");
+            H5T_VLOCK_ACQUIRE_R(sub_t_obj);
             if (NULL == (dt->shared->parent = H5T_copy(sub_t_obj, H5T_COPY_ALL)))
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy base datatype");
         } break;
@@ -3287,6 +3445,13 @@ H5T__create(H5T_class_t type, size_t size)
     ret_value = dt;
 
 done:
+    if (origin_dt)
+        H5T_VLOCK_RELEASE_R(origin_dt);
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+    if (sub_t_obj)
+        H5T_VLOCK_RELEASE_R(sub_t_obj);
+
     if (NULL == ret_value) {
         if (dt) {
             if (dt->shared->owned_vol_obj && H5VL_free_object(dt->shared->owned_vol_obj) < 0)
@@ -3324,6 +3489,7 @@ H5T__initiate_copy(const H5T_t *old_dt)
     /* Allocate space */
     if (NULL == (new_dt = H5FL_MALLOC_MT(H5T_t)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, NULL, "H5T_t memory allocation failed");
+    H5T_VLOCK_ACQUIRE_W(new_dt);
     if (NULL == (new_dt->shared = H5FL_MALLOC_MT(H5T_shared_t)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, NULL, "H5T_shared_t memory allocation failed");
 
@@ -3341,6 +3507,9 @@ H5T__initiate_copy(const H5T_t *old_dt)
     ret_value = new_dt;
 
 done:
+    if (new_dt)
+        H5T_VLOCK_RELEASE_W(new_dt);
+
     if (ret_value == NULL)
         if (new_dt) {
             if (new_dt->shared) {
@@ -3465,6 +3634,7 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
                     new_dt->shared->u.compnd.memb[i].name = s;
                     if (NULL == (tmp = (*copyfn)(old_dt->shared->u.compnd.memb[i].type)))
                         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "can't copy compound field's datatype");
+                    H5T_VLOCK_ACQUIRE_R(tmp);
                     new_dt->shared->u.compnd.memb[i].type = tmp;
                     assert(tmp != NULL);
 
@@ -3604,6 +3774,9 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
         H5O_msg_reset_share(H5O_DTYPE_ID, new_dt);
 
 done:
+    if (tmp)
+        H5T_VLOCK_RELEASE_R(tmp);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T__complete_copy() */
 
@@ -3633,6 +3806,8 @@ H5T_copy(const H5T_t *old_dt, H5T_copy_t method)
     /* Allocate and copy core datatype information */
     if (NULL == (new_dt = H5T__initiate_copy(old_dt)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "can't copy core datatype info");
+
+    H5T_VLOCK_ACQUIRE_W(new_dt);
 
     /* Check what sort of copy we are making */
     switch (method) {
@@ -3668,6 +3843,9 @@ H5T_copy(const H5T_t *old_dt, H5T_copy_t method)
     ret_value = new_dt;
 
 done:
+    if (new_dt)
+        H5T_VLOCK_RELEASE_W(new_dt);
+
     if (ret_value == NULL)
         if (new_dt) {
             assert(new_dt->shared);
@@ -3706,6 +3884,8 @@ H5T_copy_reopen(H5T_t *old_dt)
     /* Allocate and copy core datatype information */
     if (NULL == (new_dt = H5T__initiate_copy(old_dt)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "can't copy core datatype info");
+
+    H5T_VLOCK_ACQUIRE_W(new_dt);
 
     /*
      * Return a transient type (locked or unlocked) or an opened named
@@ -3772,6 +3952,9 @@ H5T_copy_reopen(H5T_t *old_dt)
     ret_value = new_dt;
 
 done:
+    if (new_dt)
+        H5T_VLOCK_RELEASE_W(new_dt);
+
     if (ret_value == NULL)
         if (new_dt) {
             assert(new_dt->shared);
@@ -3848,6 +4031,8 @@ H5T__alloc(void)
     /* Allocate & initialize datatype wrapper info */
     if (NULL == (dt = H5FL_CALLOC_MT(H5T_t)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
+    H5T_VLOCK_INIT(dt);
+    H5T_VLOCK_ACQUIRE_W(dt);
     H5O_loc_reset(&(dt->oloc));
     H5G_name_reset(&(dt->path));
     H5O_msg_reset_share(H5O_DTYPE_ID, dt);
@@ -3864,6 +4049,9 @@ H5T__alloc(void)
     ret_value = dt;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     if (ret_value == NULL)
         if (dt) {
             if (dt->shared) {
@@ -4108,6 +4296,7 @@ H5T__set_size(H5T_t *dt, size_t size)
 {
     size_t prec, offset;
     herr_t ret_value = SUCCEED; /* Return value */
+    H5T_t *base = NULL; /* base data type for strings */
 
     FUNC_ENTER_PACKAGE
 
@@ -4190,13 +4379,13 @@ H5T__set_size(H5T_t *dt, size_t size)
             case H5T_STRING:
                 /* Convert string to variable-length datatype */
                 if (size == H5T_VARIABLE) {
-                    H5T_t     *base = NULL; /* base data type */
                     H5T_cset_t tmp_cset;    /* Temp. cset info */
                     H5T_str_t  tmp_strpad;  /* Temp. strpad info */
 
                     /* Get a copy of unsigned char type as the base/parent type */
                     if (NULL == (base = (H5T_t *)H5I_object(H5T_NATIVE_UCHAR)))
                         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid base datatype");
+                    H5T_VLOCK_ACQUIRE_R(base);
                     dt->shared->parent = H5T_copy(base, H5T_COPY_ALL);
 
                     /* change this datatype into a VL string */
@@ -4275,6 +4464,9 @@ H5T__set_size(H5T_t *dt, size_t size)
     } /* end else */
 
 done:
+    if (base)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T__set_size() */
 
@@ -5613,10 +5805,11 @@ H5T_is_sensible(const H5T_t *dt)
 htri_t
 H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
 {
-    htri_t   changed;       /* Whether H5T_set_loc changed the type (even if the size didn't change) */
-    htri_t   ret_value = 0; /* Indicate that success, but no location change */
-    unsigned i;             /* Local index variable */
-    size_t   old_size;      /* Previous size of a field */
+    htri_t   changed;        /* Whether H5T_set_loc changed the type (even if the size didn't change) */
+    htri_t   ret_value = 0;  /* Indicate that success, but no location change */
+    unsigned i;              /* Local index variable */
+    size_t   old_size;       /* Previous size of a field */
+    H5T_t *memb_type = NULL; /* Compound member's datatype pointer */
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -5657,8 +5850,6 @@ H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
                 H5T__sort_value(dt, NULL);
 
                 for (i = 0; i < dt->shared->u.compnd.nmembs; i++) {
-                    H5T_t *memb_type; /* Member's datatype pointer */
-
                     /* Range check against compound member's offset */
                     if ((accum_change < 0) && ((ssize_t)dt->shared->u.compnd.memb[i].offset < accum_change))
                         HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "invalid field size in datatype");
@@ -5668,6 +5859,8 @@ H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
 
                     /* Set the member type pointer (for convenience) */
                     memb_type = dt->shared->u.compnd.memb[i].type;
+
+                    H5T_VLOCK_ACQUIRE_R(memb_type);
 
                     /* Recurse if it's VL, compound, enum or array */
                     /* (If the force_conv flag is _not_ set, the type cannot change in size, so don't recurse)
@@ -5698,6 +5891,8 @@ H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
                             accum_change += (ssize_t)(memb_type->shared->size - old_size);
                         } /* end if */
                     }     /* end if */
+
+                    H5T_VLOCK_RELEASE_R(memb_type);
                 }         /* end for */
 
                 /* Range check against datatype size */
@@ -5750,6 +5945,9 @@ H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
     }     /* end if */
 
 done:
+    if (memb_type && ret_value < 0)
+        H5T_VLOCK_RELEASE_R(memb_type);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T_set_loc() */
 

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -2903,11 +2903,12 @@ H5Tunregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t dst_id, H5T
     /* Check arguments */
     if (src_id > 0 && (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE))))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "src is not a data type");
-    H5T_VLOCK_ACQUIRE_R(src);
+    if (src)
+        H5T_VLOCK_ACQUIRE_R(src);
     if (dst_id > 0 && (NULL == (dst = (H5T_t *)H5I_object_verify(dst_id, H5I_DATATYPE))))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "dst is not a data type");
     /* Avoid double-locking the same datatype twice */
-    if (memcmp(src, dst, sizeof(H5T_t)) != 0)
+    if (dst && memcmp(src, dst, sizeof(H5T_t)) != 0)
         H5T_VLOCK_ACQUIRE_R(dst);
     if (H5T__unregister(pers, name, src, dst, func) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDELETE, FAIL, "internal unregister function failed");
@@ -3676,6 +3677,7 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
                             (ssize_t)(new_dt->shared->u.compnd.memb[i].type->shared->size -
                                       old_dt->shared->u.compnd.memb[old_match].type->shared->size);
                     } /* end if */
+                    H5T_VLOCK_RELEASE_R(tmp);
                 }     /* end for */
 
                 /* Range check against datatype size */
@@ -3776,7 +3778,7 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
         H5O_msg_reset_share(H5O_DTYPE_ID, new_dt);
 
 done:
-    if (tmp)
+    if (tmp && ret_value < 0)
         H5T_VLOCK_RELEASE_R(tmp);
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -4467,7 +4469,7 @@ H5T__set_size(H5T_t *dt, size_t size)
 
 done:
     if (base)
-        H5T_VLOCK_RELEASE_R(dt);
+        H5T_VLOCK_RELEASE_R(base);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T__set_size() */
@@ -5862,7 +5864,7 @@ H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
                     /* Set the member type pointer (for convenience) */
                     memb_type = dt->shared->u.compnd.memb[i].type;
 
-                    H5T_VLOCK_ACQUIRE_R(memb_type);
+                    H5T_VLOCK_ACQUIRE_W(memb_type);
 
                     /* Recurse if it's VL, compound, enum or array */
                     /* (If the force_conv flag is _not_ set, the type cannot change in size, so don't recurse)
@@ -5894,7 +5896,7 @@ H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
                         } /* end if */
                     }     /* end if */
 
-                    H5T_VLOCK_RELEASE_R(memb_type);
+                    H5T_VLOCK_RELEASE_W(memb_type);
                 }         /* end for */
 
                 /* Range check against datatype size */
@@ -5948,7 +5950,7 @@ H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
 
 done:
     if (memb_type && ret_value < 0)
-        H5T_VLOCK_RELEASE_R(memb_type);
+        H5T_VLOCK_RELEASE_W(memb_type);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T_set_loc() */

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -3413,6 +3413,7 @@ H5T__create(H5T_class_t type, size_t size)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "no applicable native integer type");
             if (NULL == (dt = H5T__alloc()))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
+            H5T_VLOCK_ACQUIRE_W(dt);
             dt->shared->type = type;
             if (NULL == (sub_t_obj = (H5T_t *)H5I_object(subtype)))
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, NULL, "unable to get datatype object");
@@ -3489,6 +3490,7 @@ H5T__initiate_copy(const H5T_t *old_dt)
     /* Allocate space */
     if (NULL == (new_dt = H5FL_MALLOC_MT(H5T_t)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, NULL, "H5T_t memory allocation failed");
+    H5T_VLOCK_INIT(new_dt);
     H5T_VLOCK_ACQUIRE_W(new_dt);
     if (NULL == (new_dt->shared = H5FL_MALLOC_MT(H5T_shared_t)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, NULL, "H5T_shared_t memory allocation failed");

--- a/src/H5TS.c
+++ b/src/H5TS.c
@@ -31,6 +31,9 @@
 #include "H5private.h"   /* Generic Functions                        */
 #include "H5Eprivate.h"  /* Error handling                           */
 #include "H5MMprivate.h" /* Memory management                        */
+#ifdef H5_HAVE_VIRTUAL_LOCK
+#include <stdatomic.h>
+#endif /* H5_HAVE_VIRTUAL_LOCK */
 
 #if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
 
@@ -1115,5 +1118,99 @@ H5TS_create_thread(H5TS_thread_cb_t func, H5TS_attr_t *attr, void *udata)
 
     FUNC_LEAVE_NOAPI_NAMECHECK_ONLY(ret_value)
 } /* H5TS_create_thread */
+
+#ifdef H5_HAVE_VIRTUAL_LOCK
+
+/*--------------------------------------------------------------------------
+ * NAME
+ *    H5TS_vlock_acquire
+ *
+ * USAGE
+ *    H5TS_vlock_acquire(&vlock, op_type)
+ *
+ * DESCRIPTION
+ *    Attempt to acquire the provided virtual lock with the provided op type.
+ *    If the lock is already held by another thread in violation of
+ *    mutual exclusion, an assertion will be thrown.
+ *
+ *    Provided operation type should be H5TS_VLOCK_READER
+ *    or H5TS_VLOCK_WRITER.
+ *
+ * RETURNS
+ *    Non-negative on success / Negative on failure
+ *
+ * --------------------------------------------------------------------------*/
+void
+H5TS_vlock_acquire(H5TS_vlock_t *vlock, H5TS_vlock_op_type_t op_type) {
+    FUNC_ENTER_NOAPI_NAMECHECK_ONLY;
+
+    assert(vlock);
+    assert(atomic_load(&vlock->reader_count) == 0);
+    assert(atomic_load(&vlock->writer_count) == 0);
+
+    if (op_type == H5TS_VLOCK_READER)
+        atomic_fetch_add(&vlock->reader_count, 1);
+    else if (op_type == H5TS_VLOCK_WRITER)
+        atomic_fetch_add(&vlock->writer_count, 1);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY;
+}
+
+/*--------------------------------------------------------------------------
+ * NAME
+ *    H5TS_vlock_release
+ *
+ * USAGE
+ *    H5TS_vlock_release(&vlock)
+ *
+ * DESCRIPTION
+ *    Release the provided virtual lock.
+ *
+ * RETURNS
+ *    Non-negative on success / Negative on failure
+ *
+ * --------------------------------------------------------------------------*/
+void
+H5TS_vlock_release(H5TS_vlock_t *vlock, H5TS_vlock_op_type_t op_type) {
+    assert(vlock);
+
+    FUNC_ENTER_NOAPI_NAMECHECK_ONLY
+
+    if (op_type == H5TS_VLOCK_READER) {
+        assert(atomic_load(&vlock->reader_count) == 1);
+        atomic_fetch_sub(&vlock->reader_count, 1);
+    }
+    else if (op_type == H5TS_VLOCK_WRITER) {
+        assert(atomic_load(&vlock->writer_count) == 1);
+        atomic_fetch_sub(&vlock->writer_count, 1);
+    }
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY;
+}
+
+/*--------------------------------------------------------------------------
+ * NAME
+ *    H5TS_vlock_init
+ * 
+ * USAGE
+ *    H5TS_vlock_init(&vlock)
+ * 
+ * DESCRIPTION
+ *    Initialize the provided virtual lock's reader/writer counts
+ * 
+ *--------------------------------------------------------------------------*/
+void
+H5TS_vlock_init(H5TS_vlock_t *vlock) {
+    assert(vlock);
+
+    FUNC_ENTER_NOAPI_NAMECHECK_ONLY
+
+    atomic_init(&vlock->reader_count, 0);
+    atomic_init(&vlock->writer_count, 0);
+
+    FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
+}
+
+#endif /* H5_HAVE_VIRTUAL_LOCK */
 
 #endif /* H5_HAVE_THREADSAFE or H5_HAVE_MULTITHREAD */

--- a/src/H5TS.c
+++ b/src/H5TS.c
@@ -31,7 +31,7 @@
 #include "H5private.h"   /* Generic Functions                        */
 #include "H5Eprivate.h"  /* Error handling                           */
 #include "H5MMprivate.h" /* Memory management                        */
-#ifdef H5_HAVE_VIRTUAL_LOCK
+#if H5_HAVE_VIRTUAL_LOCK
 #include <stdatomic.h>
 #endif /* H5_HAVE_VIRTUAL_LOCK */
 
@@ -1119,7 +1119,7 @@ H5TS_create_thread(H5TS_thread_cb_t func, H5TS_attr_t *attr, void *udata)
     FUNC_LEAVE_NOAPI_NAMECHECK_ONLY(ret_value)
 } /* H5TS_create_thread */
 
-#ifdef H5_HAVE_VIRTUAL_LOCK
+#if H5_HAVE_VIRTUAL_LOCK
 
 /*--------------------------------------------------------------------------
  * NAME

--- a/src/H5TS.c
+++ b/src/H5TS.c
@@ -1178,10 +1178,12 @@ H5TS_vlock_release(H5TS_vlock_t *vlock, H5TS_vlock_op_type_t op_type) {
 
     if (op_type == H5TS_VLOCK_READER) {
         assert(atomic_load(&vlock->reader_count) == 1);
+        assert(atomic_load(&vlock->writer_count) == 0);
         atomic_fetch_sub(&vlock->reader_count, 1);
     }
     else if (op_type == H5TS_VLOCK_WRITER) {
         assert(atomic_load(&vlock->writer_count) == 1);
+        assert(atomic_load(&vlock->reader_count) == 0);
         atomic_fetch_sub(&vlock->writer_count, 1);
     }
 

--- a/src/H5TSprivate.h
+++ b/src/H5TSprivate.h
@@ -100,7 +100,7 @@ typedef struct H5TS_mutex_struct {
     unsigned int    attempt_lock_count;
 } H5TS_mutex_t;
 
-#ifdef H5_HAVE_VIRTUAL_LOCK
+#if H5_HAVE_VIRTUAL_LOCK
 /* Enum for the type of operation that holds a virtual lock */
 typedef enum {
     H5TS_VLOCK_READER,
@@ -162,7 +162,7 @@ H5_DLL herr_t H5TS_cancel_count_dec(void);
 /* (Only used in the multi-thread build) */
 H5_DLL herr_t H5TS_have_mutex(H5TS_mutex_t *mutex, bool *have_mutex_ptr);
 
-#ifdef H5_HAVE_VIRTUAL_LOCK
+#if H5_HAVE_VIRTUAL_LOCK
 /* Virtual lock routines */
 H5_DLL void H5TS_vlock_acquire(H5TS_vlock_t *vlock, H5TS_vlock_op_type_t op_type);
 H5_DLL void H5TS_vlock_release(H5TS_vlock_t *vlock, H5TS_vlock_op_type_t op_type);

--- a/src/H5TSprivate.h
+++ b/src/H5TSprivate.h
@@ -21,6 +21,9 @@
 #ifndef H5TSprivate_H_
 #define H5TSprivate_H_
 
+// TODO
+#define H5_HAVE_VIRTUAL_LOCK 1
+
 #if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
 /* Include package's public headers */
 #include "H5TSdevelop.h"
@@ -100,6 +103,21 @@ typedef struct H5TS_mutex_struct {
     unsigned int    attempt_lock_count;
 } H5TS_mutex_t;
 
+#ifdef H5_HAVE_VIRTUAL_LOCK
+/* Enum for the type of operation that holds a virtual lock */
+typedef enum {
+    H5TS_VLOCK_READER,
+    H5TS_VLOCK_WRITER
+} H5TS_vlock_op_type_t;
+
+/* A virtual lock to document assumptions of single-thread usage
+ * and track violations of this assupmtion */
+typedef struct H5TS_vlock_t {
+    _Atomic size_t reader_count;
+    _Atomic size_t writer_count;
+} H5TS_vlock_t;
+#endif
+
 /* Portability wrappers around pthread types */
 typedef pthread_t       H5TS_thread_t;
 typedef pthread_attr_t  H5TS_attr_t;
@@ -146,6 +164,13 @@ H5_DLL herr_t H5TS_cancel_count_inc(void);
 H5_DLL herr_t H5TS_cancel_count_dec(void);
 /* (Only used in the multi-thread build) */
 H5_DLL herr_t H5TS_have_mutex(H5TS_mutex_t *mutex, bool *have_mutex_ptr);
+
+#ifdef H5_HAVE_VIRTUAL_LOCK
+/* Virtual lock routines */
+H5_DLL void H5TS_vlock_acquire(H5TS_vlock_t *vlock, H5TS_vlock_op_type_t op_type);
+H5_DLL void H5TS_vlock_release(H5TS_vlock_t *vlock, H5TS_vlock_op_type_t op_type);
+H5_DLL void H5TS_vlock_init(H5TS_vlock_t *vlock);
+#endif
 
 /* Testing routines */
 H5_DLL H5TS_thread_t H5TS_create_thread(void *(*func)(void *), H5TS_attr_t *attr, void *udata);

--- a/src/H5TSprivate.h
+++ b/src/H5TSprivate.h
@@ -21,9 +21,6 @@
 #ifndef H5TSprivate_H_
 #define H5TSprivate_H_
 
-// TODO
-#define H5_HAVE_VIRTUAL_LOCK 1
-
 #if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
 /* Include package's public headers */
 #include "H5TSdevelop.h"

--- a/src/H5Tarray.c
+++ b/src/H5Tarray.c
@@ -195,6 +195,7 @@ H5Tget_array_ndims(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype object");
+    H5T_VLOCK_ACQUIRE_R(dt);
     if (dt->shared->type != H5T_ARRAY)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an array datatype");
 
@@ -202,6 +203,9 @@ H5Tget_array_ndims(hid_t type_id)
     ret_value = H5T__get_array_ndims(dt);
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tget_array_ndims */
 
@@ -250,6 +254,7 @@ H5Tget_array_dims2(hid_t type_id, hsize_t dims[] /*out*/)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype object");
+    H5T_VLOCK_ACQUIRE_R(dt);
     if (dt->shared->type != H5T_ARRAY)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an array datatype");
 
@@ -257,6 +262,9 @@ H5Tget_array_dims2(hid_t type_id, hsize_t dims[] /*out*/)
     if ((ret_value = H5T__get_array_dims(dt, dims)) < 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "unable to get dimension sizes");
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tget_array_dims2() */
 
@@ -369,6 +377,8 @@ H5Tget_array_dims1(hid_t type_id, hsize_t dims[] /*out*/, int H5_ATTR_UNUSED per
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype object");
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     if (dt->shared->type != H5T_ARRAY)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an array datatype");
 
@@ -377,6 +387,9 @@ H5Tget_array_dims1(hid_t type_id, hsize_t dims[] /*out*/, int H5_ATTR_UNUSED per
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "unable to get dimension sizes");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tget_array_dims1() */
 #endif /* H5_NO_DEPRECATED_SYMBOLS */

--- a/src/H5Tarray.c
+++ b/src/H5Tarray.c
@@ -186,7 +186,7 @@ done:
 int
 H5Tget_array_ndims(hid_t type_id)
 {
-    H5T_t *dt;        /* pointer to array datatype	*/
+    H5T_t *dt = NULL; /* pointer to array datatype	*/
     int    ret_value; /* return value			*/
 
     FUNC_ENTER_API(FAIL)
@@ -245,7 +245,7 @@ H5T__get_array_ndims(const H5T_t *dt)
 int
 H5Tget_array_dims2(hid_t type_id, hsize_t dims[] /*out*/)
 {
-    H5T_t *dt;        /* pointer to array data type	*/
+    H5T_t *dt = NULL; /* pointer to array data type	*/
     int    ret_value; /* return value			*/
 
     FUNC_ENTER_API(FAIL)
@@ -368,7 +368,7 @@ done:
 int
 H5Tget_array_dims1(hid_t type_id, hsize_t dims[] /*out*/, int H5_ATTR_UNUSED perm[] /*out*/)
 {
-    H5T_t *dt;        /* Array datatype to query	*/
+    H5T_t *dt = NULL; /* Array datatype to query	*/
     int    ret_value; /* return value			*/
 
     FUNC_ENTER_API(FAIL)

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -587,14 +587,10 @@ H5Tcommitted(hid_t type_id)
     if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
-    H5T_VLOCK_ACQUIRE_R(type);
-
     /* Set return value */
     ret_value = H5T_is_named(type);
 
 done:
-    if (type)
-        H5T_VLOCK_RELEASE_R(type);
 
     FUNC_LEAVE_API_NO_MUTEX(ret_value)
 } /* end H5Tcommitted() */
@@ -792,7 +788,6 @@ H5Tget_create_plist(hid_t dtype_id)
     /* Check arguments */
     if (NULL == (type = (H5T_t *)H5I_object_verify(dtype_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a datatype");
-    H5T_VLOCK_ACQUIRE_R(type);
 
     /* Check if the datatype is committed */
     if (FAIL == (is_named = H5T_is_named(type)))
@@ -834,9 +829,6 @@ H5Tget_create_plist(hid_t dtype_id)
     } /* end else */
 
 done:
-    if (type)
-        H5T_VLOCK_RELEASE_R(type);
-
     FUNC_LEAVE_API_NO_MUTEX(ret_value)
 } /* end H5Tget_create_plist() */
 
@@ -861,7 +853,6 @@ H5Tflush(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
-    H5T_VLOCK_ACQUIRE_R(dt);
 
     if (!H5T_is_named(dt))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a committed datatype");
@@ -887,8 +878,6 @@ H5Tflush(hid_t type_id)
     }
 
 done:
-    if (dt)
-        H5T_VLOCK_RELEASE_R(dt);
 
     FUNC_LEAVE_API_NO_MUTEX(ret_value)
 } /* H5Tflush */

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -1215,7 +1215,6 @@ H5T__open_oid(const H5G_loc_t *loc)
     if (NULL == (dt = (H5T_t *)H5O_msg_read(loc->oloc, H5O_DTYPE_ID, NULL)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "unable to load type message from object header");
 
-    H5T_VLOCK_INIT(dt);
     H5T_VLOCK_ACQUIRE_W(dt);
 
     /* Mark the type as named and open */

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -1396,7 +1396,7 @@ H5T_save_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
     if (NULL == vol_dt)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "tid is not not a named datatype ID");
     /* Avoid double-locking if datatypes are the same */
-    if (memcmp(dt, vol_dt, sizeof(H5T_t)) != 0)
+    if (dt != vol_dt)
         H5T_VLOCK_ACQUIRE_W(vol_dt);
 
     /* Increase the count on the file object */
@@ -1412,7 +1412,7 @@ H5T_save_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
 done:
     if (dt)
         H5T_VLOCK_RELEASE_R(dt);
-    if (vol_dt && (memcmp(dt, vol_dt, sizeof(H5T_t)) != 0))
+    if (vol_dt && dt != vol_dt)
         H5T_VLOCK_RELEASE_W(vol_dt);
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1447,7 +1447,7 @@ H5T_restore_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "tid is not not a named datatype ID");
 
     /* Avoid double-locking if datatypes are the same */
-    if (memcmp(dt, vol_dt, sizeof(H5T_t)) != 0)
+    if (dt != vol_dt)
         H5T_VLOCK_ACQUIRE_W(vol_dt);
 
     /* Restore the H5O_shared_t data */
@@ -1463,7 +1463,7 @@ H5T_restore_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
 done:
     if (dt)
         H5T_VLOCK_RELEASE_R(dt);
-    if (vol_dt && (memcmp(dt, vol_dt, sizeof(H5T_t)) != 0))
+    if (vol_dt && dt != vol_dt)
         H5T_VLOCK_RELEASE_W(vol_dt);
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -1215,6 +1215,7 @@ H5T__open_oid(const H5G_loc_t *loc)
     if (NULL == (dt = (H5T_t *)H5O_msg_read(loc->oloc, H5O_DTYPE_ID, NULL)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "unable to load type message from object header");
 
+    H5T_VLOCK_INIT(dt);
     H5T_VLOCK_ACQUIRE_W(dt);
 
     /* Mark the type as named and open */

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -587,10 +587,15 @@ H5Tcommitted(hid_t type_id)
     if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
+    H5T_VLOCK_ACQUIRE_R(type);
+
     /* Set return value */
     ret_value = H5T_is_named(type);
 
 done:
+    if (type)
+        H5T_VLOCK_RELEASE_R(type);
+
     FUNC_LEAVE_API_NO_MUTEX(ret_value)
 } /* end H5Tcommitted() */
 
@@ -787,6 +792,7 @@ H5Tget_create_plist(hid_t dtype_id)
     /* Check arguments */
     if (NULL == (type = (H5T_t *)H5I_object_verify(dtype_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(type);
 
     /* Check if the datatype is committed */
     if (FAIL == (is_named = H5T_is_named(type)))
@@ -828,6 +834,9 @@ H5Tget_create_plist(hid_t dtype_id)
     } /* end else */
 
 done:
+    if (type)
+        H5T_VLOCK_RELEASE_R(type);
+
     FUNC_LEAVE_API_NO_MUTEX(ret_value)
 } /* end H5Tget_create_plist() */
 
@@ -852,6 +861,8 @@ H5Tflush(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     if (!H5T_is_named(dt))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a committed datatype");
 
@@ -876,6 +887,9 @@ H5Tflush(hid_t type_id)
     }
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API_NO_MUTEX(ret_value)
 } /* H5Tflush */
 
@@ -900,6 +914,8 @@ H5Trefresh(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (!H5T_is_named(dt))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a committed datatype");
 
@@ -924,6 +940,9 @@ H5Trefresh(hid_t type_id)
     }
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API_NO_MUTEX(ret_value)
 } /* H5Trefresh */
 
@@ -1196,6 +1215,8 @@ H5T__open_oid(const H5G_loc_t *loc)
     if (NULL == (dt = (H5T_t *)H5O_msg_read(loc->oloc, H5O_DTYPE_ID, NULL)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "unable to load type message from object header");
 
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     /* Mark the type as named and open */
     dt->shared->state = H5T_STATE_OPEN;
 
@@ -1214,6 +1235,9 @@ H5T__open_oid(const H5G_loc_t *loc)
     ret_value = dt;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     if (ret_value == NULL)
         if (dt == NULL)
             H5O_close(loc->oloc, NULL);
@@ -1373,10 +1397,12 @@ H5T_save_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
 
     if (NULL == (dt = (H5T_t *)H5I_object_verify(tid, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "tid is not a datatype ID");
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     vol_dt = H5T_get_actual_type(dt);
     if (NULL == vol_dt)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "tid is not not a named datatype ID");
-
+    H5T_VLOCK_ACQUIRE_W(vol_dt);
     /* Increase the count on the file object */
     vol_dt->shared->fo_count += 1;
 
@@ -1388,6 +1414,11 @@ H5T_save_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
     H5MM_memcpy(cached_H5O_shared, &(vol_dt->sh_loc), sizeof(H5O_shared_t));
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+    if (vol_dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T_save_refresh_state() */
 
@@ -1413,9 +1444,13 @@ H5T_restore_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
 
     if (NULL == (dt = (H5T_t *)H5I_object_verify(tid, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "tid not a datatype ID");
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     vol_dt = H5T_get_actual_type(dt);
     if (NULL == vol_dt)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "tid is not not a named datatype ID");
+
+    H5T_VLOCK_ACQUIRE_W(vol_dt);
 
     /* Restore the H5O_shared_t data */
     H5MM_memcpy(&(vol_dt->sh_loc), cached_H5O_shared, sizeof(H5O_shared_t));
@@ -1428,6 +1463,11 @@ H5T_restore_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
     vol_dt->shared->fo_count -= 1;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+    if (vol_dt)
+        H5T_VLOCK_RELEASE_W(vol_dt);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T_restore_refresh_state() */
 

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -1098,6 +1098,7 @@ H5T_open(const H5G_loc_t *loc)
         /* Open the datatype object */
         if (NULL == (dt = H5T__open_oid(loc)))
             HGOTO_ERROR(H5E_DATATYPE, H5E_NOTFOUND, NULL, "not found");
+        H5T_VLOCK_ACQUIRE_W(dt);
 
         /* Add the datatype to the list of opened objects in the file */
         if (H5FO_insert(dt->sh_loc.file, dt->sh_loc.u.loc.oh_addr, dt->shared, FALSE) < 0)
@@ -1117,6 +1118,9 @@ H5T_open(const H5G_loc_t *loc)
     else {
         if (NULL == (dt = H5FL_MALLOC_MT(H5T_t)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "can't allocate space for datatype");
+        H5T_VLOCK_INIT(dt);
+        H5T_VLOCK_ACQUIRE_W(dt);
+
         dt->vol_obj = NULL;
 
 #if defined(H5_USING_MEMCHECKER) || !defined(NDEBUG)
@@ -1165,6 +1169,9 @@ H5T_open(const H5G_loc_t *loc)
     ret_value = dt;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     if (ret_value == NULL) {
         if (dt) {
             if (shared_fo == NULL) { /* Need to free shared file object */

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -914,7 +914,6 @@ H5Trefresh(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
-    H5T_VLOCK_ACQUIRE_W(dt);
 
     if (!H5T_is_named(dt))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a committed datatype");
@@ -940,8 +939,6 @@ H5Trefresh(hid_t type_id)
     }
 
 done:
-    if (dt)
-        H5T_VLOCK_RELEASE_W(dt);
 
     FUNC_LEAVE_API_NO_MUTEX(ret_value)
 } /* H5Trefresh */
@@ -1409,7 +1406,10 @@ H5T_save_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
     vol_dt = H5T_get_actual_type(dt);
     if (NULL == vol_dt)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "tid is not not a named datatype ID");
-    H5T_VLOCK_ACQUIRE_W(vol_dt);
+    /* Avoid double-locking if datatypes are the same */
+    if (memcmp(dt, vol_dt, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_ACQUIRE_W(vol_dt);
+
     /* Increase the count on the file object */
     vol_dt->shared->fo_count += 1;
 
@@ -1423,8 +1423,8 @@ H5T_save_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
 done:
     if (dt)
         H5T_VLOCK_RELEASE_R(dt);
-    if (vol_dt)
-        H5T_VLOCK_RELEASE_W(dt);
+    if (vol_dt && (memcmp(dt, vol_dt, sizeof(H5T_t)) != 0))
+        H5T_VLOCK_RELEASE_W(vol_dt);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T_save_refresh_state() */
@@ -1457,7 +1457,9 @@ H5T_restore_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
     if (NULL == vol_dt)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "tid is not not a named datatype ID");
 
-    H5T_VLOCK_ACQUIRE_W(vol_dt);
+    /* Avoid double-locking if datatypes are the same */
+    if (memcmp(dt, vol_dt, sizeof(H5T_t)) != 0)
+        H5T_VLOCK_ACQUIRE_W(vol_dt);
 
     /* Restore the H5O_shared_t data */
     H5MM_memcpy(&(vol_dt->sh_loc), cached_H5O_shared, sizeof(H5O_shared_t));
@@ -1472,7 +1474,7 @@ H5T_restore_refresh_state(hid_t tid, H5O_shared_t *cached_H5O_shared)
 done:
     if (dt)
         H5T_VLOCK_RELEASE_R(dt);
-    if (vol_dt)
+    if (vol_dt && (memcmp(dt, vol_dt, sizeof(H5T_t)) != 0))
         H5T_VLOCK_RELEASE_W(vol_dt);
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -577,7 +577,7 @@ done:
 htri_t
 H5Tcommitted(hid_t type_id)
 {
-    H5T_t *type;      /* Datatype to query */
+    H5T_t *type = NULL; /* Datatype to query */
     htri_t ret_value; /* Return value */
 
     FUNC_ENTER_API_NO_MUTEX(FAIL)
@@ -852,7 +852,7 @@ done:
 herr_t
 H5Tflush(hid_t type_id)
 {
-    H5T_t *dt;                  /* Datatype for this operation */
+    H5T_t *dt = NULL;           /* Datatype for this operation */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NO_MUTEX(FAIL)
@@ -905,7 +905,7 @@ done:
 herr_t
 H5Trefresh(hid_t type_id)
 {
-    H5T_t *dt;                  /* Datatype for this operation */
+    H5T_t *dt = NULL;           /* Datatype for this operation */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NO_MUTEX(FAIL)

--- a/src/H5Tcompound.c
+++ b/src/H5Tcompound.c
@@ -84,7 +84,7 @@ static H5T_t *H5T__reopen_member_type(const H5T_t *dt, unsigned membno);
 size_t
 H5Tget_member_offset(hid_t type_id, unsigned membno)
 {
-    H5T_t *dt;        /* Datatype to query */
+    H5T_t *dt = NULL; /* Datatype to query */
     size_t ret_value; /* Return value */
 
     FUNC_ENTER_API(0)
@@ -187,7 +187,7 @@ done:
 hid_t
 H5Tget_member_type(hid_t type_id, unsigned membno)
 {
-    H5T_t *dt;             /* Datatype to query */
+    H5T_t *dt = NULL;      /* Datatype to query */
     H5T_t *memb_dt = NULL; /* Member datatype */
     hid_t  ret_value;      /* Return value */
 
@@ -379,7 +379,7 @@ done:
 herr_t
 H5Tpack(hid_t type_id)
 {
-    H5T_t *dt;                  /* Datatype to modify */
+    H5T_t *dt = NULL;           /* Datatype to modify */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)

--- a/src/H5Tcompound.c
+++ b/src/H5Tcompound.c
@@ -93,6 +93,7 @@ H5Tget_member_offset(hid_t type_id, unsigned membno)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)) || H5T_COMPOUND != dt->shared->type)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, 0, "not a compound datatype");
+    H5T_VLOCK_ACQUIRE_R(dt);
     if (membno >= dt->shared->u.compnd.nmembs)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "invalid member number");
 
@@ -100,6 +101,9 @@ H5Tget_member_offset(hid_t type_id, unsigned membno)
     ret_value = H5T_GET_MEMBER_OFFSET(dt->shared, membno);
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tget_member_offset() */
 
@@ -193,18 +197,24 @@ H5Tget_member_type(hid_t type_id, unsigned membno)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)) || H5T_COMPOUND != dt->shared->type)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a compound datatype");
+    H5T_VLOCK_ACQUIRE_R(dt);
     if (membno >= dt->shared->u.compnd.nmembs)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "invalid member number");
 
     /* Retrieve the datatype for the member */
     if (NULL == (memb_dt = H5T__reopen_member_type(dt, membno)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, H5I_INVALID_HID, "unable to retrieve member type");
-
+    H5T_VLOCK_ACQUIRE_R(memb_dt);
     /* Get an ID for the datatype */
     if ((ret_value = H5I_register(H5I_DATATYPE, memb_dt, TRUE)) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, H5I_INVALID_HID, "unable register datatype ID");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+    if (memb_dt)
+        H5T_VLOCK_RELEASE_R(memb_dt);
+
     if (ret_value < 0)
         if (memb_dt && H5T_close(memb_dt) < 0)
             HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, H5I_INVALID_HID, "can't close datatype");
@@ -332,6 +342,7 @@ H5Tinsert(hid_t parent_id, const char *name, size_t offset, hid_t member_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't insert compound datatype within itself");
     if (NULL == (parent = (H5T_t *)H5I_object_verify(parent_id, H5I_DATATYPE)) ||
         H5T_COMPOUND != parent->shared->type)
+    H5T_VLOCK_ACQUIRE_W(parent);
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a compound datatype");
     if (H5T_STATE_TRANSIENT != parent->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parent type read-only");
@@ -339,12 +350,17 @@ H5Tinsert(hid_t parent_id, const char *name, size_t offset, hid_t member_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no member name");
     if (NULL == (member = (H5T_t *)H5I_object_verify(member_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
-
+    H5T_VLOCK_ACQUIRE_W(member);
     /* Insert */
     if (H5T__insert(parent, name, offset, member) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINSERT, FAIL, "unable to insert member");
 
 done:
+    if (parent)
+        H5T_VLOCK_RELEASE_W(parent);
+    if (member)
+        H5T_VLOCK_RELEASE_W(member);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tinsert() */
 
@@ -371,12 +387,16 @@ H5Tpack(hid_t type_id)
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)) ||
         H5T_detect_class(dt, H5T_COMPOUND, TRUE) <= 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a compound datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
 
     /* Pack */
     if (H5T__pack(dt) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to pack compound datatype");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tpack() */
 

--- a/src/H5Tcompound.c
+++ b/src/H5Tcompound.c
@@ -330,8 +330,8 @@ H5T__get_member_size(const H5T_t *dt, unsigned membno)
 herr_t
 H5Tinsert(hid_t parent_id, const char *name, size_t offset, hid_t member_id)
 {
-    H5T_t *parent;              /* The compound parent datatype */
-    H5T_t *member;              /* The member datatype	*/
+    H5T_t *parent = NULL;       /* The compound parent datatype */
+    H5T_t *member = NULL;       /* The member datatype	*/
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -340,9 +340,11 @@ H5Tinsert(hid_t parent_id, const char *name, size_t offset, hid_t member_id)
     /* Check args */
     if (parent_id == member_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't insert compound datatype within itself");
-    if (NULL == (parent = (H5T_t *)H5I_object_verify(parent_id, H5I_DATATYPE)) ||
-        H5T_COMPOUND != parent->shared->type)
+    if (NULL == (parent = (H5T_t *)H5I_object_verify(parent_id, H5I_DATATYPE)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a compound datatype");
     H5T_VLOCK_ACQUIRE_W(parent);
+
+    if  (H5T_COMPOUND != parent->shared->type)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a compound datatype");
     if (H5T_STATE_TRANSIENT != parent->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parent type read-only");

--- a/src/H5Tconv.c
+++ b/src/H5Tconv.c
@@ -2036,14 +2036,18 @@ H5T__conv_struct_init(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata)
                 H5T_t *type;
 
                 type = H5T_copy(src->shared->u.compnd.memb[i].type, H5T_COPY_ALL);
+                H5T_VLOCK_ACQUIRE_R(type);
                 tid  = H5I_register(H5I_DATATYPE, type, FALSE);
                 assert(tid >= 0);
                 priv->src_memb_id[i] = tid;
+                H5T_VLOCK_RELEASE_R(type);
 
                 type = H5T_copy(dst->shared->u.compnd.memb[src2dst[i]].type, H5T_COPY_ALL);
+                H5T_VLOCK_ACQUIRE_R(type);
                 tid  = H5I_register(H5I_DATATYPE, type, FALSE);
                 assert(tid >= 0);
                 priv->dst_memb_id[src2dst[i]] = tid;
+                H5T_VLOCK_RELEASE_R(type);
             } /* end if */
         }     /* end for */
     }         /* end if */

--- a/src/H5Tcset.c
+++ b/src/H5Tcset.c
@@ -77,7 +77,7 @@ done:
 herr_t
 H5Tset_cset(hid_t type_id, H5T_cset_t cset)
 {
-    H5T_t *dt;
+    H5T_t *dt = NULL;
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)

--- a/src/H5Tcset.c
+++ b/src/H5Tcset.c
@@ -86,6 +86,7 @@ H5Tset_cset(hid_t type_id, H5T_cset_t cset)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    H5T_VLOCK_ACQUIRE_W(dt);
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTINIT, FAIL, "data type is read-only");
     if (cset < H5T_CSET_ASCII || cset >= H5T_NCSET)
@@ -102,5 +103,8 @@ H5Tset_cset(hid_t type_id, H5T_cset_t cset)
         dt->shared->u.vlen.cset = cset;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 }

--- a/src/H5Tenum.c
+++ b/src/H5Tenum.c
@@ -70,7 +70,7 @@ done:
     if (parent)
         H5T_VLOCK_RELEASE_R(parent);
     if (dt)
-        H5T_VLOCK_RELEASE_R(parent);
+        H5T_VLOCK_RELEASE_R(dt);
 
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tenum_create() */

--- a/src/H5Tenum.c
+++ b/src/H5Tenum.c
@@ -442,7 +442,7 @@ done:
 herr_t
 H5Tenum_valueof(hid_t type, const char *name, void *value /*out*/)
 {
-    H5T_t *dt;
+    H5T_t *dt = NULL;
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)

--- a/src/H5Tenum.c
+++ b/src/H5Tenum.c
@@ -54,15 +54,24 @@ H5Tenum_create(hid_t parent_id)
         H5T_INTEGER != parent->shared->type)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not an integer data type");
 
+    H5T_VLOCK_ACQUIRE_R(parent);
+
     /* Build new type */
     if (NULL == (dt = H5T__enum_create(parent)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5I_INVALID_HID, "cannot create enum type");
+
+    H5T_VLOCK_ACQUIRE_R(dt);
 
     /* Register the type */
     if ((ret_value = H5I_register(H5I_DATATYPE, dt, TRUE)) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register data type ID");
 
 done:
+    if (parent)
+        H5T_VLOCK_RELEASE_R(parent);
+    if (dt)
+        H5T_VLOCK_RELEASE_R(parent);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tenum_create() */
 
@@ -91,12 +100,16 @@ H5T__enum_create(const H5T_t *parent)
     /* Build new type */
     if (NULL == (ret_value = H5T__alloc()))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
+    H5T_VLOCK_ACQUIRE_W(ret_value);
     ret_value->shared->type   = H5T_ENUM;
     ret_value->shared->parent = H5T_copy(parent, H5T_COPY_ALL);
     assert(ret_value->shared->parent);
     ret_value->shared->size = ret_value->shared->parent->shared->size;
 
 done:
+    if (ret_value)
+        H5T_VLOCK_RELEASE_W(ret_value);
+
     FUNC_LEAVE_NOAPI(ret_value)
 }
 
@@ -128,6 +141,8 @@ H5Tenum_insert(hid_t type, const char *name, const void *value)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_ENUM != dt->shared->type)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an enumeration data type");
     if (!name || !*name)
@@ -140,6 +155,9 @@ H5Tenum_insert(hid_t type, const char *name, const void *value)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to insert new enumeration member");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 }
 
@@ -226,6 +244,7 @@ H5Tget_member_value(hid_t type, unsigned membno, void *value /*out*/)
 
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    H5T_VLOCK_ACQUIRE_R(dt);
     if (H5T_ENUM != dt->shared->type)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "operation not defined for data type class");
     if (membno >= dt->shared->u.enumer.nmembs)
@@ -236,6 +255,9 @@ H5Tget_member_value(hid_t type, unsigned membno, void *value /*out*/)
     if (H5T__get_member_value(dt, membno, value) < 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to get member value");
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 }
 
@@ -294,6 +316,7 @@ H5Tenum_nameof(hid_t type, const void *value, char *name /*out*/, size_t size)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    H5T_VLOCK_ACQUIRE_R(dt);
     if (H5T_ENUM != dt->shared->type)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an enumeration data type");
     if (!value)
@@ -305,6 +328,9 @@ H5Tenum_nameof(hid_t type, const void *value, char *name /*out*/, size_t size)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "nameof query failed");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 }
 
@@ -425,6 +451,7 @@ H5Tenum_valueof(hid_t type, const char *name, void *value /*out*/)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    H5T_VLOCK_ACQUIRE_R(dt);
     if (H5T_ENUM != dt->shared->type)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an enumeration data type");
     if (!name || !*name)
@@ -436,6 +463,9 @@ H5Tenum_valueof(hid_t type, const char *name, void *value /*out*/)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "valueof query failed");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* H5Tenum_valueof() */
 

--- a/src/H5Tfields.c
+++ b/src/H5Tfields.c
@@ -40,7 +40,7 @@
 int
 H5Tget_nmembers(hid_t type_id)
 {
-    H5T_t *dt;        /* Datatype to query */
+    H5T_t *dt = NULL; /* Datatype to query */
     int    ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)

--- a/src/H5Tfields.c
+++ b/src/H5Tfields.c
@@ -49,11 +49,15 @@ H5Tget_nmembers(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(dt);
 
     if ((ret_value = H5T_get_nmembers(dt)) < 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "cannot return member number");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tget_nmembers() */
 
@@ -119,11 +123,15 @@ H5Tget_member_name(hid_t type_id, unsigned membno)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(dt);
 
     if (NULL == (ret_value = H5T__get_member_name(dt, membno)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "unable to get member name");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 }
 

--- a/src/H5Tfixed.c
+++ b/src/H5Tfixed.c
@@ -109,6 +109,8 @@ H5Tset_sign(hid_t type_id, H5T_sign_t sign)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an integer datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTINIT, FAIL, "datatype is read-only");
     if (sign < H5T_SGN_NONE || sign >= H5T_NSGN)
@@ -124,5 +126,8 @@ H5Tset_sign(hid_t type_id, H5T_sign_t sign)
     dt->shared->u.atomic.u.i.sign = sign;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 }

--- a/src/H5Tfloat.c
+++ b/src/H5Tfloat.c
@@ -43,7 +43,7 @@ herr_t
 H5Tget_fields(hid_t type_id, size_t *spos /*out*/, size_t *epos /*out*/, size_t *esize /*out*/,
               size_t *mpos /*out*/, size_t *msize /*out*/)
 {
-    H5T_t *dt;                  /* Datatype */
+    H5T_t *dt = NULL;           /* Datatype */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -96,7 +96,7 @@ done:
 herr_t
 H5Tset_fields(hid_t type_id, size_t spos, size_t epos, size_t esize, size_t mpos, size_t msize)
 {
-    H5T_t *dt;                  /* Datatype */
+    H5T_t *dt = NULL;           /* Datatype */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -156,7 +156,7 @@ done:
 size_t
 H5Tget_ebias(hid_t type_id)
 {
-    H5T_t *dt;        /* Datatype */
+    H5T_t *dt = NULL; /* Datatype */
     size_t ret_value; /* Return value */
 
     FUNC_ENTER_API(0)
@@ -194,7 +194,7 @@ done:
 herr_t
 H5Tset_ebias(hid_t type_id, size_t ebias)
 {
-    H5T_t *dt;                  /* Datatype */
+    H5T_t *dt = NULL;           /* Datatype */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -271,7 +271,7 @@ done:
 herr_t
 H5Tset_norm(hid_t type_id, H5T_norm_t norm)
 {
-    H5T_t *dt;                  /* Datatype */
+    H5T_t *dt = NULL;           /* Datatype */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
@@ -354,7 +354,7 @@ done:
 herr_t
 H5Tset_inpad(hid_t type_id, H5T_pad_t pad)
 {
-    H5T_t *dt;                  /* Datatype */
+    H5T_t *dt = NULL;           /* Datatype */
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)

--- a/src/H5Tfloat.c
+++ b/src/H5Tfloat.c
@@ -52,6 +52,8 @@ H5Tget_fields(hid_t type_id, size_t *spos /*out*/, size_t *epos /*out*/, size_t 
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     while (dt->shared->parent)
         dt = dt->shared->parent; /*defer to parent*/
     if (H5T_FLOAT != dt->shared->type)
@@ -70,6 +72,9 @@ H5Tget_fields(hid_t type_id, size_t *spos /*out*/, size_t *epos /*out*/, size_t 
         *msize = dt->shared->u.atomic.u.f.msize;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tget_fields() */
 
@@ -100,6 +105,8 @@ H5Tset_fields(hid_t type_id, size_t spos, size_t epos, size_t esize, size_t mpos
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTSET, FAIL, "datatype is read-only");
     while (dt->shared->parent)
@@ -129,6 +136,9 @@ H5Tset_fields(hid_t type_id, size_t spos, size_t epos, size_t esize, size_t mpos
     dt->shared->u.atomic.u.f.msize = msize;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tset_fields() */
 
@@ -155,6 +165,8 @@ H5Tget_ebias(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, 0, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     while (dt->shared->parent)
         dt = dt->shared->parent; /*defer to parent*/
     if (H5T_FLOAT != dt->shared->type)
@@ -164,6 +176,9 @@ H5Tget_ebias(hid_t type_id)
     H5_CHECKED_ASSIGN(ret_value, size_t, dt->shared->u.atomic.u.f.ebias, uint64_t);
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tget_ebias() */
 
@@ -188,6 +203,8 @@ H5Tset_ebias(hid_t type_id, size_t ebias)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTSET, FAIL, "datatype is read-only");
     while (dt->shared->parent)
@@ -199,6 +216,9 @@ H5Tset_ebias(hid_t type_id, size_t ebias)
     dt->shared->u.atomic.u.f.ebias = ebias;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tset_ebias() */
 
@@ -260,6 +280,8 @@ H5Tset_norm(hid_t type_id, H5T_norm_t norm)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTSET, FAIL, "datatype is read-only");
     if (norm < H5T_NORM_IMPLIED || norm > H5T_NORM_NONE)
@@ -273,6 +295,9 @@ H5Tset_norm(hid_t type_id, H5T_norm_t norm)
     dt->shared->u.atomic.u.f.norm = norm;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tset_norm() */
 
@@ -338,6 +363,8 @@ H5Tset_inpad(hid_t type_id, H5T_pad_t pad)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTSET, FAIL, "datatype is read-only");
     if (pad < H5T_PAD_ZERO || pad >= H5T_NPAD)
@@ -351,5 +378,8 @@ H5Tset_inpad(hid_t type_id, H5T_pad_t pad)
     dt->shared->u.atomic.u.f.pad = pad;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tset_inpad() */

--- a/src/H5Tfloat.c
+++ b/src/H5Tfloat.c
@@ -165,10 +165,10 @@ H5Tget_ebias(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, 0, "not a datatype");
-    H5T_VLOCK_ACQUIRE_R(dt);
 
     while (dt->shared->parent)
         dt = dt->shared->parent; /*defer to parent*/
+    H5T_VLOCK_ACQUIRE_R(dt);
     if (H5T_FLOAT != dt->shared->type)
         HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, 0, "operation not defined for datatype class");
 

--- a/src/H5Tnative.c
+++ b/src/H5Tnative.c
@@ -229,6 +229,7 @@ H5T__get_native_type(H5T_t *dtype, H5T_direction_t direction, size_t *struct_ali
             if (0 == H5T_cmp(ret_value, dt, FALSE)) {
                 align    = H5T_HOBJREF_ALIGN_g;
                 ref_size = sizeof(hobj_ref_t);
+                H5T_VLOCK_RELEASE_R(dt);
             } /* end if */
             else {
                 H5T_VLOCK_RELEASE_R(dt);

--- a/src/H5Tnative.c
+++ b/src/H5Tnative.c
@@ -67,7 +67,7 @@ static herr_t H5T__cmp_offset(size_t *comp_size, size_t *offset, size_t elem_siz
 hid_t
 H5Tget_native_type(hid_t type_id, H5T_direction_t direction)
 {
-    H5T_t *dt;               /* Datatype to create native datatype from */
+    H5T_t *dt        = NULL; /* Datatype to create native datatype from */
     H5T_t *new_dt    = NULL; /* Datatype for native datatype created */
     size_t comp_size = 0;    /* Compound datatype's size */
     hid_t  ret_value;        /* Return value */
@@ -560,7 +560,7 @@ static H5T_t *
 H5T__get_native_integer(size_t prec, H5T_sign_t sign, H5T_direction_t direction, size_t *struct_align,
                         size_t *offset, size_t *comp_size)
 {
-    H5T_t *dt;                 /* Appropriate native datatype to copy */
+    H5T_t *dt = NULL;          /* Appropriate native datatype to copy */
     hid_t  tid         = (-1); /* Datatype ID of appropriate native datatype */
     size_t align       = 0;    /* Alignment necessary for native datatype */
     size_t native_size = 0;    /* Datatype size of the native type */

--- a/src/H5Tnative.c
+++ b/src/H5Tnative.c
@@ -78,18 +78,26 @@ H5Tget_native_type(hid_t type_id, H5T_direction_t direction)
     /* Check arguments */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a data type");
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     if (direction != H5T_DIR_DEFAULT && direction != H5T_DIR_ASCEND && direction != H5T_DIR_DESCEND)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not valid direction value");
 
     /* Get the native type */
     if (NULL == (new_dt = H5T__get_native_type(dt, direction, NULL, NULL, &comp_size)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "cannot retrieve native type");
+    H5T_VLOCK_ACQUIRE_R(new_dt);
 
     /* Get an ID for the new type */
     if ((ret_value = H5I_register(H5I_DATATYPE, new_dt, TRUE)) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register data type");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+    if (new_dt)
+        H5T_VLOCK_RELEASE_R(new_dt);
+
     /* Error cleanup */
     if (ret_value < 0)
         if (new_dt && H5T_close_real(new_dt) < 0)
@@ -213,20 +221,21 @@ H5T__get_native_type(H5T_t *dtype, H5T_direction_t direction, size_t *struct_ali
 
             if (NULL == (ret_value = H5T_copy(dtype, H5T_COPY_TRANSIENT)))
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot copy reference type");
-
             /* Decide if the data type is object reference. */
             if (NULL == (dt = (H5T_t *)H5I_object(H5T_STD_REF_OBJ_g)))
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a data type");
-
+            H5T_VLOCK_ACQUIRE_R(dt);
             /* Update size, offset and compound alignment for parent. */
             if (0 == H5T_cmp(ret_value, dt, FALSE)) {
                 align    = H5T_HOBJREF_ALIGN_g;
                 ref_size = sizeof(hobj_ref_t);
             } /* end if */
             else {
+                H5T_VLOCK_RELEASE_R(dt);
                 /* Decide if the data type is dataset region reference. */
                 if (NULL == (dt = (H5T_t *)H5I_object(H5T_STD_REF_DSETREG_g)))
                     HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a data type");
+                H5T_VLOCK_ACQUIRE_R(dt);
 
                 if (0 == H5T_cmp(ret_value, dt, FALSE)) {
                     align    = H5T_HDSETREGREF_ALIGN_g;
@@ -237,6 +246,7 @@ H5T__get_native_type(H5T_t *dtype, H5T_direction_t direction, size_t *struct_ali
                     align    = H5T_REF_ALIGN_g;
                     ref_size = sizeof(H5R_ref_t);
                 } /* end else */
+                H5T_VLOCK_RELEASE_R(dt);
             }     /* end else */
 
             if (H5T__cmp_offset(comp_size, offset, ref_size, (size_t)1, align, struct_align) < 0)
@@ -265,6 +275,7 @@ H5T__get_native_type(H5T_t *dtype, H5T_direction_t direction, size_t *struct_ali
             for (u = 0; u < nmemb; u++) {
                 if (NULL == (memb_type = H5T_get_member_type(dtype, u)))
                     HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "member type retrieval failed");
+                H5T_VLOCK_ACQUIRE_R(memb_type);
 
                 if (NULL == (comp_mname[u] = H5T__get_member_name(dtype, u)))
                     HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "member type retrieval failed");
@@ -273,8 +284,12 @@ H5T__get_native_type(H5T_t *dtype, H5T_direction_t direction, size_t *struct_ali
                                                                  &(memb_offset[u]), &children_size)))
                     HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "member identifier retrieval failed");
 
+                H5T_VLOCK_RELEASE_R(memb_type);
+
                 if (H5T_close_real(memb_type) < 0)
                     HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot close datatype");
+                
+                memb_type = NULL;
             } /* end for */
 
             /* The alignment for whole compound type */
@@ -489,6 +504,9 @@ H5T__get_native_type(H5T_t *dtype, H5T_direction_t direction, size_t *struct_ali
     } /* end switch */
 
 done:
+    if (memb_type)
+        H5T_VLOCK_RELEASE_R(memb_type);
+
     /* Error cleanup */
     if (NULL == ret_value) {
         if (new_type)
@@ -663,14 +681,23 @@ H5T__get_native_integer(size_t prec, H5T_sign_t sign, H5T_direction_t direction,
     if (NULL == (dt = (H5T_t *)H5I_object(tid)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a data type");
 
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     if (NULL == (ret_value = H5T_copy(dt, H5T_COPY_TRANSIENT)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot copy type");
+
+    H5T_VLOCK_ACQUIRE_R(ret_value);
 
     /* compute size and offset of compound type member. */
     if (H5T__cmp_offset(comp_size, offset, native_size, (size_t)1, align, struct_align) < 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot compute compound offset");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+    if (ret_value)
+        H5T_VLOCK_RELEASE_R(ret_value);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T__get_native_integer() */
 H5_GCC_DIAG_ON("duplicated-branches")
@@ -773,14 +800,23 @@ H5T__get_native_float(size_t size, H5T_direction_t direction, size_t *struct_ali
     assert(tid >= 0);
     if (NULL == (dt = (H5T_t *)H5I_object(tid)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a data type");
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     if ((ret_value = H5T_copy(dt, H5T_COPY_TRANSIENT)) == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot retrieve float type");
+
+    H5T_VLOCK_ACQUIRE_R(ret_value);
 
     /* compute offset of compound type member. */
     if (H5T__cmp_offset(comp_size, offset, native_size, (size_t)1, align, struct_align) < 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot compute compound offset");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+    if (ret_value)
+        H5T_VLOCK_RELEASE_R(ret_value);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T__get_native_float() */
 H5_GCC_DIAG_ON("duplicated-branches")
@@ -872,14 +908,23 @@ H5T__get_native_bitfield(size_t prec, H5T_direction_t direction, size_t *struct_
     if (NULL == (dt = (H5T_t *)H5I_object(tid)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a data type");
 
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     if ((ret_value = H5T_copy(dt, H5T_COPY_TRANSIENT)) == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot copy type");
+
+    H5T_VLOCK_ACQUIRE_R(ret_value);
 
     /* compute size and offset of compound type member. */
     if (H5T__cmp_offset(comp_size, offset, native_size, (size_t)1, align, struct_align) < 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot compute compound offset");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+    if (ret_value)
+        H5T_VLOCK_RELEASE_R(ret_value);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T__get_native_bitfield() */
 H5_GCC_DIAG_ON("duplicated-branches")

--- a/src/H5Toffset.c
+++ b/src/H5Toffset.c
@@ -64,11 +64,16 @@ H5Tget_offset(hid_t type_id)
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an atomic data type");
 
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     /* Get offset */
     if ((ret_value = H5T_get_offset(dt)) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL, "can't get offset for specified datatype");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tget_offset() */
 
@@ -162,6 +167,8 @@ H5Tset_offset(hid_t type_id, size_t offset)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an atomic data type");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTINIT, FAIL, "data type is read-only");
     if (H5T_STRING == dt->shared->type && offset != 0)
@@ -177,6 +184,9 @@ H5Tset_offset(hid_t type_id, size_t offset)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to set offset");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 }
 

--- a/src/H5Toffset.c
+++ b/src/H5Toffset.c
@@ -54,7 +54,7 @@ static herr_t H5T__set_offset(const H5T_t *dt, size_t offset);
 int
 H5Tget_offset(hid_t type_id)
 {
-    H5T_t *dt;
+    H5T_t *dt = NULL;
     int    ret_value;
 
     FUNC_ENTER_API(-1)
@@ -158,7 +158,7 @@ done:
 herr_t
 H5Tset_offset(hid_t type_id, size_t offset)
 {
-    H5T_t *dt;
+    H5T_t *dt = NULL;
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)

--- a/src/H5Topaque.c
+++ b/src/H5Topaque.c
@@ -44,6 +44,8 @@ H5Tset_tag(hid_t type_id, const char *tag)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTINIT, FAIL, "data type is read-only");
     while (dt->shared->parent)
@@ -60,6 +62,9 @@ H5Tset_tag(hid_t type_id, const char *tag)
     dt->shared->u.opaque.tag = H5MM_strdup(tag);
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 }
 
@@ -85,6 +90,8 @@ H5Tget_tag(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a data type");
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     while (dt->shared->parent)
         dt = dt->shared->parent; /*defer to parent*/
     if (H5T_OPAQUE != dt->shared->type)
@@ -95,5 +102,8 @@ H5Tget_tag(hid_t type_id)
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 }

--- a/src/H5Torder.c
+++ b/src/H5Torder.c
@@ -186,6 +186,8 @@ H5Tset_order(hid_t type_id, H5T_order_t order)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (order < H5T_ORDER_LE || order > H5T_ORDER_NONE || order == H5T_ORDER_MIXED)
         HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "illegal byte order");
     if (NULL != dt->vol_obj)
@@ -198,6 +200,9 @@ H5Tset_order(hid_t type_id, H5T_order_t order)
         HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL, "can't set order");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tset_order() */
 

--- a/src/H5Tpad.c
+++ b/src/H5Tpad.c
@@ -94,8 +94,12 @@ H5Tset_pad(hid_t type_id, H5T_pad_t lsb, H5T_pad_t msb)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid pad type");
     if (H5T_ENUM == dt->shared->type && dt->shared->u.enumer.nmembs > 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "operation not allowed after members are defined");
+    H5T_VLOCK_RELEASE_W(dt);
+
     while (dt->shared->parent)
         dt = dt->shared->parent; /*defer to parent*/
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (!H5T_IS_ATOMIC(dt->shared))
         HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL, "operation not defined for specified data type");
 

--- a/src/H5Tpad.c
+++ b/src/H5Tpad.c
@@ -45,6 +45,8 @@ H5Tget_pad(hid_t type_id, H5T_pad_t *lsb /*out*/, H5T_pad_t *msb /*out*/)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    H5T_VLOCK_ACQUIRE_R(dt);
+
     while (dt->shared->parent)
         dt = dt->shared->parent; /*defer to parent*/
     if (!H5T_IS_ATOMIC(dt->shared))
@@ -57,6 +59,9 @@ H5Tget_pad(hid_t type_id, H5T_pad_t *lsb /*out*/, H5T_pad_t *msb /*out*/)
         *msb = dt->shared->u.atomic.msb_pad;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 }
 
@@ -81,6 +86,8 @@ H5Tset_pad(hid_t type_id, H5T_pad_t lsb, H5T_pad_t msb)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTINIT, FAIL, "data type is read-only");
     if (lsb < H5T_PAD_ZERO || lsb >= H5T_NPAD || msb < H5T_PAD_ZERO || msb >= H5T_NPAD)
@@ -97,5 +104,8 @@ H5Tset_pad(hid_t type_id, H5T_pad_t lsb, H5T_pad_t msb)
     dt->shared->u.atomic.msb_pad = msb;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 }

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -355,6 +355,9 @@ struct H5T_t {
     H5O_loc_t      oloc;    /* Object location, if the type is a named type */
     H5G_name_t     path;    /* group hier. path if the type is a named type */
     H5VL_object_t *vol_obj; /* pointer to VOL object when working with committed datatypes */
+#if H5_HAVE_VIRTUAL_LOCK
+    H5TS_vlock_t   vlock;   /* Virtual lock for this type */
+#endif
 };
 
 /* The master list of soft conversion functions */

--- a/src/H5Tprecis.c
+++ b/src/H5Tprecis.c
@@ -52,12 +52,16 @@ H5Tget_precision(hid_t type_id)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, 0, "not a datatype");
+    H5T_VLOCK_ACQUIRE_R(dt);
 
     /* Get precision */
     if ((ret_value = H5T_get_precision(dt)) == 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, 0, "can't get precision for specified datatype");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tget_precision() */
 
@@ -129,6 +133,8 @@ H5Tset_precision(hid_t type_id, size_t prec)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTSET, FAIL, "datatype is read-only");
     if (NULL != dt->vol_obj)
@@ -147,6 +153,9 @@ H5Tset_precision(hid_t type_id, size_t prec)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, FAIL, "unable to set precision");
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 }
 

--- a/src/H5Tprecis.c
+++ b/src/H5Tprecis.c
@@ -43,7 +43,7 @@ static herr_t H5T__set_precision(const H5T_t *dt, size_t prec);
 size_t
 H5Tget_precision(hid_t type_id)
 {
-    H5T_t *dt;
+    H5T_t *dt = NULL;
     size_t ret_value;
 
     FUNC_ENTER_API(0)

--- a/src/H5Tprivate.h
+++ b/src/H5Tprivate.h
@@ -177,4 +177,22 @@ H5_DLL int         H5T_get_offset(const H5T_t *dt);
 /* Fixed-point functions */
 H5_DLL H5T_sign_t H5T_get_sign(H5T_t const *dt);
 
+#if H5_HAVE_VIRTUAL_LOCK
+H5_DLL void H5T_vlock_init(H5T_t *dt);
+H5_DLL void H5T_vlock_acquire(H5T_t *dt, H5TS_vlock_op_type_t op_type);
+H5_DLL void H5T_vlock_release(H5T_t *dt, H5TS_vlock_op_type_t op_type);
+
+#define H5T_VLOCK_INIT(dt) H5T_vlock_init(dt)
+#define H5T_VLOCK_ACQUIRE_W(dt) H5T_vlock_acquire(dt, H5TS_VLOCK_WRITER)
+#define H5T_VLOCK_ACQUIRE_R(dt) H5T_vlock_acquire(dt, H5TS_VLOCK_READER)
+#define H5T_VLOCK_RELEASE_W(dt) H5T_vlock_release(dt, H5TS_VLOCK_WRITER)
+#define H5T_VLOCK_RELEASE_R(dt) H5T_vlock_release(dt, H5TS_VLOCK_READER)
+#else /* H5_HAVE_VIRTUAL_LOCK */
+#define H5T_VLOCK_INIT(dt)
+#define H5T_VLOCK_ACQUIRE_W(dt)
+#define H5T_VLOCK_ACQUIRE_R(dt)
+#define H5T_VLOCK_RELEASE_W(dt)
+#define H5T_VLOCK_RELEASE_R(dt)
+#endif /* H5_HAVE_VIRTUAL_LOCK */
+
 #endif /* H5Tprivate_H */

--- a/src/H5Tprivate.h
+++ b/src/H5Tprivate.h
@@ -188,11 +188,11 @@ H5_DLL void H5T_vlock_release(H5T_t *dt, H5TS_vlock_op_type_t op_type);
 #define H5T_VLOCK_RELEASE_W(dt) H5T_vlock_release(dt, H5TS_VLOCK_WRITER)
 #define H5T_VLOCK_RELEASE_R(dt) H5T_vlock_release(dt, H5TS_VLOCK_READER)
 #else /* H5_HAVE_VIRTUAL_LOCK */
-#define H5T_VLOCK_INIT(dt)
-#define H5T_VLOCK_ACQUIRE_W(dt)
-#define H5T_VLOCK_ACQUIRE_R(dt)
-#define H5T_VLOCK_RELEASE_W(dt)
-#define H5T_VLOCK_RELEASE_R(dt)
+#define H5T_VLOCK_INIT(dt) (void) dt
+#define H5T_VLOCK_ACQUIRE_W(dt) (void) dt
+#define H5T_VLOCK_ACQUIRE_R(dt) (void) dt
+#define H5T_VLOCK_RELEASE_W(dt) (void) dt
+#define H5T_VLOCK_RELEASE_R(dt) (void) dt
 #endif /* H5_HAVE_VIRTUAL_LOCK */
 
 #endif /* H5Tprivate_H */

--- a/src/H5Tstrpad.c
+++ b/src/H5Tstrpad.c
@@ -97,6 +97,8 @@ H5Tset_strpad(hid_t type_id, H5T_str_t strpad)
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     if (H5T_STATE_TRANSIENT != dt->shared->state)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTINIT, FAIL, "datatype is read-only");
     if (strpad < H5T_STR_NULLTERM || strpad >= H5T_NSTR)
@@ -113,5 +115,8 @@ H5Tset_strpad(hid_t type_id, H5T_str_t strpad)
         dt->shared->u.vlen.pad = strpad;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     FUNC_LEAVE_API(ret_value)
 }

--- a/src/H5Tvlen.c
+++ b/src/H5Tvlen.c
@@ -151,16 +151,23 @@ H5Tvlen_create(hid_t base_id)
     /* Check args */
     if (NULL == (base = (H5T_t *)H5I_object_verify(base_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an valid base datatype");
+    H5T_VLOCK_ACQUIRE_R(base);
 
     /* Create up VL datatype */
     if ((dt = H5T__vlen_create(base)) == NULL)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "invalid VL location");
+    H5T_VLOCK_ACQUIRE_R(dt);
 
     /* Register the type */
     if ((ret_value = H5I_register(H5I_DATATYPE, dt, TRUE)) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register datatype");
 
 done:
+    if (base)
+        H5T_VLOCK_RELEASE_R(base);
+    if (dt)
+        H5T_VLOCK_RELEASE_R(dt);
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tvlen_create() */
 
@@ -190,6 +197,8 @@ H5T__vlen_create(const H5T_t *base)
     /* Build new type */
     if (NULL == (dt = H5T__alloc()))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, NULL, "memory allocation failed");
+    H5T_VLOCK_ACQUIRE_W(dt);
+
     dt->shared->type = H5T_VLEN;
 
     /*
@@ -214,6 +223,9 @@ H5T__vlen_create(const H5T_t *base)
     ret_value = dt;
 
 done:
+    if (dt)
+        H5T_VLOCK_RELEASE_W(dt);
+
     if (!ret_value)
         if (dt && H5T_close_real(dt) < 0)
             HDONE_ERROR(H5E_DATATYPE, H5E_CANTRELEASE, NULL, "unable to release datatype info");


### PR DESCRIPTION
Virtual locking is enabled when the library is built with multi-threading and debug mode. It enforces the assumption that access to certain resources will always be single-threaded, throwing an assertion failure if more than one thread is accessing a resource at the same time.

Structs that virtual locks are used in the handling of:
- H5CX_t
- H5S_t
- H5T_t