### PR TITLE
Add 60-minute timeout to multithread test workflow

### DIFF
--- a/.github/workflows/multithread_test.yml
+++ b/.github/workflows/multithread_test.yml
@@ -50,6 +50,9 @@ jobs:
 
             fail-fast: false
 
+        # Restrict runtime to 60 minutes in case tests hang
+        timeout-minutes: 60
+
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4


### PR DESCRIPTION
The multithread_test.yml workflow is hanging in mt_id_test in Autotools and running for a very long time, causing the CI to bog down.