### PR TITLE
Fix non-async call in H5Gclose_async

### DIFF
--- a/src/H5G.c
+++ b/src/H5G.c
@@ -938,7 +938,7 @@ H5Gclose(hid_t group_id)
 
     /* TBD: Retain lock to protect ID iteration */
     H5_API_LOCK
-    dec_ref_ret = H5I_dec_app_ref_always_close(group_id);
+    dec_ref_ret = H5I_dec_app_ref(group_id);
     H5_API_UNLOCK
     
     if (dec_ref_ret < 0)
@@ -995,7 +995,7 @@ H5Gclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
 
     /* TBD: Retain lock to protect ID iteration */
     H5_API_LOCK
-    dec_ref_ret = H5I_dec_app_ref_always_close(group_id);
+    dec_ref_ret = H5I_dec_app_ref_async(group_id, token_ptr);
     H5_API_UNLOCK
 
     if (dec_ref_ret < 0)

--- a/test/threads/unit/mt_vl_test.c
+++ b/test/threads/unit/mt_vl_test.c
@@ -18,7 +18,6 @@
 
 #define MT_TEST_VOL_REGISTRATION_FILENAME "mt_test_vol_registration.h5"
 #define MT_TEST_VOL_WRAP_CTX_FILE_NAME "mt_test_vol_wrap_ctx_file.h5"
-#define MT_DUMMY_GROUP_NAME "mt_dummy_group"
 #define NONEXISTENT_FILENAME "nonexistent.h5"
 #define SUBCLS_NAME_SIZE 100
 #define H5F_ACS_VOL_CONN_NAME "vol_connector_info" /* Name of the VOL connector info property */


### PR DESCRIPTION
The MT H5VL changes accidentally replaced a few H5I_dec_ref()-type calls with `H5I_dec_app_ref_always_close()`. This reverts those changes.