### PR TITLE
Fix CMake MT build on Mac

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1232,7 +1232,7 @@ if (BUILD_STATIC_LIBS)
     target_link_libraries (${HDF5_LIB_TARGET}
       PRIVATE
           "$<$<OR:$<BOOL:${HDF5_ENABLE_THREADSAFE}>,$<BOOL:${HDF5_ENABLE_SUBFILING_VFD}>,$<BOOL:${HDF5_ENABLE_MULTITHREAD}>>:Threads::Threads>"
-          "$<$<BOOL:${HDF5_ENABLE_MULTITHREAD}>:atomic>"
+          "$<$<AND:$<BOOL:${HDF5_ENABLE_MULTITHREAD}>,$<NOT:$<PLATFORM_ID:Darwin>>>:atomic>"
     )
   endif ()
   set_global_variable (HDF5_LIBRARIES_TO_EXPORT ${HDF5_LIB_TARGET})
@@ -1272,7 +1272,7 @@ if (BUILD_SHARED_LIBS)
   target_link_libraries (${HDF5_LIBSH_TARGET}
       PRIVATE ${LINK_LIBS} ${LINK_COMP_LIBS}
               "$<$<OR:$<BOOL:${HDF5_ENABLE_THREADSAFE}>,$<BOOL:${HDF5_ENABLE_SUBFILING_VFD}>,$<BOOL:${HDF5_ENABLE_MULTITHREAD}>>:Threads::Threads>"
-              "$<$<BOOL:${HDF5_ENABLE_MULTITHREAD}>:atomic>"
+              "$<$<AND:$<BOOL:${HDF5_ENABLE_MULTITHREAD}>,$<NOT:$<PLATFORM_ID:Darwin>>>:atomic>"
       PUBLIC "$<$<NOT:$<PLATFORM_ID:Windows>>:${CMAKE_DL_LIBS}>" "$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:MPI::MPI_C>"
   )
   set_global_variable (HDF5_LIBRARIES_TO_EXPORT "${HDF5_LIBRARIES_TO_EXPORT};${HDF5_LIBSH_TARGET}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -648,7 +648,7 @@ if (NOT BUILD_SHARED_LIBS)
     target_link_libraries (mt_id_test
       PRIVATE
         "$<$<OR:$<BOOL:${HDF5_ENABLE_THREADSAFE}>,$<BOOL:${HDF5_ENABLE_MULTITHREAD}>>:Threads::Threads>"
-        "$<$<BOOL:${HDF5_ENABLE_MULTITHREAD}>:atomic>"
+        "$<$<AND:$<BOOL:${HDF5_ENABLE_MULTITHREAD}>,$<NOT:$<PLATFORM_ID:Darwin>>>:atomic>"
     )
   endif ()
 else ()
@@ -657,7 +657,7 @@ else ()
     PRIVATE
       ${HDF5_TEST_LIBSH_TARGET}
       "$<$<OR:$<BOOL:${HDF5_ENABLE_THREADSAFE}>,$<BOOL:${HDF5_ENABLE_MULTITHREAD}>>:Threads::Threads>"
-      "$<$<BOOL:${HDF5_ENABLE_MULTITHREAD}>:atomic>"
+      "$<$<AND:$<BOOL:${HDF5_ENABLE_MULTITHREAD}>,$<NOT:$<PLATFORM_ID:Darwin>>>:atomic>"
   )
 endif ()
 set_target_properties (mt_id_test PROPERTIES FOLDER test)


### PR DESCRIPTION
On MacOS, atomic operations are provided by the system libraries and not libatomic, so the linking step would fail looking for the atomic library. I tested this change on a Mac, and the API tests and mthdf5 tests still passed with and without multiple concurrent threads.