### PR TITLE
Fix bad objcopy test cleanup on failure

### DIFF
--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -17097,6 +17097,8 @@ error:
     {
         H5Dclose(did);
         H5Dclose(did2);
+        H5Dclose(did3);
+        H5Dclose(did4);
         H5Sclose(sid);
         H5Gclose(gid);
         H5Gclose(gid2);

--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -1511,6 +1511,8 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
     H5G_info_t ginfo2;    /* Group info struct */
     hsize_t    idx;       /* Index over the objects in group */
     unsigned   cpy_flags; /* Object copy flags */
+    hid_t      oid = H5I_INVALID_HID; /* IDs of objects within group */
+    hid_t      oid2 = H5I_INVALID_HID;
 
     /* Retrieve the object copy flags from the property list, if it's non-DEFAULT */
     if (pid != H5P_DEFAULT) {
@@ -1563,7 +1565,6 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
 
             /* Extra checks for "real" objects */
             if (linfo.type == H5L_TYPE_HARD) {
-                hid_t             oid, oid2;     /* IDs of objects within group */
                 H5O_info2_t       oinfo, oinfo2; /* Data model object info */
                 H5O_native_info_t ninfo, ninfo2; /* Native file format object info */
 
@@ -1648,8 +1649,11 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
                 /* Close objects */
                 if (H5Oclose(oid) < 0)
                     TEST_ERROR;
+                oid = H5I_INVALID_HID;
+
                 if (H5Oclose(oid2) < 0)
                     TEST_ERROR;
+                oid2 = H5I_INVALID_HID;
             } /* end if */
             else {
                 /* Check that both links are the same size */
@@ -1690,6 +1694,8 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
 error:
     H5E_BEGIN_TRY
     {
+        H5Oclose(oid);
+        H5Oclose(oid2);
     }
     H5E_END_TRY
     return FALSE;

--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -8817,6 +8817,7 @@ error:
         H5Gclose(gid);
         H5Fclose(fid_dst);
         H5Fclose(fid_src);
+        H5Fclose(fid_ext);
     }
     H5E_END_TRY
     return 1;


### PR DESCRIPTION
If test_copy_dataset_open() fails after creating and before closing `did3` and `did4` in the main test body, they will not be closed during error cleanup. This delays the closing of the test file and causes file creation conflicts later on.