### PR TITLE
Merge testing framework updates from HDF5 develop

### DIFF
--- a/test/btree2.c
+++ b/test/btree2.c
@@ -9928,11 +9928,11 @@ main(void)
     ExpressMode = h5_get_testexpress();
 
     /* For the Direct I/O driver, skip intensive tests due to poor performance */
-    if (!HDstrcmp(envval, "direct"))
-        ExpressMode = 2;
+    if (ExpressMode < H5_TEST_EXPRESS_QUICK && !strcmp(envval, "direct"))
+        ExpressMode = H5_TEST_EXPRESS_QUICK;
 
-    if (ExpressMode > 1)
-        printf("***Express test mode on.  Some tests may be skipped\n");
+    if (ExpressMode > H5_TEST_EXPRESS_EXHAUSTIVE)
+        printf("***Express test mode %d.  Some tests may be skipped\n", ExpressMode);
 
     /* Initialize v2 B-tree creation parameters */
     init_cparam(&cparam, &cparam2);
@@ -9968,7 +9968,7 @@ main(void)
         nerrors += test_insert_level2_2internal_split(fapl, &cparam, &tparam);
         nerrors += test_insert_level2_3internal_redistrib(fapl, &cparam, &tparam);
         nerrors += test_insert_level2_3internal_split(fapl, &cparam, &tparam);
-        if (ExpressMode > 1)
+        if (ExpressMode > H5_TEST_EXPRESS_FULL)
             printf("***Express test mode on.  test_insert_lots skipped\n");
         else
             nerrors += test_insert_lots(fapl, &cparam, &tparam);
@@ -9982,7 +9982,7 @@ main(void)
         nerrors += test_update_level1_3leaf_redistrib(fapl, &cparam2, &tparam);
         nerrors += test_update_level1_middle_split(fapl, &cparam2, &tparam);
         nerrors += test_update_make_level2(fapl, &cparam2, &tparam);
-        if (ExpressMode > 1)
+        if (ExpressMode > H5_TEST_EXPRESS_FULL)
             printf("***Express test mode on.  test_update_lots skipped\n");
         else
             nerrors += test_update_lots(fapl, &cparam2, &tparam);
@@ -10009,7 +10009,7 @@ main(void)
         nerrors += test_remove_level2_2internal_merge_right(fapl, &cparam, &tparam);
         nerrors += test_remove_level2_3internal_merge(fapl, &cparam, &tparam);
         nerrors += test_remove_level2_collapse_right(fapl, &cparam, &tparam);
-        if (ExpressMode > 1)
+        if (ExpressMode > H5_TEST_EXPRESS_FULL)
             printf("***Express test mode on.  test_remove_lots skipped\n");
         else
             nerrors += test_remove_lots(envval, fapl, &cparam);

--- a/test/cache.c
+++ b/test/cache.c
@@ -259,22 +259,22 @@ smoke_check_1(int express_test, unsigned paged)
     else
         TESTING("smoke check #1 -- all clean, ins, dest, ren, 4/2 MB cache");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -454,22 +454,22 @@ smoke_check_2(int express_test, unsigned paged)
     else
         TESTING("smoke check #2 -- ~1/2 dirty, ins, dest, ren, 4/2 MB cache");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -648,22 +648,22 @@ smoke_check_3(int express_test, unsigned paged)
     else
         TESTING("smoke check #3 -- all clean, ins, dest, ren, 2/1 KB cache");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -843,22 +843,22 @@ smoke_check_4(int express_test, unsigned paged)
     else
         TESTING("smoke check #4 -- ~1/2 dirty, ins, dest, ren, 2/1 KB cache");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -1078,22 +1078,22 @@ smoke_check_5(int express_test, unsigned paged)
     else
         TESTING("smoke check #5 -- all clean, ins, prot, unprot, AR cache 1");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -1302,7 +1302,7 @@ smoke_check_6(int express_test, unsigned paged)
     else
         TESTING("smoke check #6 -- ~1/2 dirty, ins, prot, unprot, AR cache 1");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
