### PR TITLE
Check for errors on h5test initialization

### DIFF
--- a/test/btree2.c
+++ b/test/btree2.c
@@ -9923,7 +9923,11 @@ main(void)
         envval = "nomatch";
 
     /* Reset library */
-    h5_test_init();
+    if (h5_test_init() < 0) {
+        fprintf(stderr, "failed to initialized h5test\n");
+        exit(EXIT_FAILURE);
+    }
+
     fapl        = h5_fileaccess();
     ExpressMode = h5_get_testexpress();
 

--- a/test/earray.c
+++ b/test/earray.c
@@ -2301,7 +2301,11 @@ main(void)
     hbool_t             api_ctx_pushed = FALSE; /* Whether API context pushed */
 
     /* Reset library */
-    h5_test_init();
+    if (h5_test_init() < 0) {
+        fprintf(stderr, "failed to initialized h5test\n");
+        exit(EXIT_FAILURE);
+    }
+
     fapl = h5_fileaccess();
 
     /* Set the filename to use for this test (dependent on fapl) */

--- a/test/farray.c
+++ b/test/farray.c
@@ -1632,7 +1632,11 @@ main(void)
     hbool_t             api_ctx_pushed = FALSE; /* Whether API context pushed */
 
     /* Reset library */
-    h5_test_init();
+    if (h5_test_init() < 0) {
+        fprintf(stderr, "failed to initialized h5test\n");
+        exit(EXIT_FAILURE);
+    }
+
     fapl = h5_fileaccess();
 
     /* Set the filename to use for this test (dependent on fapl) */

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -378,20 +378,30 @@ h5_reset(void)
 /*
  * Performs test framework initialization
  */
-void
+herr_t
 h5_test_init(void)
 {
+    int ret = SUCCEED;
     fflush(stdout);
     fflush(stderr);
     H5close();
 
     /* Save current error stack reporting routine and redirect to our local one */
     assert(err_func == NULL);
-    H5Eget_auto2(H5E_DEFAULT, &err_func, NULL);
-    H5Eset_auto2(H5E_DEFAULT, h5_errors, NULL);
+    if (H5Eget_auto2(H5E_DEFAULT, &err_func, NULL) < 0) {
+        ret = FAIL;
+        goto done;
+    }
+
+    if (H5Eset_auto2(H5E_DEFAULT, h5_errors, NULL) < 0) {
+        ret = FAIL;
+        goto done;
+    }
 
     /* Retrieve the TestExpress mode */
     TestExpress_g = h5_get_testexpress();
+done:
+    return ret;
 } /* end h5_test_init() */
 
 /*

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -168,14 +168,14 @@ H5TEST_DLLVAR uint64_t vol_cap_flags_g;
  *
  * \brief Performs test framework initialization
  *
- * \return nothing
+ * \return Zero on success, negative value on failure
  *
  * \details h5_test_init() performs test initialization actions, such as
  *          setting the TestExpress level setting, and should be called
  *          toward the beginning of the main() function in a test program.
  *
  */
-H5TEST_DLL void h5_test_init(void);
+H5TEST_DLL herr_t h5_test_init(void);
 
 /**
  * --------------------------------------------------------------------------


### PR DESCRIPTION
If an error occurs during library initialization as part of `h5_test_init()`, further tests are very likely to fail or segfault. I specifically encountered this while testing the Bypass VOL.

Adds a return code to `h5_test_init()` so that clients to h5test can abort early on initialization failures. 