### PR TITLE
Fix old H5P_object_verify call in parallel build

### DIFF
--- a/src/H5FDmpio.c
+++ b/src/H5FDmpio.c
@@ -3829,7 +3829,7 @@ H5FD__mpio_delete(const char *filename, hid_t fapl_id)
 
     assert(filename);
 
-    if (NULL == (plist = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
+    if (NULL == (plist = H5P_object_verify(fapl_id, H5P_FILE_ACCESS, true)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");
     assert(H5FD_MPIO == H5P_peek_driver(plist));
 


### PR DESCRIPTION
This was missed in #25 and is breaking parallel (mpio) builds