@@ -1311,15 +1311,15 @@ smoke_check_6(int express_test, unsigned paged)
     pass = TRUE;
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -1527,22 +1527,22 @@ smoke_check_7(int express_test, unsigned paged)
     else
         TESTING("smoke check #7 -- all clean, ins, prot, unprot, AR cache 2");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -1752,22 +1752,22 @@ smoke_check_8(int express_test, unsigned paged)
     else
         TESTING("smoke check #8 -- ~1/2 dirty, ins, prot, unprot, AR cache 2");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -1942,22 +1942,22 @@ smoke_check_9(int express_test, unsigned paged)
     else
         TESTING("smoke check #9 -- all clean, ins, dest, ren, 4/2 MB, corked");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -2247,22 +2247,22 @@ smoke_check_10(int express_test, unsigned paged)
     else
         TESTING("smoke check #10 -- ~1/2 dirty, ins, dest, ren, 4/2 MB, corked");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -2552,15 +2552,15 @@ write_permitted_check(int
 #if H5C_MAINTAIN_CLEAN_AND_DIRTY_LRU_LISTS
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -33880,7 +33880,7 @@ main(void)
 
             fprintf(stdout, "\n\nRe-running tests with paged aggregation:\n");
 
-            if (express_test > 0)
+            if (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)
                 fprintf(stdout, "    Skipping smoke checks.\n");
 
             fprintf(stdout, "\n");

--- a/test/cache_api.c
+++ b/test/cache_api.c
@@ -949,7 +949,7 @@ mdc_api_call_smoke_check(int express_test, unsigned paged, hid_t fcpl_id)
 
     pass = TRUE;
 
-    if (express_test > 0) {
+    if (express_test > H5_TEST_EXPRESS_EXHAUSTIVE) {
 
         SKIPPED();
 

--- a/test/fheap.c
+++ b/test/fheap.c
@@ -15986,9 +15986,9 @@ main(void)
      *      in the future for parallel build.
      */
     ExpressMode = h5_get_testexpress();
-    if (ExpressMode > 0)
+    if (ExpressMode > H5_TEST_EXPRESS_EXHAUSTIVE)
         printf("***Express test mode %d.  Some tests may be skipped\n", ExpressMode);
-    else if (ExpressMode == 0) {
+    else if (ExpressMode == H5_TEST_EXPRESS_EXHAUSTIVE) {
 #ifdef H5_HAVE_PARALLEL
         num_pb_fs = NUM_PB_FS - 2;
 #else
@@ -16204,7 +16204,7 @@ main(void)
                     /* If this test fails, uncomment the tests above, which build up to this
                      * level of complexity gradually. -QAK
                      */
-                    if (ExpressMode > 1)
+                    if (ExpressMode > H5_TEST_EXPRESS_FULL)
                         printf(
                             "***Express test mode on.  test_man_start_5th_recursive_indirect is skipped\n");
                     else
@@ -16252,7 +16252,7 @@ main(void)
                                 nerrors += test_man_remove_first_row(fapl, &small_cparam, &tparam);
                                 nerrors += test_man_remove_first_two_rows(fapl, &small_cparam, &tparam);
                                 nerrors += test_man_remove_first_four_rows(fapl, &small_cparam, &tparam);
-                                if (ExpressMode > 1)
+                                if (ExpressMode > H5_TEST_EXPRESS_FULL)
                                     printf("***Express test mode on.  Some tests skipped\n");
                                 else {
                                     nerrors += test_man_remove_all_root_direct(fapl, &small_cparam, &tparam);
@@ -16302,7 +16302,7 @@ main(void)
                                 nerrors +=
                                     test_man_fill_1st_row_3rd_direct_fill_2nd_direct_less_one_wrap_start_block_add_skipped(
                                         fapl, &small_cparam, &tparam);
-                                if (ExpressMode > 1)
+                                if (ExpressMode > H5_TEST_EXPRESS_FULL)
                                     printf("***Express test mode on.  Some tests skipped\n");
                                 else {
                                     nerrors +=
@@ -16432,7 +16432,7 @@ main(void)
             }     /* end block */
 
             /* Random object insertion & deletion */
-            if (ExpressMode > 1)
+            if (ExpressMode > H5_TEST_EXPRESS_FULL)
                 printf("***Express test mode on.  Some tests skipped\n");
             else {
                 /* Random tests using "small" heap creation parameters */

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -1049,16 +1049,16 @@ h5_get_testexpress(void)
 
     /* TestExpress_g is uninitialized if it has a negative value */
     if (express_val < 0) {
-        /* Default to level 1 if not overridden */
-        express_val = 1;
+        /* Default to full run of tests if not overridden */
+        express_val = H5_TEST_EXPRESS_FULL;
 
         /* Check if a default test express level is defined (e.g., by build system) */
 #ifdef H5_TEST_EXPRESS_LEVEL_DEFAULT
         express_val = H5_TEST_EXPRESS_LEVEL_DEFAULT;
         if (express_val < 0)
-            express_val = 1; /* Reset to default */
-        else if (express_val > 3)
-            express_val = 3;
+            express_val = H5_TEST_EXPRESS_FULL; /* Reset to default */
+        else if (express_val > H5_TEST_EXPRESS_SMOKE_TEST)
+            express_val = H5_TEST_EXPRESS_SMOKE_TEST;
 #endif
     }
 
@@ -1068,13 +1068,13 @@ h5_get_testexpress(void)
     env_val = getenv("HDF5TestExpress");
     if (env_val) {
         if (strcmp(env_val, "0") == 0)
-            express_val = 0;
+            express_val = H5_TEST_EXPRESS_EXHAUSTIVE;
         else if (strcmp(env_val, "1") == 0)
-            express_val = 1;
+            express_val = H5_TEST_EXPRESS_FULL;
         else if (strcmp(env_val, "2") == 0)
-            express_val = 2;
+            express_val = H5_TEST_EXPRESS_QUICK;
         else
-            express_val = 3;
+            express_val = H5_TEST_EXPRESS_SMOKE_TEST;
     }
 
     return express_val;
@@ -1087,9 +1087,9 @@ void
 h5_set_testexpress(int new_val)
 {
     if (new_val < 0)
-        new_val = 1; /* Reset to default */
-    else if (new_val > 3)
-        new_val = 3;
+        new_val = H5_TEST_EXPRESS_FULL; /* Reset to default */
+    else if (new_val > H5_TEST_EXPRESS_SMOKE_TEST)
+        new_val = H5_TEST_EXPRESS_SMOKE_TEST;
 
     TestExpress_g = new_val;
 }

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -384,6 +384,12 @@ extern pthread_key_t test_thread_info_key_g;
             }                                                                                                \
     } while (0)
 
+/* Macros for the different TestExpress levels for expediting tests */
+#define H5_TEST_EXPRESS_EXHAUSTIVE 0 /** Exhaustive run; tests should take as long as necessary */
+#define H5_TEST_EXPRESS_FULL       1 /** Full run; tests should take no more than 30 minutes    */
+#define H5_TEST_EXPRESS_QUICK      2 /** Quick run; tests should take no more than 10 minutes   */
+#define H5_TEST_EXPRESS_SMOKE_TEST 3 /** Smoke test; tests should take no more than 1 minute    */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -463,10 +469,14 @@ H5TEST_DLL void h5_restore_err(void);
  *          (currently level 1, unless overridden at configuration time). The
  *          different TestExpress level settings have the following meanings:
  *
- *          + 0             - Tests should take as long as necessary
- *          + 1             - Tests should take no more than 30 minutes
- *          + 2             - Tests should take no more than 10 minutes
- *          + 3 (or higher) - Tests should take no more than 1 minute
+ *          + 0 / #H5_TEST_EXPRESS_EXHAUSTIVE - Tests should take as long as
+ *                                              necessary
+ *          + 1 / #H5_TEST_EXPRESS_FULL       - Tests should take no more
+ *                                              than 30 minutes
+ *          + 2 / #H5_TEST_EXPRESS_QUICK      - Tests should take no more
+ *                                              than 10 minutes
+ *          + 3 / #H5_TEST_EXPRESS_SMOKE_TEST - Tests should take no more
+ *                                              than 1 minute
  *
  *          If the TestExpress level setting is not yet initialized, this
  *          function will first set a local variable to the value of the
@@ -474,9 +484,17 @@ H5TEST_DLL void h5_restore_err(void);
  *          the environment variable "HDF5TestExpress" is defined, its value
  *          will override the local variable's value. Acceptable values for
  *          the environment variable are the strings "0", "1" and "2"; any
- *          other string will cause the variable to be set to the value 3.
- *          Once the value for the local variable has been determined,
- *          h5_get_testexpress() returns that value.
+ *          other string will cause the variable to be set to the value
+ *          3 / H5_TEST_EXPRESS_SMOKE_TEST. Once the value for the local
+ *          variable has been determined, h5_get_testexpress() returns that
+ *          value.
+ *
+ *          The limitation imposed by the TestExpress functionality applies
+ *          to the total runtime of a test executable, even if it contains
+ *          multiple sub-tests.
+ *
+ *          The standard system for test times is a Linux machine running in
+ *          NFS space (to catch tests that involve a great deal of disk I/O).
  *
  * \see h5_set_testexpress()
  *

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -386,7 +386,7 @@ extern pthread_key_t test_thread_info_key_g;
 
 /* Macros for the different TestExpress levels for expediting tests */
 #define H5_TEST_EXPRESS_EXHAUSTIVE 0 /** Exhaustive run; tests should take as long as necessary */
-#define H5_TEST_EXPRESS_FULL       1 /** Full run; tests should take no more than 30 minutes    */
+#define H5_TEST_EXPRESS_FULL       1 /** Full run; tests should take no more than 20 minutes    */
 #define H5_TEST_EXPRESS_QUICK      2 /** Quick run; tests should take no more than 10 minutes   */
 #define H5_TEST_EXPRESS_SMOKE_TEST 3 /** Smoke test; tests should take no more than 1 minute    */
 

--- a/test/testframe.c
+++ b/test/testframe.c
@@ -182,6 +182,12 @@ TestInit(const char *ProgName, void (*TestPrivateUsage)(FILE *stream),
     /* Initialize value for TestExpress functionality */
     h5_get_testexpress();
 
+    /* Enable alarm timer for test program once TestExpress setting
+     * has been determined
+     */
+    if (TestAlarmOn() < 0)
+        MESSAGE(5, ("Couldn't enable test alarm timer\n"));
+
     /* Record the program name and private routines if provided. */
     TestProgName = ProgName;
     if (NULL != TestPrivateUsage)
@@ -506,10 +512,6 @@ PerformTests(void)
         test_num_errs = H5_ATOMIC_LOAD(TestArray[Loop].TestNumErrors);
         H5_ATOMIC_STORE(TestArray[Loop].TestNumErrors, TestNumErrs_g);
 
-        if (TestAlarmOn() < 0)
-            MESSAGE(5, ("Couldn't enable test alarm timer for test -- %s (%s) \n",
-                        TestArray[Loop].Description, TestArray[Loop].Name));
-
         if (!is_test_mt) {
             if (TestArray[Loop].TestSetupFunc)
                 TestArray[Loop].TestSetupFunc(TestArray[Loop].TestParameters);
@@ -518,8 +520,6 @@ PerformTests(void)
 
             if (TestArray[Loop].TestCleanupFunc)
                 TestArray[Loop].TestCleanupFunc(TestArray[Loop].TestParameters);
-
-            TestAlarmOff();
 
             test_num_errs = H5_ATOMIC_LOAD(TestArray[Loop].TestNumErrors);
             H5_ATOMIC_STORE(TestArray[Loop].TestNumErrors, TestNumErrs_g - test_num_errs);
@@ -531,7 +531,6 @@ PerformTests(void)
 
             PerformThreadedTest(TestArray[Loop]);
 
-            TestAlarmOff();
             H5_ATOMIC_STORE(TestArray[Loop].TestNumErrors, TestNumErrs_g - test_num_errs);
             MESSAGE(5, ("===============================================\n"));
             MESSAGE(5, ("There were %d errors detected.\n\n", (int)H5_ATOMIC_LOAD(TestArray[Loop].TestNumErrors)));
@@ -894,6 +893,8 @@ TestShutdown(void)
 
     free(TestArray);
 
+    TestAlarmOff();
+
     return SUCCEED;
 }
 
@@ -1140,30 +1141,38 @@ SetTestMaxNumThreads(int max_num_threads)
 herr_t
 TestAlarmOn(void)
 {
+    /* A TestExpress setting of H5_TEST_EXPRESS_EXHAUSTIVE should allow
+     * tests to run for as long as necessary, so avoid enabling an
+     * alarm-style timer here that would, by default, kill the test.
+     */
+    if (GetTestExpress() == H5_TEST_EXPRESS_EXHAUSTIVE)
+        return SUCCEED;
 #ifdef H5_HAVE_ALARM
-    char         *env_val   = HDgetenv("HDF5_ALARM_SECONDS"); /* Alarm environment */
-    unsigned long alarm_sec = H5_ALARM_SEC;                   /* Number of seconds before alarm goes off */
+    else {
+        char         *env_val   = getenv("HDF5_ALARM_SECONDS"); /* Alarm environment */
+        unsigned long alarm_sec = H5_ALARM_SEC;                 /* Number of seconds before alarm goes off */
 
-    /* Get the alarm value from the environment variable, if set */
-    if (env_val != NULL) {
-        errno     = 0;
-        alarm_sec = strtoul(env_val, NULL, 10);
-        if (errno != 0) {
-            if (TestFrameworkProcessID_g == 0)
-                fprintf(stderr, "%s: error while parsing value (%s) specified for alarm timeout\n", __func__,
-                        env_val);
-            return FAIL;
+        /* Get the alarm value from the environment variable, if set */
+        if (env_val != NULL) {
+            errno     = 0;
+            alarm_sec = strtoul(env_val, NULL, 10);
+            if (errno != 0) {
+                if (TestFrameworkProcessID_g == 0)
+                    fprintf(stderr, "%s: error while parsing value (%s) specified for alarm timeout\n",
+                            __func__, env_val);
+                return FAIL;
+            }
+            else if (alarm_sec > (unsigned long)UINT_MAX) {
+                if (TestFrameworkProcessID_g == 0)
+                    fprintf(stderr, "%s: value (%lu) specified for alarm timeout too large\n", __func__,
+                            alarm_sec);
+                return FAIL;
+            }
         }
-        else if (alarm_sec > (unsigned long)UINT_MAX) {
-            if (TestFrameworkProcessID_g == 0)
-                fprintf(stderr, "%s: value (%lu) specified for alarm timeout too large\n", __func__,
-                        alarm_sec);
-            return FAIL;
-        }
+
+        /* Set the number of seconds before alarm goes off */
+        alarm((unsigned)alarm_sec);
     }
-
-    /* Set the number of seconds before alarm goes off */
-    alarm((unsigned)alarm_sec);
 #endif
 
     return SUCCEED;

--- a/test/testframe.c
+++ b/test/testframe.c
@@ -238,18 +238,21 @@ TestUsage(FILE *stream)
     fprintf(stream, "              [-o[nly] name]+ \n");
     fprintf(stream, "              [-b[egin] name] \n");
     fprintf(stream, "              [-[max]t[hreads]]  \n");
+    fprintf(stream, "              [-[testex]p[ress] (0-3)]  \n");
     fprintf(stream, "              [-s[ummary]]  \n");
     fprintf(stream, "              [-c[leanoff]]  \n");
     fprintf(stream, "              [-h[elp]]  \n");
     fprintf(stream, "\n\n");
-    fprintf(stream, "verbose     controls the amount of information displayed\n");
-    fprintf(stream, "exclude     to exclude tests by name\n");
-    fprintf(stream, "only        to name tests which should be run\n");
-    fprintf(stream, "begin       start at the name of the test given\n");
-    fprintf(stream, "maxthreads  maximum number of threads to be used by multi-thread tests\n");
-    fprintf(stream, "summary     prints a summary of test results at the end\n");
-    fprintf(stream, "cleanoff    does not delete *.hdf files after execution of tests\n");
-    fprintf(stream, "help        print out this information\n");
+    fprintf(stream, "verbose      controls the amount of information displayed\n");
+    fprintf(stream, "exclude      to exclude tests by name\n");
+    fprintf(stream, "only         to name tests which should be run\n");
+    fprintf(stream, "begin        start at the name of the test given\n");
+    fprintf(stream, "maxthreads   maximum number of threads to be used by multi-thread tests\n");
+    fprintf(stream, "testexpress  set the TestExpress level for expediting tests\n");
+    fprintf(stream, "               lower values run more tests; higher values skip more tests\n");
+    fprintf(stream, "summary      prints a summary of test results at the end\n");
+    fprintf(stream, "cleanoff     does not delete *.hdf files after execution of tests\n");
+    fprintf(stream, "help         print out this information\n");
     if (TestPrivateUsage_g) {
         fprintf(stream, "\nExtra options\n");
         TestPrivateUsage_g(stream);
@@ -422,6 +425,42 @@ TestParseCmdLine(int argc, char *argv[])
                 ret_value = FAIL;
                 goto done;
             }
+        }
+        else if ((strcmp(*argv, "-testexpress") == 0) || (strcmp(*argv, "-p") == 0)) {
+            long test_express_level;
+
+            if (argc <= 0 || !argv[1]) {
+                if (TestFrameworkProcessID_g == 0)
+                    fprintf(stderr, "no argument given to -testexpress option\n");
+                ret_value = FAIL;
+                goto done;
+            }
+
+            --argc;
+            ++argv;
+
+            errno              = 0;
+            test_express_level = strtol(*argv, NULL, 10);
+            if (errno != 0) {
+                if (TestFrameworkProcessID_g == 0)
+                    fprintf(stderr, "error while parsing value (%s) specified for TestExpress level\n",
+                            *argv);
+                ret_value = FAIL;
+                goto done;
+            }
+            if (test_express_level < 0) {
+                if (TestFrameworkProcessID_g == 0)
+                    fprintf(stderr, "invalid value (%ld) specified for TestExpress level\n",
+                            test_express_level);
+                ret_value = FAIL;
+                goto done;
+            }
+
+            /* Clamp value to current highest TestExpress level */
+            if (test_express_level > H5_TEST_EXPRESS_SMOKE_TEST)
+                test_express_level = H5_TEST_EXPRESS_SMOKE_TEST;
+
+            SetTestExpress((int)test_express_level);
         }
         else {
             /* non-standard option.  Break out. */

--- a/test/testframe.h
+++ b/test/testframe.h
@@ -518,17 +518,18 @@ H5TEST_DLL herr_t ParseTestVerbosity(char *argv);
  *          expedited. The variable may be set to one of the following
  *          values:
  *
- *          0: Exhaustive run
- *             Tests should take as long as necessary
- *          1: Full run. Default value if H5_TEST_EXPRESS_LEVEL_DEFAULT
- *             and the HDF5TestExpress environment variable are not defined
- *             Tests should take no more than 30 minutes
- *          2: Quick run
- *             Tests should take no more than 10 minutes
- *          3: Smoke test.
+ *          0 / H5_TEST_EXPRESS_EXHAUSTIVE: Exhaustive run
+ *             Tests should take as long as necessary.
+ *          1 / H5_TEST_EXPRESS_FULL: Full run
+ *             Default value if H5_TEST_EXPRESS_LEVEL_DEFAULT and the
+ *             HDF5TestExpress environment variable are not defined.
+ *             Tests should take no more than 30 minutes.
+ *          2 / H5_TEST_EXPRESS_QUICK: Quick run
+ *             Tests should take no more than 10 minutes.
+ *          3 / H5_TEST_EXPRESS_SMOKE_TEST: Smoke test
  *             Default if the HDF5TestExpress environment variable is set to
- *             a value other than 0-3
- *             Tests should take less than 1 minute
+ *             a value other than 0-3.
+ *             Tests should take less than 1 minute.
  *
  *          The macro H5_TEST_EXPRESS_LEVEL_DEFAULT may be defined to one
  *          of these values at library configuration time in order to

--- a/test/tsohm.c
+++ b/test/tsohm.c
@@ -615,7 +615,7 @@ size1_helper(hid_t file, const char *filename, hid_t fapl_id, hbool_t test_file_
     /* Closing and re-opening the file takes a long time on systems without
      * local disks.  Don't close and reopen if express testing is enabled.
      */
-    if (h5_get_testexpress() > 1)
+    if (h5_get_testexpress() > H5_TEST_EXPRESS_FULL)
         test_file_closing = false;
 
     /* Initialize wdata */
@@ -1553,7 +1553,7 @@ size2_helper(hid_t fcpl_id, int test_file_closing, size2_helper_struct *ret_size
     /* Closing and re-opening the file takes a long time on systems without
      * local disks.  Don't close and reopen if express testing is enabled.
      */
-    if (h5_get_testexpress() > 1)
+    if (h5_get_testexpress() > H5_TEST_EXPRESS_FULL)
         test_file_closing = 0;
 
     /* Create a file and get its size */

--- a/testpar/t_2Gio.c
+++ b/testpar/t_2Gio.c
@@ -2593,7 +2593,7 @@ main(int argc, char **argv)
     H5_mpi_set_bigio_count(oldsize);
 
     express_test = GetTestExpress();
-    if ((express_test == 0) && (mpi_rank < 2)) {
+    if ((express_test == H5_TEST_EXPRESS_EXHAUSTIVE) && (mpi_rank < 2)) {
         MpioTest2G(test_comm);
     }
 

--- a/testpar/t_shapesame.c
+++ b/testpar/t_shapesame.c
@@ -1954,7 +1954,7 @@ contig_hs_dr_pio_test(const void *params, ShapeSameTestMethods sstest_type)
     if (local_express_test < 0) {
         max_skips = max_skips_tbl[0];
     }
-    else if (local_express_test > 3) {
+    else if (local_express_test > H5_TEST_EXPRESS_SMOKE_TEST) {
         max_skips = max_skips_tbl[3];
     }
     else {
@@ -3873,7 +3873,7 @@ ckrbrd_hs_dr_pio_test(const void *params, ShapeSameTestMethods sstest_type)
     if (local_express_test < 0) {
         max_skips = max_skips_tbl[0];
     }
-    else if (local_express_test > 3) {
+    else if (local_express_test > H5_TEST_EXPRESS_SMOKE_TEST) {
         max_skips = max_skips_tbl[3];
     }
     else {


### PR DESCRIPTION
Adds new -testexpress command-line option and adjusts the usage of the `alarm(2)` timer in the framework