### PR TITLE
Enable and test multi-threading in H5CX

### DIFF
--- a/src/H5A.c
+++ b/src/H5A.c
@@ -330,9 +330,7 @@ H5A__create_by_name_api_common(hid_t loc_id, const char *obj_name, const char *a
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, H5I_INVALID_HID, "can't set object access arguments");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&aapl_id, H5P_CLS_AACC, loc_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, H5I_INVALID_HID, "can't set attribute access property list info");
@@ -658,9 +656,7 @@ H5A__open_by_name_api_common(hid_t loc_id, const char *obj_name, const char *att
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, H5I_INVALID_HID, "can't set object access arguments");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&aapl_id, H5P_CLS_AACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, H5I_INVALID_HID, "can't set attribute access property list info");
@@ -804,9 +800,7 @@ H5A__open_by_idx_api_common(hid_t loc_id, const char *obj_name, H5_index_t idx_t
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, H5I_INVALID_HID, "can't set object access arguments");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&aapl_id, H5P_CLS_AACC, loc_id, FALSE);
-    H5_API_UNLOCK
     
     if (ret_value < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, H5I_INVALID_HID, "can't set attribute access property list info");
@@ -1370,9 +1364,7 @@ H5Aget_name_by_idx(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_i
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid iteration order specified");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -1522,9 +1514,7 @@ H5Aget_info_by_name(hid_t loc_id, const char *obj_name, const char *attr_name, H
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid info pointer");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -1585,9 +1575,7 @@ H5Aget_info_by_idx(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_i
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid info pointer");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -2036,9 +2024,7 @@ H5Aiterate_by_name(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_i
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid iteration order specified");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -2104,9 +2090,7 @@ H5Adelete(hid_t loc_id, const char *name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "name parameter cannot be an empty string");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(loc_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, FAIL, "can't set collective metadata read");
@@ -2167,9 +2151,7 @@ H5Adelete_by_name(hid_t loc_id, const char *obj_name, const char *attr_name, hid
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no attribute name");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -2243,9 +2225,7 @@ H5Adelete_by_idx(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_ite
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid iteration order specified");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, FAIL, "can't set access property list info");

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -137,14 +137,10 @@ H5D__create_api_common(hid_t loc_id, const char *name, hid_t type_id, hid_t spac
     }
 
     /* Set the DCPL for the API context */
-    H5_API_LOCK
     H5CX_set_dcpl(dcpl_id);
-    H5_API_UNLOCK
 
     /* Set the LCPL for the API context */
-    H5_API_LOCK
     H5CX_set_lcpl(lcpl_id);
-    H5_API_UNLOCK
 
     /* Create the dataset */
     if (NULL == (dset = H5VL_dataset_create(*vol_obj_ptr, &loc_params, name, lcpl_id, type_id, space_id,
@@ -329,14 +325,10 @@ H5Dcreate_anon(hid_t loc_id, hid_t type_id, hid_t space_id, hid_t dcpl_id, hid_t
     }
 
     /* Set the DCPL for the API context */
-    H5_API_LOCK
     H5CX_set_dcpl(dcpl_id);
-    H5_API_UNLOCK
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&dapl_id, H5P_CLS_DACC, loc_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTSET, H5I_INVALID_HID, "can't set access property list info");
@@ -2078,9 +2070,7 @@ H5D__set_extent_api_common(hid_t dset_id, const hsize_t size[], void **token_ptr
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "size array cannot be NULL");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(dset_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTSET, FAIL, "can't set collective metadata read info");
@@ -2188,9 +2178,7 @@ H5Dflush(hid_t dset_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "dset_id parameter is not a valid dataset identifier");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(dset_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTSET, FAIL, "can't set collective metadata read info");
@@ -2234,9 +2222,7 @@ H5Drefresh(hid_t dset_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "dset_id parameter is not a valid dataset identifier");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(dset_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTSET, FAIL, "can't set collective metadata read info");
@@ -2282,9 +2268,7 @@ H5Dformat_convert(hid_t dset_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "dset_id parameter is not a valid dataset identifier");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(dset_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTSET, FAIL, "can't set collective metadata read info");

--- a/src/H5F.c
+++ b/src/H5F.c
@@ -601,9 +601,7 @@ H5F__create_api_common(const char *filename, unsigned flags, hid_t fcpl_id, hid_
     }
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&fapl_id, H5P_CLS_FACC, H5I_INVALID_HID, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, H5I_INVALID_HID, "can't set access property list info");
@@ -621,9 +619,7 @@ H5F__create_api_common(const char *filename, unsigned flags, hid_t fcpl_id, hid_
     /* Stash a copy of the "top-level" connector property, before any pass-through
      *  connectors modify or unwrap it.
      */
-    H5_API_LOCK
     ret_value = H5CX_set_vol_connector_prop(&connector_prop);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, H5I_INVALID_HID, "can't set VOL connector info in API context");
@@ -810,9 +806,7 @@ H5F__open_api_common(const char *filename, unsigned flags, hid_t fapl_id, void *
                     "SWMR read access on a file open for read-write access is not allowed");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&fapl_id, H5P_CLS_FACC, H5I_INVALID_HID, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, H5I_INVALID_HID, "can't set access property list info");
@@ -830,9 +824,7 @@ H5F__open_api_common(const char *filename, unsigned flags, hid_t fapl_id, void *
     /* Stash a copy of the "top-level" connector property, before any pass-through
      *  connectors modify or unwrap it.
      */
-    H5_API_LOCK
     ret_value = H5CX_set_vol_connector_prop(&connector_prop);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, H5I_INVALID_HID, "can't set VOL connector info in API context");
@@ -1217,9 +1209,7 @@ H5Fdelete(const char *filename, hid_t fapl_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "no file name specified");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&fapl_id, H5P_CLS_FACC, H5I_INVALID_HID, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -1237,9 +1227,7 @@ H5Fdelete(const char *filename, hid_t fapl_id)
     /* Stash a copy of the "top-level" connector property, before any pass-through
      *  connectors modify or unwrap it.
      */
-    H5_API_LOCK
     ret_value = H5CX_set_vol_connector_prop(&connector_prop);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set VOL connector info in API context");
@@ -1316,9 +1304,7 @@ H5Fmount(hid_t loc_id, const char *name, hid_t child_id, hid_t plist_id)
     }
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(loc_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set collective metadata read info");
@@ -1431,9 +1417,7 @@ H5Funmount(hid_t loc_id, const char *name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "name parameter cannot be the empty string");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(loc_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set collective metadata read info");
@@ -2393,9 +2377,7 @@ H5Fstart_swmr_write(hid_t file_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "hid_t identifier is not a file ID");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(file_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set collective metadata read info");
@@ -2553,9 +2535,7 @@ H5Fset_libver_bounds(hid_t file_id, H5F_libver_t low, H5F_libver_t high)
         HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, FAIL, "not a file ID");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(file_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set collective metadata read info");
@@ -2600,9 +2580,7 @@ H5Fformat_convert(hid_t file_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "file_id parameter is not a valid file identifier");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(file_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set collective metadata read info");

--- a/src/H5G.c
+++ b/src/H5G.c
@@ -188,9 +188,7 @@ H5G__create_api_common(hid_t loc_id, const char *name, hid_t lcpl_id, hid_t gcpl
     }
 
     /* Set the LCPL for the API context */
-    H5_API_LOCK
     H5CX_set_lcpl(lcpl_id);
-    H5_API_UNLOCK
 
     /* Create the group */
     if (NULL == (grp = H5VL_group_create(*vol_obj_ptr, &loc_params, name, lcpl_id, gcpl_id, gapl_id,
@@ -370,9 +368,7 @@ H5Gcreate_anon(hid_t loc_id, hid_t gcpl_id, hid_t gapl_id)
     }
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&gapl_id, H5P_CLS_GACC, loc_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_SYM, H5E_CANTSET, H5I_INVALID_HID, "can't set access property list info");
@@ -1040,9 +1036,7 @@ H5Gflush(hid_t group_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a group ID");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(group_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_SYM, H5E_CANTSET, FAIL, "can't set collective metadata read info");
@@ -1083,9 +1077,7 @@ H5Grefresh(hid_t group_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a group ID");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(group_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_SYM, H5E_CANTSET, FAIL, "can't set collective metadata read info");

--- a/src/H5L.c
+++ b/src/H5L.c
@@ -122,15 +122,11 @@ H5Lmove(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, const char *ds
         lcpl_id = H5P_LINK_CREATE_DEFAULT;
 
     /* Set the LCPL for the API context */
-    H5_API_LOCK
     H5CX_set_lcpl(lcpl_id);
-    H5_API_UNLOCK
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, ((src_loc_id != H5L_SAME_LOC) ? src_loc_id : dst_loc_id),
                              TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -237,15 +233,11 @@ H5Lcopy(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, const char *ds
         lcpl_id = H5P_LINK_CREATE_DEFAULT;
 
     /* Set the LCPL for the API context */
-    H5_API_LOCK
     H5CX_set_lcpl(lcpl_id);
-    H5_API_UNLOCK
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, ((src_loc_id != H5L_SAME_LOC) ? src_loc_id : dst_loc_id),
                              TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
             HGOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -351,14 +343,10 @@ H5L__create_soft_api_common(const char *link_target, hid_t link_loc_id, const ch
         lcpl_id = H5P_LINK_CREATE_DEFAULT;
 
     /* Set the LCPL for the API context */
-    H5_API_LOCK
     H5CX_set_lcpl(lcpl_id);
-    H5_API_UNLOCK
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, link_loc_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -506,14 +494,10 @@ H5L__create_hard_api_common(hid_t cur_loc_id, const char *cur_name, hid_t link_l
         lcpl_id = H5P_LINK_CREATE_DEFAULT;
 
     /* Set the LCPL for the API context */
-    H5_API_LOCK
     H5CX_set_lcpl(lcpl_id);
-    H5_API_UNLOCK
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, cur_loc_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -707,14 +691,10 @@ H5Lcreate_external(const char *file_name, const char *obj_name, hid_t link_loc_i
         lcpl_id = H5P_LINK_CREATE_DEFAULT;
 
     /* Set the LCPL for the API context */
-    H5_API_LOCK
     H5CX_set_lcpl(lcpl_id);
-    H5_API_UNLOCK
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, link_loc_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -810,14 +790,10 @@ H5Lcreate_ud(hid_t link_loc_id, const char *link_name, H5L_type_t link_type, con
         lcpl_id = H5P_LINK_CREATE_DEFAULT;
 
     /* Set the LCPL for the API context */
-    H5_API_LOCK
     H5CX_set_lcpl(lcpl_id);
-    H5_API_UNLOCK
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, link_loc_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -1989,9 +1965,7 @@ H5Lvisit_by_name2(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no callback operator specified");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set access property list info");

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -463,9 +463,7 @@ H5O__copy_api_common(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, c
     }
 
     /* Set the LCPL for the API context */
-    H5_API_LOCK
     H5CX_set_lcpl(lcpl_id);
-    H5_API_UNLOCK
 
     /* Setup and check args */
     if (H5VL_setup_loc_args(src_loc_id, &vol_obj1, &loc_params1) < 0)
@@ -884,14 +882,10 @@ H5Olink(hid_t obj_id, hid_t new_loc_id, const char *new_name, hid_t lcpl_id, hid
         lcpl_id = H5P_LINK_CREATE_DEFAULT;
 
     /* Set the LCPL for the API context */
-    H5_API_LOCK
     H5CX_set_lcpl(lcpl_id);
-    H5_API_UNLOCK
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, obj_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -977,9 +971,7 @@ H5Oincr_refcount(hid_t object_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(object_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -1033,9 +1025,7 @@ H5Odecr_refcount(hid_t object_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(object_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -1082,9 +1072,7 @@ H5Oexists_by_name(hid_t loc_id, const char *name, hid_t lapl_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "name parameter cannot be an empty string");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -1314,9 +1302,7 @@ H5Oget_info_by_idx3(hid_t loc_id, const char *group_name, H5_index_t idx_type, H
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid fields");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -1430,9 +1416,7 @@ H5Oget_native_info_by_name(hid_t loc_id, const char *name, H5O_native_info_t *oi
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid fields");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -1499,9 +1483,7 @@ H5Oget_native_info_by_idx(hid_t loc_id, const char *group_name, H5_index_t idx_t
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid fields");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -1565,9 +1547,7 @@ H5Oset_comment(hid_t obj_id, const char *comment)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
     /* Set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(obj_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set collective metadata read info");
@@ -1621,9 +1601,7 @@ H5Oset_comment_by_name(hid_t loc_id, const char *name, const char *comment, hid_
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no name");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -1736,9 +1714,7 @@ H5Oget_comment_by_name(hid_t loc_id, const char *name, char *comment /*out*/, si
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, (-1), "no name");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, (-1), "can't set access property list info");
@@ -1910,9 +1886,7 @@ H5Ovisit_by_name3(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_it
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid fields");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, FALSE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set access property list info");

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -144,9 +144,7 @@ H5T__commit_api_common(hid_t loc_id, const char *name, hid_t type_id, hid_t lcpl
     }
 
     /* Set the LCPL for the API context */
-    H5_API_LOCK
     H5CX_set_lcpl(lcpl_id);
-    H5_API_UNLOCK
 
     /* Set up object access arguments */
     if (H5VL_setup_acc_args(loc_id, H5P_CLS_TACC, TRUE, &tapl_id, vol_obj_ptr, &loc_params) < 0)
@@ -374,9 +372,7 @@ H5Tcommit_anon(hid_t loc_id, hid_t type_id, hid_t tcpl_id, hid_t tapl_id)
     }
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&tapl_id, H5P_CLS_TACC, loc_id, TRUE);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -860,9 +856,7 @@ H5Tflush(hid_t type_id)
         H5VL_datatype_specific_args_t vol_cb_args; /* Arguments to VOL callback */
 
         /* Set up collective metadata if appropriate */
-        H5_API_LOCK
         ret_value = H5CX_set_loc(type_id);
-        H5_API_UNLOCK
 
         if (ret_value < 0)
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -908,9 +902,7 @@ H5Trefresh(hid_t type_id)
         H5VL_datatype_specific_args_t vol_cb_args; /* Arguments to VOL callback */
 
         /* Set up collective metadata if appropriate */
-        H5_API_LOCK
         ret_value = H5CX_set_loc(type_id);
-        H5_API_UNLOCK
 
         if (ret_value < 0)
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, FAIL, "can't set access property list info");

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -2593,9 +2593,7 @@ H5VL_free_lib_state(void *state)
     assert(state);
 
     /* Free the API context state */
-    H5_API_LOCK
     ret_value = H5CX_free_state((H5CX_state_t *)state);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTRELEASE, FAIL, "can't free API context state");
@@ -3062,9 +3060,7 @@ H5VL_setup_args(hid_t loc_id, H5I_type_t id_type, H5VL_object_t **vol_obj)
         HGOTO_ERROR(H5E_VOL, H5E_BADTYPE, FAIL, "not the correct type of ID");
 
     /* Set up collective metadata (if appropriate) */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(loc_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "can't set collective metadata read");
@@ -3098,9 +3094,7 @@ H5VL_setup_loc_args(hid_t loc_id, H5VL_object_t **vol_obj, H5VL_loc_params_t *lo
         HGOTO_ERROR(H5E_VOL, H5E_BADTYPE, FAIL, "not the correct type of ID");
 
     /* Set up collective metadata (if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_loc(loc_id);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "can't set collective metadata read");
@@ -3137,9 +3131,7 @@ H5VL_setup_acc_args(hid_t loc_id, const H5P_libclass_t *libclass, hbool_t is_col
     assert(loc_params);
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(acspl_id, libclass, loc_id, is_collective);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -3216,9 +3208,7 @@ H5VL_setup_name_args(hid_t loc_id, const char *name, hbool_t is_collective, hid_
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "name parameter cannot be an empty string");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, is_collective);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "can't set access property list info");
@@ -3270,9 +3260,7 @@ H5VL_setup_idx_args(hid_t loc_id, const char *name, H5_index_t idx_type, H5_iter
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid iteration order specified");
 
     /* Verify access property list and set up collective metadata if appropriate */
-    H5_API_LOCK
     ret_value = H5CX_set_apl(&lapl_id, H5P_CLS_LACC, loc_id, is_collective);
-    H5_API_UNLOCK
 
     if (ret_value < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "can't set access property list info");

--- a/test/threads/CMakeLists.txt
+++ b/test/threads/CMakeLists.txt
@@ -5,6 +5,7 @@ project (HDF5_TEST_MT C)
 set (HDF5_TEST_MT_SOURCES
   testmthdf5.c 
   unit/mt_vl_test.c 
+  unit/mt_cx_test.c
   unit/mt_misc_test.c
   unit/mt_test_util.c
 )

--- a/test/threads/Makefile.am
+++ b/test/threads/Makefile.am
@@ -26,7 +26,7 @@ noinst_PROGRAMS = testmthdf5
 # Programs to be built when testing
 check_PROGRAMS = testmthdf5
 
-testmthdf5_SOURCES=testmthdf5.c testmthdf5.h unit/mt_vl_test.c unit/mt_misc_test.c unit/mt_test_util.c
+testmthdf5_SOURCES=testmthdf5.c testmthdf5.h unit/mt_vl_test.c unit/mt_cx_test.c unit/mt_misc_test.c unit/mt_test_util.c
 
 testmthdf5_LDADD = $(LIBH5TEST) $(LIBHDF5)
 

--- a/test/threads/testmthdf5.c
+++ b/test/threads/testmthdf5.c
@@ -110,6 +110,9 @@ int main(int argc, char *argv[])
         &params, sizeof(mt_test_params), no_threaded_test_flag, "MT reg/unreg of connectors while searching for connector");
 
     /* H5CX tests */
+    AddTest("mt_ctx_vol_conn_prop", mt_test_api_ctx_vol_conn_prop,
+        NULL, "MT usage of API context VOL connector property routines", &params, 0);
+
     AddTest("mt_ctx_plist_modify", mt_test_shared_plist_modify,
         NULL, "MT modification of property list shared through API context", &params, 0);
 

--- a/test/threads/testmthdf5.c
+++ b/test/threads/testmthdf5.c
@@ -110,12 +110,12 @@ int main(int argc, char *argv[])
         &params, sizeof(mt_test_params), no_threaded_test_flag, "MT reg/unreg of connectors while searching for connector");
 
     /* H5CX tests */
-    AddTest("mt_ctx_vol_conn_prop", mt_test_api_ctx_vol_conn_prop,
-        NULL, "MT usage of API context VOL connector property routines", &params, 0);
+    AddTest("mt_ctx_vol_conn_prop", mt_test_api_ctx_vol_conn_prop, NULL, NULL,
+        &params, sizeof(mt_test_params), no_threaded_test_flag, "MT usage of API context VOL connector property routines");
 
-    AddTest("mt_ctx_vol_wrap_ctx", mt_test_api_ctx_vol_wrap_ctx,
-        mt_test_api_ctx_vol_wrap_ctx_cleanup,
-        "MT usage of API context VOL wrap context routines", &params, 0);
+    AddTest("mt_ctx_vol_wrap_ctx", mt_test_api_ctx_vol_wrap_ctx, NULL,
+        mt_test_api_ctx_vol_wrap_ctx_cleanup, &params, sizeof(mt_test_params), 
+        no_threaded_test_flag, "MT usage of API context VOL wrap context routines");
 
     /* Misc MT tests */
     AddTest("mt_library_init", mt_test_library_init, NULL, NULL,

--- a/test/threads/testmthdf5.c
+++ b/test/threads/testmthdf5.c
@@ -113,6 +113,10 @@ int main(int argc, char *argv[])
     AddTest("mt_ctx_plist_modify", mt_test_shared_plist_modify,
         NULL, "MT modification of property list shared through API context", &params, 0);
 
+    AddTest("mt_ctx_vol_wrap_ctx", mt_test_api_ctx_vol_wrap_ctx,
+        mt_test_api_ctx_vol_wrap_ctx_cleanup,
+        "MT usage of API context VOL wrap context routines", &params, 0);
+
     /* Misc MT tests */
     AddTest("mt_library_init", mt_test_library_init, NULL, NULL,
         &params, sizeof(mt_test_params), threaded_test_flag, "MT usage of H5open/H5close");

--- a/test/threads/testmthdf5.c
+++ b/test/threads/testmthdf5.c
@@ -113,9 +113,6 @@ int main(int argc, char *argv[])
     AddTest("mt_ctx_vol_conn_prop", mt_test_api_ctx_vol_conn_prop,
         NULL, "MT usage of API context VOL connector property routines", &params, 0);
 
-    AddTest("mt_ctx_plist_modify", mt_test_shared_plist_modify,
-        NULL, "MT modification of property list shared through API context", &params, 0);
-
     AddTest("mt_ctx_vol_wrap_ctx", mt_test_api_ctx_vol_wrap_ctx,
         mt_test_api_ctx_vol_wrap_ctx_cleanup,
         "MT usage of API context VOL wrap context routines", &params, 0);

--- a/test/threads/testmthdf5.c
+++ b/test/threads/testmthdf5.c
@@ -109,6 +109,10 @@ int main(int argc, char *argv[])
     AddTest("mt_reg_search", mt_test_register_and_search, NULL, NULL,
         &params, sizeof(mt_test_params), no_threaded_test_flag, "MT reg/unreg of connectors while searching for connector");
 
+    /* H5CX tests */
+    AddTest("mt_ctx_plist_modify", mt_test_shared_plist_modify,
+        NULL, "MT modification of property list shared through API context", &params, 0);
+
     /* Misc MT tests */
     AddTest("mt_library_init", mt_test_library_init, NULL, NULL,
         &params, sizeof(mt_test_params), threaded_test_flag, "MT usage of H5open/H5close");

--- a/test/threads/testmthdf5.h
+++ b/test/threads/testmthdf5.h
@@ -42,6 +42,11 @@ herr_t mt_test_registration_operation_cleanup(TestParams_t *args);
 herr_t mt_test_vol_wrap_ctx(TestParams_t *args);
 herr_t mt_test_vol_wrap_ctx_cleanup(TestParams_t *args);
 
-herr_t mt_test_library_init(TestParams_t *args);
+/* H5CX Tests */
+void mt_test_shared_plist_modify(void);
+
+/* Misc Tests */
+void mt_test_library_init(const void *args);
+
 #endif /* H5_HAVE_MULTITHREAD */
 #endif /* MTSAFE_H */

--- a/test/threads/testmthdf5.h
+++ b/test/threads/testmthdf5.h
@@ -43,6 +43,7 @@ herr_t mt_test_vol_wrap_ctx(TestParams_t *args);
 herr_t mt_test_vol_wrap_ctx_cleanup(TestParams_t *args);
 
 /* H5CX Tests */
+void mt_test_api_ctx_vol_conn_prop(void);
 void mt_test_shared_plist_modify(void);
 
 void mt_test_api_ctx_vol_wrap_ctx(void);

--- a/test/threads/testmthdf5.h
+++ b/test/threads/testmthdf5.h
@@ -43,13 +43,13 @@ herr_t mt_test_vol_wrap_ctx(TestParams_t *args);
 herr_t mt_test_vol_wrap_ctx_cleanup(TestParams_t *args);
 
 /* H5CX Tests */
-void mt_test_api_ctx_vol_conn_prop(void *args);
+herr_t mt_test_api_ctx_vol_conn_prop(TestParams_t *args);
 
-void mt_test_api_ctx_vol_wrap_ctx(void *args);
-void mt_test_api_ctx_vol_wrap_ctx_cleanup(void);
+herr_t mt_test_api_ctx_vol_wrap_ctx(TestParams_t *args);
+herr_t mt_test_api_ctx_vol_wrap_ctx_cleanup(TestParams_t *args);
 
 /* Misc Tests */
-void mt_test_library_init(const void *args);
+herr_t mt_test_library_init(TestParams_t *args);
 
 #endif /* H5_HAVE_MULTITHREAD */
 #endif /* MTSAFE_H */

--- a/test/threads/testmthdf5.h
+++ b/test/threads/testmthdf5.h
@@ -44,7 +44,6 @@ herr_t mt_test_vol_wrap_ctx_cleanup(TestParams_t *args);
 
 /* H5CX Tests */
 void mt_test_api_ctx_vol_conn_prop(void);
-void mt_test_shared_plist_modify(void);
 
 void mt_test_api_ctx_vol_wrap_ctx(void);
 void mt_test_api_ctx_vol_wrap_ctx_cleanup(void);

--- a/test/threads/testmthdf5.h
+++ b/test/threads/testmthdf5.h
@@ -43,9 +43,9 @@ herr_t mt_test_vol_wrap_ctx(TestParams_t *args);
 herr_t mt_test_vol_wrap_ctx_cleanup(TestParams_t *args);
 
 /* H5CX Tests */
-void mt_test_api_ctx_vol_conn_prop(void);
+void mt_test_api_ctx_vol_conn_prop(void *args);
 
-void mt_test_api_ctx_vol_wrap_ctx(void);
+void mt_test_api_ctx_vol_wrap_ctx(void *args);
 void mt_test_api_ctx_vol_wrap_ctx_cleanup(void);
 
 /* Misc Tests */

--- a/test/threads/testmthdf5.h
+++ b/test/threads/testmthdf5.h
@@ -45,6 +45,9 @@ herr_t mt_test_vol_wrap_ctx_cleanup(TestParams_t *args);
 /* H5CX Tests */
 void mt_test_shared_plist_modify(void);
 
+void mt_test_api_ctx_vol_wrap_ctx(void);
+void mt_test_api_ctx_vol_wrap_ctx_cleanup(void);
+
 /* Misc Tests */
 void mt_test_library_init(const void *args);
 

--- a/test/threads/unit/mt_cx_test.c
+++ b/test/threads/unit/mt_cx_test.c
@@ -1,16 +1,156 @@
-#include "testhdf5.h"
 #include "H5CXprivate.h"
+#include "H5Iprivate.h"
+#include "H5VLint.c"
+
 #include "../testmthdf5.h"
+#include "h5test.h"
+
 #include "mt_test_util.h"
+#include "mt_passthru_wrapper_vol_connector.h"
+#include "H5VLpassthru_private.h"
 
 #define EFILE_PREFIX_1 "EFILE_PREFIX_1"
 #define EFILE_PREFIX_2 "new_prefix"
+
+#define MT_TEST_API_CTX_VOL_WRAP_CTX_FILENAME "mt_test_api_ctx_vol_wrap_ctx.h5"
 
 #if H5_HAVE_MULTITHREAD
 
 #include <pthread.h>
 
+void *mt_test_api_ctx_vol_wrap_ctx_helper(void *arg);
 void *mt_test_shared_plist_modify_helper(void *arg);
+
+/* Test that the API Context's handling of the VOL wrap context is safe when executing in parallel
+ */
+void mt_test_api_ctx_vol_wrap_ctx(void) {
+#ifndef H5_MT_TEST_VOL_DIR
+    printf("Skipping test because H5_MT_TEST_VOL_DIR is not defined\n");
+    return;
+#else
+    H5VL_wrap_ctx_t *wrap_ctx = NULL; /* Generic H5VL-controlled wrap context object */
+    H5VL_pass_through_wrap_ctx_t passthru_wrap_ctx_expected = {H5VL_NATIVE, NULL}; /* MT Passthru-controlled VOL wrap context */
+
+    /* MT Passthru -> Native VOL */
+    H5VL_pass_through_info_t mt_passthru_info = {H5VL_NATIVE, NULL};
+    H5VL_object_t *vol_object = NULL;
+
+    hid_t fapl_id = H5I_INVALID_HID;
+    hid_t file_id = H5I_INVALID_HID;
+    hid_t mt_passthru_id = H5I_INVALID_HID;
+
+    herr_t ret = SUCCEED;
+    int res = 0;
+
+    if (GetTestMaxNumThreads() <= 0) {
+        printf("    No threadcount specified with -maxthreads; skipping test\n");
+        return;
+    }
+
+    /* Allow MT Passthru VOL to be discovered by name */
+    ret = H5PLprepend(H5_MT_TEST_VOL_DIR);
+    CHECK(ret, FAIL, "H5PLprepend");
+
+    /* Register connector */
+    mt_passthru_id = H5VLregister_connector_by_name(MT_PASSTHRU_WRAPPER_NAME, H5P_DEFAULT);
+    CHECK(mt_passthru_id, H5I_INVALID_HID, "H5VLregister_connector");
+
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+    CHECK(fapl_id, H5I_INVALID_HID, "H5Pcreate");
+
+    /* Set up VOL connector stack */
+    ret = H5Pset_vol(fapl_id, mt_passthru_id, &mt_passthru_info);
+    CHECK(ret, FAIL, "H5Pset_vol");
+
+    /* Get a VOL object to retrieve the VOL wrap context from */
+    file_id = H5Fcreate(MT_TEST_API_CTX_VOL_WRAP_CTX_FILENAME, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
+    CHECK(file_id, H5I_INVALID_HID, "H5Fopen");
+
+    vol_object = (H5VL_object_t*) H5I_object_verify(file_id, H5I_FILE);
+    CHECK(vol_object, NULL, "H5I_object_verify");
+    CHECK(vol_object->data, NULL, "H5I_object_verify");
+
+    /* Retrieve VOL wrap context for VOL object */
+    ret = H5VL__new_vol_wrapper((const H5VL_object_t *) vol_object, &wrap_ctx);
+    CHECK(ret, FAIL, "H5VL__new_vol_wrapper");
+    VERIFY(H5_ATOMIC_LOAD(wrap_ctx->rc), 1, "H5VLget_wrap_ctx");
+    
+    res = memcmp(wrap_ctx->obj_wrap_ctx, &passthru_wrap_ctx_expected, sizeof(H5VL_pass_through_wrap_ctx_t));
+    VERIFY(res, 0, "H5VL__new_vol_wrapper");
+
+    mt_test_run_helper_in_parallel(mt_test_api_ctx_vol_wrap_ctx_helper, (void *)wrap_ctx);
+
+    /* VOL Wrap Context should still be valid */
+    VERIFY(H5_ATOMIC_LOAD(wrap_ctx->rc), 1, "H5VLget_wrap_ctx");
+    res = memcmp(wrap_ctx->obj_wrap_ctx, &passthru_wrap_ctx_expected, sizeof(H5VL_pass_through_wrap_ctx_t));
+    VERIFY(res, 0, "H5VLget_wrap_ctx");
+
+    ret = H5VL_dec_vol_wrapper(wrap_ctx);
+    CHECK(ret, FAIL, "H5VLfree_wrap_ctx");
+
+    ret = H5VLunregister_connector(mt_passthru_id);
+    CHECK(ret, FAIL, "H5VLunregister_connector");
+
+    ret = H5Pclose(fapl_id);
+    CHECK(ret, FAIL, "H5Pclose");
+
+    ret = H5Fclose(file_id);
+    CHECK(ret, FAIL, "H5Fclose");
+
+    return;
+#endif    
+}
+
+void *mt_test_api_ctx_vol_wrap_ctx_helper(void *arg) {
+    H5VL_pass_through_wrap_ctx_t wrap_ctx_expected = {H5VL_NATIVE, NULL};
+    H5VL_wrap_ctx_t *wrap_ctx = (H5VL_wrap_ctx_t *)arg;
+    H5CX_state_t *api_state = NULL;
+    herr_t ret = SUCCEED;
+    int res = 0;
+
+    /* Create context node to store VOL Wrap Context */
+    ret = H5CX_push();
+    CHECK(ret, FAIL, "H5CX_push");
+
+    ret = H5CX_set_vol_wrap_ctx(wrap_ctx);
+    CHECK(ret, FAIL, "H5CX_set_vol_wrap_ctx");
+
+    ret = H5CX_retrieve_state(&api_state);
+    CHECK(ret, FAIL, "H5CX_retrieve_state");
+    CHECK(api_state, NULL, "H5CX_retrieve_state");
+
+    ret = H5CX_restore_state(api_state);
+    CHECK(ret, FAIL, "H5CX_restore_state");
+
+    ret = H5CX_free_state(api_state);
+    CHECK(ret, FAIL, "H5CX_free_state");
+
+    /* VOL Wrap context should still be valid due to reference in main thread */
+    ret = H5CX_get_vol_wrap_ctx((void **)&wrap_ctx);
+    CHECK(ret, FAIL, "H5CX_get_vol_wrap_ctx");
+    CHECK(H5_ATOMIC_LOAD(wrap_ctx->rc), 0, "H5CX_get_vol_wrap_ctx");
+    
+    res = memcmp(wrap_ctx->obj_wrap_ctx, &wrap_ctx_expected, sizeof(H5VL_pass_through_wrap_ctx_t));
+    VERIFY(res, 0, "H5CX_get_vol_wrap_ctx");
+
+    /* Retrieve, restore, and free API Context state */
+    ret = H5CX_pop(FALSE);
+    CHECK(ret, FAIL, "H5CX_pop");
+
+    return NULL;
+}
+
+void mt_test_api_ctx_vol_wrap_ctx_cleanup(void) {
+#ifdef H5_MT_TEST_VOL_DIR
+    herr_t ret = SUCCEED;
+
+    if (GetTestMaxNumThreads() > 0) {
+        ret = H5Fdelete(MT_TEST_API_CTX_VOL_WRAP_CTX_FILENAME, H5P_DEFAULT);
+        CHECK(ret, FAIL, "H5Fdelete");
+    }
+#endif
+    return;
+}
 
 /* ! This test will fail with an unsafe read until H5P is internally multi-thread safe !
  * Test that concurrent operations on the property value under the context are memory-safe.

--- a/test/threads/unit/mt_cx_test.c
+++ b/test/threads/unit/mt_cx_test.c
@@ -20,7 +20,6 @@
 
 void *mt_test_api_ctx_vol_conn_prop_helper(void *args);
 void *mt_test_api_ctx_vol_wrap_ctx_helper(void *arg);
-void *mt_test_shared_plist_modify_helper(void *arg);
 
 /* Test that the API Context's handling of the VOL Connector property is safe when executing in parallel
 */
@@ -235,97 +234,6 @@ void mt_test_api_ctx_vol_wrap_ctx_cleanup(void) {
     }
 #endif
     return;
-}
-
-/* ! This test will fail with an unsafe read until H5P is internally multi-thread safe !
- * Test that concurrent operations on the property value under the context are memory-safe.
- * This is invalid API usage, so don't expect any specific order of operations or final value.
- */
-void
-mt_test_shared_plist_modify(void)
-{
-#ifdef H5P_MT_REWORK
-    hid_t  dapl_id     = H5I_INVALID_HID;
-    herr_t ret         = SUCCEED;
-    int    num_threads = 0;
-
-    num_threads = GetTestMaxNumThreads();
-
-    if (num_threads == 0) {
-        printf("    No threadcount specified with -maxthreads; skipping test\n");
-        return;
-    }
-
-    dapl_id = H5Pcreate(H5P_DATASET_ACCESS);
-    CHECK(dapl_id, H5I_INVALID_HID, "H5Pcreate");
-
-    /* Increase ref count of plist for each thread it will be provided to */
-    for (int i = 0; i < num_threads; i++) {
-        ret = H5Iinc_ref(dapl_id);
-        CHECK(ret, FAIL, "H5Iinc_ref");
-    }
-
-    /* Use external file prefix in order to test against
-     * a property that has dynamic memory allocation */
-    ret = H5Pset_efile_prefix(dapl_id, EFILE_PREFIX_1);
-    CHECK(ret, FAIL, "H5Pset_efile_prefix");
-
-    mt_test_run_helper_in_parallel(mt_test_shared_plist_modify_helper, (void *)&dapl_id);
-
-#else  /* H5P_MT_REWORK */
-    printf("    H5P is not internally multi-thread safe. Skipping test.\n");
-#endif /* H5P_MT_REWORK */
-    return;
-}
-
-void *
-mt_test_shared_plist_modify_helper(void *arg)
-{
-    hid_t       dapl_id            = H5I_INVALID_HID;
-    herr_t      ret                = SUCCEED;
-    const char *efile_prefix       = NULL;
-    char       *saved_efile_prefix = NULL;
-
-    assert(arg);
-
-    dapl_id = *(hid_t *)arg;
-
-    /* Create context node that will persist through operations */
-    ret = H5VL_start_lib_state();
-    CHECK(ret, FAIL, "H5VL_start_lib_state");
-
-    /* Set the DAPL on the persistent context node */
-    ret = H5CX_set_apl(&dapl_id, H5P_CLS_DACC, H5I_INVALID_HID, FALSE);
-    CHECK(ret, FAIL, "H5CX_set_apl");
-
-    ret = H5CX_get_ext_file_prefix(&efile_prefix);
-    CHECK(ret, FAIL, "H5CX_get_ext_file_prefix");
-
-    /* Save for later comparison. */
-    saved_efile_prefix = strdup(efile_prefix);
-
-    if (strcmp(efile_prefix, EFILE_PREFIX_1) != 0 && strcmp(efile_prefix, EFILE_PREFIX_2) != 0) {
-        TestErrPrintf("    Unexpected value for efile prefix\n");
-    }
-
-    ret = H5Pset_efile_prefix(dapl_id, EFILE_PREFIX_2);
-    CHECK(ret, FAIL, "H5Pset_efile_prefix");
-
-    /* Retrieve value.
-     * With multi-threaded H5P, this access should be thread-safe and match the previous value. */
-    ret = H5CX_get_ext_file_prefix(&efile_prefix);
-    CHECK(ret, FAIL, "H5CX_get_ext_file_prefix");
-
-    VERIFY(strcmp(efile_prefix, saved_efile_prefix), 0, "H5CX_get_ext_file_prefix");
-
-    /* Clean up */
-
-    ret = H5VL_finish_lib_state();
-    CHECK(ret, FAIL, "H5VL_finish_lib_state");
-
-    free(saved_efile_prefix);
-
-    return NULL;
 }
 
 #endif /* H5_HAVE_MULTITHREAD */

--- a/test/threads/unit/mt_cx_test.c
+++ b/test/threads/unit/mt_cx_test.c
@@ -1,0 +1,106 @@
+#include "testhdf5.h"
+#include "H5CXprivate.h"
+#include "../testmthdf5.h"
+#include "mt_test_util.h"
+
+#define EFILE_PREFIX_1 "EFILE_PREFIX_1"
+#define EFILE_PREFIX_2 "new_prefix"
+
+#if H5_HAVE_MULTITHREAD
+
+#include <pthread.h>
+
+void *mt_test_shared_plist_modify_helper(void *arg);
+
+/* ! This test will fail with an unsafe read until H5P is internally multi-thread safe !
+ * Test that concurrent operations on the property value under the context are memory-safe.
+ * This is invalid API usage, so don't expect any specific order of operations or final value.
+ */
+void
+mt_test_shared_plist_modify(void)
+{
+#ifdef H5P_MT_REWORK
+    hid_t  dapl_id     = H5I_INVALID_HID;
+    herr_t ret         = SUCCEED;
+    int    num_threads = 0;
+
+    num_threads = GetTestMaxNumThreads();
+
+    if (num_threads == 0) {
+        printf("    No threadcount specified with -maxthreads; skipping test\n");
+        return;
+    }
+
+    dapl_id = H5Pcreate(H5P_DATASET_ACCESS);
+    CHECK(dapl_id, H5I_INVALID_HID, "H5Pcreate");
+
+    /* Increase ref count of plist for each thread it will be provided to */
+    for (int i = 0; i < num_threads; i++) {
+        ret = H5Iinc_ref(dapl_id);
+        CHECK(ret, FAIL, "H5Iinc_ref");
+    }
+
+    /* Use external file prefix in order to test against
+     * a property that has dynamic memory allocation */
+    ret = H5Pset_efile_prefix(dapl_id, EFILE_PREFIX_1);
+    CHECK(ret, FAIL, "H5Pset_efile_prefix");
+
+    mt_test_run_helper_in_parallel(mt_test_shared_plist_modify_helper, (void *)&dapl_id);
+
+#else  /* H5P_MT_REWORK */
+    printf("    H5P is not internally multi-thread safe. Skipping test.\n");
+#endif /* H5P_MT_REWORK */
+    return;
+}
+
+void *
+mt_test_shared_plist_modify_helper(void *arg)
+{
+    hid_t       dapl_id            = H5I_INVALID_HID;
+    herr_t      ret                = SUCCEED;
+    const char *efile_prefix       = NULL;
+    char       *saved_efile_prefix = NULL;
+
+    assert(arg);
+
+    dapl_id = *(hid_t *)arg;
+
+    /* Create context node that will persist through operations */
+    ret = H5VL_start_lib_state();
+    CHECK(ret, FAIL, "H5VL_start_lib_state");
+
+    /* Set the DAPL on the persistent context node */
+    ret = H5CX_set_apl(&dapl_id, H5P_CLS_DACC, H5I_INVALID_HID, FALSE);
+    CHECK(ret, FAIL, "H5CX_set_apl");
+
+    ret = H5CX_get_ext_file_prefix(&efile_prefix);
+    CHECK(ret, FAIL, "H5CX_get_ext_file_prefix");
+
+    /* Save for later comparison. */
+    saved_efile_prefix = strdup(efile_prefix);
+
+    if (strcmp(efile_prefix, EFILE_PREFIX_1) != 0 && strcmp(efile_prefix, EFILE_PREFIX_2) != 0) {
+        TestErrPrintf("    Unexpected value for efile prefix\n");
+    }
+
+    ret = H5Pset_efile_prefix(dapl_id, EFILE_PREFIX_2);
+    CHECK(ret, FAIL, "H5Pset_efile_prefix");
+
+    /* Retrieve value.
+     * With multi-threaded H5P, this access should be thread-safe and match the previous value. */
+    ret = H5CX_get_ext_file_prefix(&efile_prefix);
+    CHECK(ret, FAIL, "H5CX_get_ext_file_prefix");
+
+    VERIFY(strcmp(efile_prefix, saved_efile_prefix), 0, "H5CX_get_ext_file_prefix");
+
+    /* Clean up */
+
+    ret = H5VL_finish_lib_state();
+    CHECK(ret, FAIL, "H5VL_finish_lib_state");
+
+    free(saved_efile_prefix);
+
+    return NULL;
+}
+
+#endif /* H5_HAVE_MULTITHREAD */

--- a/test/threads/unit/mt_cx_test.c
+++ b/test/threads/unit/mt_cx_test.c
@@ -23,7 +23,7 @@ void *mt_test_api_ctx_vol_wrap_ctx_helper(void *arg);
 
 /* Test that the API Context's handling of the VOL Connector property is safe when executing in parallel
 */
-void mt_test_api_ctx_vol_conn_prop(void) {
+void mt_test_api_ctx_vol_conn_prop(void H5_ATTR_UNUSED *args) {
 #ifndef H5_MT_TEST_VOL_DIR
     printf("Skipping test because H5_MT_TEST_VOL_DIR is not defined\n");
     return;
@@ -107,7 +107,7 @@ void *mt_test_api_ctx_vol_conn_prop_helper(void *args) {
 
 /* Test that the API Context's handling of the VOL wrap context is safe when executing in parallel
  */
-void mt_test_api_ctx_vol_wrap_ctx(void) {
+void mt_test_api_ctx_vol_wrap_ctx(void H5_ATTR_UNUSED *args) {
 #ifndef H5_MT_TEST_VOL_DIR
     printf("Skipping test because H5_MT_TEST_VOL_DIR is not defined\n");
     return;

--- a/test/threads/unit/mt_cx_test.c
+++ b/test/threads/unit/mt_cx_test.c
@@ -46,10 +46,10 @@ void *mt_test_api_ctx_vol_wrap_ctx_helper(void *arg);
  * Specifically, verify that the API Context State routines properly deep
  * copy the VOL Connector property and leave the original value unmodified.
 */
-void mt_test_api_ctx_vol_conn_prop(void H5_ATTR_UNUSED *args) {
+herr_t mt_test_api_ctx_vol_conn_prop(TestParams_t H5_ATTR_UNUSED *args) {
 #ifndef H5_MT_TEST_VOL_DIR
     printf("Skipping test because H5_MT_TEST_VOL_DIR is not defined\n");
-    return;
+    return SUCCEED;
 #else
     H5VL_pass_through_info_t mt_passthru_info_expected = {H5VL_NATIVE, NULL};
     H5VL_connector_prop_t vol_connector_prop = {0, &mt_passthru_info_expected};
@@ -59,7 +59,7 @@ void mt_test_api_ctx_vol_conn_prop(void H5_ATTR_UNUSED *args) {
 
     if (GetTestMaxNumThreads() <= 0) {
         printf("    No threadcount specified with -maxthreads; skipping test\n");
-        return;
+        return SUCCEED;
     }
 
     /* Use the MT Native VOL Wrapper in order to 
@@ -88,7 +88,7 @@ void mt_test_api_ctx_vol_conn_prop(void H5_ATTR_UNUSED *args) {
     CHECK(ret, FAIL, "H5VLunregister_connector");
 #endif
 
-    return;
+    return SUCCEED;
 }
 
 void *mt_test_api_ctx_vol_conn_prop_helper(void *args) {
@@ -133,10 +133,10 @@ void *mt_test_api_ctx_vol_conn_prop_helper(void *args) {
  * Specifically, verify that the API Context State routines properly deep
  * copy the VOL wrap context and leave the original value unmodified.
  */
-void mt_test_api_ctx_vol_wrap_ctx(void H5_ATTR_UNUSED *args) {
+herr_t mt_test_api_ctx_vol_wrap_ctx(TestParams_t H5_ATTR_UNUSED *args) {
 #ifndef H5_MT_TEST_VOL_DIR
     printf("Skipping test because H5_MT_TEST_VOL_DIR is not defined\n");
-    return;
+    return SUCCEED;
 #else
     H5VL_wrap_ctx_t *wrap_ctx = NULL; /* Generic H5VL-controlled wrap context object */
     H5VL_pass_through_wrap_ctx_t passthru_wrap_ctx_expected = {H5VL_NATIVE, NULL}; /* MT Passthru-controlled VOL wrap context */
@@ -154,7 +154,7 @@ void mt_test_api_ctx_vol_wrap_ctx(void H5_ATTR_UNUSED *args) {
 
     if (GetTestMaxNumThreads() <= 0) {
         printf("    No threadcount specified with -maxthreads; skipping test\n");
-        return;
+        return SUCCEED;
     }
 
     /* Allow MT Passthru VOL to be discovered by name */
@@ -207,7 +207,7 @@ void mt_test_api_ctx_vol_wrap_ctx(void H5_ATTR_UNUSED *args) {
     ret = H5Fclose(file_id);
     CHECK(ret, FAIL, "H5Fclose");
 
-    return;
+    return SUCCEED;
 #endif    
 }
 
@@ -250,7 +250,7 @@ void *mt_test_api_ctx_vol_wrap_ctx_helper(void *arg) {
     return NULL;
 }
 
-void mt_test_api_ctx_vol_wrap_ctx_cleanup(void) {
+herr_t mt_test_api_ctx_vol_wrap_ctx_cleanup(TestParams_t  H5_ATTR_UNUSED *args) {
 #ifdef H5_MT_TEST_VOL_DIR
     herr_t ret = SUCCEED;
 
@@ -259,7 +259,7 @@ void mt_test_api_ctx_vol_wrap_ctx_cleanup(void) {
         CHECK(ret, FAIL, "H5Fdelete");
     }
 #endif
-    return;
+    return SUCCEED;
 }
 
 #endif /* H5_HAVE_MULTITHREAD */

--- a/test/threads/unit/mt_cx_test.c
+++ b/test/threads/unit/mt_cx_test.c
@@ -1,3 +1,23 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/* Purpose: Tests for API Context behavior in multi-threaded environments.
+ *          While API Context functionality is implicitly validated through
+ *          other multi-threaded tests, this file contains
+ *          unit tests targeting for specific uncommon
+ *          usage patterns.
+ */
+
+
 #include "H5CXprivate.h"
 #include "H5Iprivate.h"
 #include "H5VLint.c"
@@ -22,6 +42,9 @@ void *mt_test_api_ctx_vol_conn_prop_helper(void *args);
 void *mt_test_api_ctx_vol_wrap_ctx_helper(void *arg);
 
 /* Test that the API Context's handling of the VOL Connector property is safe when executing in parallel
+ *
+ * Specifically, verify that the API Context State routines properly deep
+ * copy the VOL Connector property and leave the original value unmodified.
 */
 void mt_test_api_ctx_vol_conn_prop(void H5_ATTR_UNUSED *args) {
 #ifndef H5_MT_TEST_VOL_DIR
@@ -106,6 +129,9 @@ void *mt_test_api_ctx_vol_conn_prop_helper(void *args) {
 }
 
 /* Test that the API Context's handling of the VOL wrap context is safe when executing in parallel
+ *
+ * Specifically, verify that the API Context State routines properly deep
+ * copy the VOL wrap context and leave the original value unmodified.
  */
 void mt_test_api_ctx_vol_wrap_ctx(void H5_ATTR_UNUSED *args) {
 #ifndef H5_MT_TEST_VOL_DIR

--- a/test/threads/unit/mt_cx_test.c
+++ b/test/threads/unit/mt_cx_test.c
@@ -18,8 +18,93 @@
 
 #include <pthread.h>
 
+void *mt_test_api_ctx_vol_conn_prop_helper(void *args);
 void *mt_test_api_ctx_vol_wrap_ctx_helper(void *arg);
 void *mt_test_shared_plist_modify_helper(void *arg);
+
+/* Test that the API Context's handling of the VOL Connector property is safe when executing in parallel
+*/
+void mt_test_api_ctx_vol_conn_prop(void) {
+#ifndef H5_MT_TEST_VOL_DIR
+    printf("Skipping test because H5_MT_TEST_VOL_DIR is not defined\n");
+    return;
+#else
+    H5VL_pass_through_info_t mt_passthru_info_expected = {H5VL_NATIVE, NULL};
+    H5VL_connector_prop_t vol_connector_prop = {0, &mt_passthru_info_expected};
+    hid_t mt_passthru_id = H5I_INVALID_HID;
+    herr_t ret = SUCCEED;
+    int res = 0;
+
+    if (GetTestMaxNumThreads() <= 0) {
+        printf("    No threadcount specified with -maxthreads; skipping test\n");
+        return;
+    }
+
+    /* Use the MT Native VOL Wrapper in order to 
+     * test the case where multi-threading proceeds into a connector
+     */
+
+    /* Allow MT Passthru VOL to be discovered by name */
+    ret = H5PLprepend(H5_MT_TEST_VOL_DIR);
+    CHECK(ret, FAIL, "H5PLprepend");
+
+    /* Register connector */
+    mt_passthru_id = H5VLregister_connector_by_name(MT_PASSTHRU_WRAPPER_NAME, H5P_DEFAULT);
+    CHECK(mt_passthru_id, H5I_INVALID_HID, "H5VLregister_connector");
+
+    vol_connector_prop.connector_id = mt_passthru_id;
+
+    mt_test_run_helper_in_parallel(mt_test_api_ctx_vol_conn_prop_helper, (void *)&vol_connector_prop);
+
+    /* Verify that the original VOL connector property buffer still exists with correct values */
+    VERIFY(vol_connector_prop.connector_id, mt_passthru_id, "H5CX");
+    res = memcmp(vol_connector_prop.connector_info, &mt_passthru_info_expected, sizeof(H5VL_pass_through_info_t));
+    VERIFY(res, 0, "H5CX");
+
+    /* Unregister connector */
+    ret = H5VLunregister_connector(mt_passthru_id);
+    CHECK(ret, FAIL, "H5VLunregister_connector");
+#endif
+
+    return;
+}
+
+void *mt_test_api_ctx_vol_conn_prop_helper(void *args) {
+    H5VL_connector_prop_t *vol_connector_prop_in = (H5VL_connector_prop_t *)args;
+    H5VL_connector_prop_t vol_connector_prop_out = {0, NULL};
+    H5VL_pass_through_info_t mt_passthru_info_expected = {H5VL_NATIVE, NULL};
+    H5VL_connector_prop_t vol_connector_prop_expected = {vol_connector_prop_in->connector_id,
+                                                         (void*) &mt_passthru_info_expected};
+    H5CX_state_t *api_state = NULL;
+    herr_t ret = SUCCEED;
+
+    /* Create context node to store VOL Connector Property */
+    ret = H5CX_push();
+    CHECK(ret, FAIL, "H5CX_push");
+
+    ret = H5CX_set_vol_connector_prop(vol_connector_prop_in);
+    CHECK(ret, FAIL, "H5CX_set_vol_connector_prop");
+
+    ret = H5CX_retrieve_state(&api_state);
+    CHECK(ret, FAIL, "H5CX_retrieve_state");
+    CHECK(api_state, NULL, "H5CX_retrieve_state");
+
+    ret = H5CX_free_state(api_state);
+    CHECK(ret, FAIL, "H5CX_free_state");
+
+    /* Check that the VOL Connector Property is still valid */
+    ret = H5CX_get_vol_connector_prop(&vol_connector_prop_out);
+    CHECK(ret, FAIL, "H5CX_get_vol_connector_prop");
+    VERIFY(vol_connector_prop_out.connector_id, vol_connector_prop_expected.connector_id, "H5CX_get_vol_connector_prop");
+
+    ret = memcmp(vol_connector_prop_out.connector_info, vol_connector_prop_expected.connector_info, sizeof(H5VL_pass_through_info_t));
+    VERIFY(ret, 0, "memcmp");
+
+    ret = H5CX_pop(false);
+    CHECK(ret, FAIL, "H5CX_pop");
+
+    return NULL;
+}
 
 /* Test that the API Context's handling of the VOL wrap context is safe when executing in parallel
  */

--- a/test/threads/unit/mt_test_util.c
+++ b/test/threads/unit/mt_test_util.c
@@ -18,6 +18,7 @@ void mt_test_run_helper_in_parallel(mt_test_cb mt_test_func, void *args) {
   threads = (pthread_t *)calloc((long unsigned int) max_num_threads, sizeof(pthread_t));
   assert(threads != NULL);
 
+  /* Run the test in a varying number of threads, up to max_num_threads */
   for (int num_threads = 1; num_threads <= max_num_threads; num_threads++) {
     memset(threads, 0, sizeof(pthread_t) * (long unsigned int) num_threads);
 


### PR DESCRIPTION
Since the API context is threadlocal, enabling multi-threading doesn't require any changes to the API Context's behavior.

- Remove API lock acquisition around H5CX calls from MT modules

- Add multithread tests for the API Context in `testmthdf5`