### PR TITLE
Fix various issues in multithread CI

### DIFF
--- a/.github/workflows/multithread_test.yml
+++ b/.github/workflows/multithread_test.yml
@@ -119,7 +119,7 @@ jobs:
                   API_TEST_COMMAND="./test/API/h5_api_test"
                 else
                   cd build
-                  API_TEST_COMMAND="ctest -N -R 'h5_api_test'"
+                  API_TEST_COMMAND="./build/bin/h5_api_test"
                 fi
 
                 echo "$CONNECTOR_STACKS" | jq -r '.[]' | while IFS= read -r connector_stack; do
@@ -156,7 +156,7 @@ jobs:
                 if [[ "${{ matrix.build_system }}" == "autotools" ]]; then
                   MT_VL_TEST_COMMAND="./threads/testmthdf5"
                 else
-                  MT_VL_TEST_COMMAND="ctest -R 'testmthdf5'"
+                  MT_VL_TEST_COMMAND="./build/bin/testmthdf5'"
                 fi
 
                 echo "$CONNECTOR_STACKS" | jq -r '.[]' | while IFS= read -r connector_stack; do

--- a/.github/workflows/multithread_test.yml
+++ b/.github/workflows/multithread_test.yml
@@ -21,20 +21,20 @@ jobs:
                 build_mode: ["production", "debug"]
                 include:
                     # Non-multi thread library builds should only run non-threaded
-                    - multi_thread: "threadsafe"
+                    - thread_build: "threadsafe"
                       test_thread_counts: 0
                       connector_stacks: 
                         - ""
                         - "pass_through under_vol=0\\;under_info={}"
 
-                    - multi_thread: "singlethread"
+                    - thread_build: "singlethread"
                       test_thread_counts: 0
                       connector_stacks: 
                         - ""
                         - "pass_through under_vol=0\\;under_info={}"
 
                     # Only multi-threaded builds should run with -maxthreads (>0) or the MT wrapper connectors
-                    - multi_thread: "--enable-multithread --disable-hl"
+                    - thread_build: "multithread"
                       test_thread_counts: 0 1 16
                       connector_stacks: 
                         - ""                                                                        # Native
@@ -58,7 +58,7 @@ jobs:
               if: matrix.build_system == 'autotools'
               run: |
                   sudo apt install automake autoconf libtool libtool-bin
-                  sudo apt install libaec0 libaec-dev valgrind
+                  sudo apt install libaec0 libaec-dev
 
             - name: Configure HDF5 (Autotools)
               if: matrix.build_system == 'autotools'
@@ -116,10 +116,10 @@ jobs:
                 CONNECTOR_STACKS='${{ toJson(matrix.connector_stacks) }}'
 
                 if [[ "${{ matrix.build_system }}" == "autotools" ]]; then
-                  API_TEST_COMMAND="valgrind ./test/API/h5_api_test"
+                  API_TEST_COMMAND="./test/API/h5_api_test"
                 else
                   cd build
-                  API_TEST_COMMAND="valgrind ctest -N -R 'h5_api_test'"
+                  API_TEST_COMMAND="ctest -N -R 'h5_api_test'"
                 fi
 
                 echo "$CONNECTOR_STACKS" | jq -r '.[]' | while IFS= read -r connector_stack; do
@@ -154,9 +154,9 @@ jobs:
                 CONNECTOR_STACKS='${{ toJson(matrix.connector_stacks) }}'
 
                 if [[ "${{ matrix.build_system }}" == "autotools" ]]; then
-                  MT_VL_TEST_COMMAND="valgrind ./threads/testmthdf5"
+                  MT_VL_TEST_COMMAND="./threads/testmthdf5"
                 else
-                  MT_VL_TEST_COMMAND="valgrind ctest -R 'testmthdf5'"
+                  MT_VL_TEST_COMMAND="ctest -R 'testmthdf5'"
                 fi
 
                 echo "$CONNECTOR_STACKS" | jq -r '.[]' | while IFS= read -r connector_stack; do

--- a/.github/workflows/multithread_test.yml
+++ b/.github/workflows/multithread_test.yml
@@ -156,7 +156,7 @@ jobs:
                 if [[ "${{ matrix.build_system }}" == "autotools" ]]; then
                   MT_VL_TEST_COMMAND="./threads/testmthdf5"
                 else
-                  MT_VL_TEST_COMMAND="./build/bin/testmthdf5'"
+                  MT_VL_TEST_COMMAND="./build/bin/testmthdf5"
                 fi
 
                 echo "$CONNECTOR_STACKS" | jq -r '.[]' | while IFS= read -r connector_stack; do

--- a/configure.ac
+++ b/configure.ac
@@ -2063,7 +2063,9 @@ esac
 
 if test "X$MULTITHREAD" = "Xyes"; then
     AC_DEFINE([HAVE_MULTITHREAD], [1], [Define if we have multithread support])
-    AC_DEFINE_UNQUOTED([MT_TEST_VOL_DIR], ["$srcdir/test/.libs/"], [The directory containing the multi-threaded wrapper VOL connectors])
+
+    absolute_srcdir=`cd $srcdir && pwd`
+    AC_DEFINE_UNQUOTED([MT_TEST_VOL_DIR], ["$absolute_srcdir/test/.libs/"], [The directory containing the multi-threaded wrapper VOL connectors])
 
     ## ----------------------------------------------------------------------
     ## Is the Pthreads library present?  It has a header file `pthread.h' and


### PR DESCRIPTION
- Correct include matrix

The `include` field is currently checking for the wrong variable in the matrix, resulting in MT test scenarios being run when the library isn't built for multithreading. This correct the name of the field being checked, and also removes valgrind usage from the workflow.

- Correct invocation of API tests and testmthdf5 with CMake to properly pass in -maxthreads argument

CMake doesn't allow arguments to be passed to test executables through ctest, so do it directly

- Set MT_TEST_VOL_DIR to absolute path with autotools

This lines up with CMake, and fixes an issue with testmthdf5 tests failing in the autotools workflow