### PR TITLE
H5I bug fix

### DIFF
--- a/.github/workflows/multithread_test.yml
+++ b/.github/workflows/multithread_test.yml
@@ -51,7 +51,7 @@ jobs:
             fail-fast: false
 
         # Restrict runtime to 60 minutes in case tests hang
-        timeout-minutes: 120
+        timeout-minutes: 180
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/multithread_test.yml
+++ b/.github/workflows/multithread_test.yml
@@ -51,7 +51,7 @@ jobs:
             fail-fast: false
 
         # Restrict runtime to 60 minutes in case tests hang
-        timeout-minutes: 60
+        timeout-minutes: 120
 
         steps:
             - name: Checkout repository

--- a/src/H5A.c
+++ b/src/H5A.c
@@ -253,11 +253,11 @@ H5Acreate_async(const char *app_file, const char *app_func, unsigned app_line, h
                 const char *attr_name, hid_t type_id, hid_t space_id, hid_t acpl_id, hid_t aapl_id,
                 hid_t es_id)
 {
-    H5VL_object_t *vol_obj   = NULL;            /* Object for loc_id */
-    void          *token     = NULL;            /* Request token for async operation        */
-    void         **token_ptr = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
-    hid_t          ret_value = H5I_INVALID_HID; /* Return value */
-    int            dec_ref_ret = 0;             /* Ref count decrement return value */
+    H5VL_object_t *vol_obj     = NULL;            /* Object for loc_id */
+    void          *token       = NULL;            /* Request token for async operation        */
+    void         **token_ptr   = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
+    hid_t          ret_value   = H5I_INVALID_HID; /* Return value */
+    int            dec_ref_ret = 0;               /* Ref count decrement return value */
 
     FUNC_ENTER_API_NO_MUTEX(H5I_INVALID_HID)
     H5TRACE10("i", "*s*sIui*siiiii", app_file, app_func, app_line, loc_id, attr_name, type_id, space_id,
@@ -278,10 +278,8 @@ H5Acreate_async(const char *app_file, const char *app_func, unsigned app_line, h
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE10(__func__, "*s*sIui*siiiii", app_file, app_func, app_line, loc_id, attr_name, type_id, space_id, acpl_id, aapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on attribute ID");
@@ -413,11 +411,11 @@ H5Acreate_by_name_async(const char *app_file, const char *app_func, unsigned app
                         const char *obj_name, const char *attr_name, hid_t type_id, hid_t space_id,
                         hid_t acpl_id, hid_t aapl_id, hid_t lapl_id, hid_t es_id)
 {
-    H5VL_object_t *vol_obj   = NULL;            /* Object for loc_id */
-    void          *token     = NULL;            /* Request token for async operation        */
-    void         **token_ptr = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
-    hid_t          ret_value = H5I_INVALID_HID; /* Return value */
-    int            dec_ref_ret = 0;             /* Ref count decrement return value */
+    H5VL_object_t *vol_obj     = NULL;            /* Object for loc_id */
+    void          *token       = NULL;            /* Request token for async operation        */
+    void         **token_ptr   = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
+    hid_t          ret_value   = H5I_INVALID_HID; /* Return value */
+    int            dec_ref_ret = 0;               /* Ref count decrement return value */
 
     FUNC_ENTER_API_NO_MUTEX(H5I_INVALID_HID)
     H5TRACE12("i", "*s*sIui*s*siiiiii", app_file, app_func, app_line, loc_id, obj_name, attr_name, type_id,
@@ -438,11 +436,9 @@ H5Acreate_by_name_async(const char *app_file, const char *app_func, unsigned app
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE12(__func__, "*s*sIui*s*siiiiii", app_file, app_func, app_line, loc_id, obj_name, attr_name, type_id, space_id, acpl_id, aapl_id, lapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref(ret_value);
-            H5_API_UNLOCK
-            
+
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on attribute ID");
 
@@ -585,11 +581,11 @@ hid_t
 H5Aopen_async(const char *app_file, const char *app_func, unsigned app_line, hid_t loc_id,
               const char *attr_name, hid_t aapl_id, hid_t es_id)
 {
-    H5VL_object_t *vol_obj   = NULL;            /* Object for loc_id */
-    void          *token     = NULL;            /* Request token for async operation        */
-    void         **token_ptr = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
-    hid_t          ret_value = H5I_INVALID_HID; /* Return value */
-    int            dec_ref_ret = 0;             /* Ref count decrement return value */
+    H5VL_object_t *vol_obj     = NULL;            /* Object for loc_id */
+    void          *token       = NULL;            /* Request token for async operation        */
+    void         **token_ptr   = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
+    hid_t          ret_value   = H5I_INVALID_HID; /* Return value */
+    int            dec_ref_ret = 0;               /* Ref count decrement return value */
 
     FUNC_ENTER_API_NO_MUTEX(H5I_INVALID_HID)
     H5TRACE7("i", "*s*sIui*sii", app_file, app_func, app_line, loc_id, attr_name, aapl_id, es_id);
@@ -608,10 +604,8 @@ H5Aopen_async(const char *app_file, const char *app_func, unsigned app_line, hid
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE7(__func__, "*s*sIui*sii", app_file, app_func, app_line, loc_id, attr_name, aapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on attribute ID");
@@ -725,10 +719,10 @@ hid_t
 H5Aopen_by_name_async(const char *app_file, const char *app_func, unsigned app_line, hid_t loc_id,
                       const char *obj_name, const char *attr_name, hid_t aapl_id, hid_t lapl_id, hid_t es_id)
 {
-    H5VL_object_t *vol_obj   = NULL;            /* Object for loc_id */
-    void          *token     = NULL;            /* Request token for async operation        */
-    void         **token_ptr = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
-    hid_t          ret_value = H5I_INVALID_HID;
+    H5VL_object_t *vol_obj     = NULL;            /* Object for loc_id */
+    void          *token       = NULL;            /* Request token for async operation        */
+    void         **token_ptr   = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
+    hid_t          ret_value   = H5I_INVALID_HID;
     int            dec_ref_ret = 0; /* Ref count decrement return value */
 
     FUNC_ENTER_API_NO_MUTEX(H5I_INVALID_HID)
@@ -750,10 +744,8 @@ H5Aopen_by_name_async(const char *app_file, const char *app_func, unsigned app_l
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE9(__func__, "*s*sIui*s*siii", app_file, app_func, app_line, loc_id, obj_name, attr_name, aapl_id, lapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on attribute ID");
@@ -807,7 +799,7 @@ H5A__open_by_idx_api_common(hid_t loc_id, const char *obj_name, H5_index_t idx_t
     H5_API_LOCK
     ret_value = H5CX_set_apl(&aapl_id, H5P_CLS_AACC, loc_id, FALSE);
     H5_API_UNLOCK
-    
+
     if (ret_value < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTSET, H5I_INVALID_HID, "can't set attribute access property list info");
 
@@ -876,10 +868,10 @@ H5Aopen_by_idx_async(const char *app_file, const char *app_func, unsigned app_li
                      const char *obj_name, H5_index_t idx_type, H5_iter_order_t order, hsize_t n,
                      hid_t aapl_id, hid_t lapl_id, hid_t es_id)
 {
-    H5VL_object_t *vol_obj   = NULL;            /* Object for loc_id */
-    void          *token     = NULL;            /* Request token for async operation        */
-    void         **token_ptr = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
-    hid_t          ret_value = H5I_INVALID_HID;
+    H5VL_object_t *vol_obj     = NULL;            /* Object for loc_id */
+    void          *token       = NULL;            /* Request token for async operation        */
+    void         **token_ptr   = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
+    hid_t          ret_value   = H5I_INVALID_HID;
     int            dec_ref_ret = 0; /* Ref count decrement return value */
 
     FUNC_ENTER_API_NO_MUTEX(H5I_INVALID_HID)
@@ -901,10 +893,8 @@ H5Aopen_by_idx_async(const char *app_file, const char *app_func, unsigned app_li
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE11(__func__, "*s*sIui*sIiIohiii", app_file, app_func, app_line, loc_id, obj_name, idx_type, order, n, aapl_id, lapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on attribute ID");
@@ -2288,8 +2278,8 @@ done:
 herr_t
 H5Aclose(hid_t attr_id)
 {
-    herr_t ret_value = SUCCEED; /* Return value */
-    int    dec_ref_ret = 0;     /* Ref count decrement return value */
+    herr_t ret_value   = SUCCEED; /* Return value */
+    int    dec_ref_ret = 0;       /* Ref count decrement return value */
 
     FUNC_ENTER_API_NO_MUTEX(FAIL)
     H5TRACE1("e", "i", attr_id);
@@ -2301,10 +2291,8 @@ H5Aclose(hid_t attr_id)
     /* Decrement the counter on the attribute ID. It will be freed if the count
      * reaches zero.
      */
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
+
     dec_ref_ret = H5I_dec_app_ref(attr_id);
-    H5_API_UNLOCK
 
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTDEC, FAIL, "decrementing attribute ID failed");
@@ -2325,12 +2313,12 @@ done:
 herr_t
 H5Aclose_async(const char *app_file, const char *app_func, unsigned app_line, hid_t attr_id, hid_t es_id)
 {
-    H5VL_object_t *vol_obj   = NULL;            /* Object for loc_id */
-    H5VL_t        *connector = NULL;            /* VOL connector */
-    void          *token     = NULL;            /* Request token for async operation        */
-    void         **token_ptr = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
-    herr_t         ret_value = SUCCEED;         /* Return value */
-    int            dec_ref_ret = 0;             /* Ref count decrement return value */
+    H5VL_object_t *vol_obj     = NULL;            /* Object for loc_id */
+    H5VL_t        *connector   = NULL;            /* VOL connector */
+    void          *token       = NULL;            /* Request token for async operation        */
+    void         **token_ptr   = H5_REQUEST_NULL; /* Pointer to request token for async operation        */
+    herr_t         ret_value   = SUCCEED;         /* Return value */
+    int            dec_ref_ret = 0;               /* Ref count decrement return value */
 
     FUNC_ENTER_API_NO_MUTEX(FAIL)
     H5TRACE5("e", "*s*sIuii", app_file, app_func, app_line, attr_id, es_id);
@@ -2357,10 +2345,8 @@ H5Aclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
     /* Decrement the counter on the attribute ID. It will be freed if the count
      * reaches zero.
      */
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
+
     dec_ref_ret = H5I_dec_app_ref_async(attr_id, token_ptr);
-    H5_API_UNLOCK
 
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTDEC, FAIL, "decrementing attribute ID failed");

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -246,10 +246,8 @@ H5Dcreate_async(const char *app_file, const char *app_func, unsigned app_line, h
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE11(__func__, "*s*sIui*siiiiii", app_file, app_func, app_line, loc_id, name, type_id, space_id, lcpl_id, dcpl_id, dapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref_always_close(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_DATASET, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on dataset ID");
@@ -486,10 +484,8 @@ H5Dopen_async(const char *app_file, const char *app_func, unsigned app_line, hid
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE7(__func__, "*s*sIui*sii", app_file, app_func, app_line, loc_id, name, dapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref_always_close(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_DATASET, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on dataset ID");
@@ -528,10 +524,8 @@ H5Dclose(hid_t dset_id)
     /* Decrement the counter on the dataset.  It will be freed if the count
      * reaches zero.
      */
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
+
     dec_ref_ret = H5I_dec_app_ref_always_close(dset_id);
-    H5_API_UNLOCK
 
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTDEC, FAIL, "can't decrement count on dataset ID");
@@ -584,10 +578,8 @@ H5Dclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
     /* Decrement the counter on the dataset.  It will be freed if the count
      * reaches zero.
      */
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
+
     dec_ref_ret = H5I_dec_app_ref_always_close_async(dset_id, token_ptr);
-    H5_API_UNLOCK
 
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTDEC, FAIL, "can't decrement count on dataset ID");
@@ -715,10 +707,8 @@ H5Dget_space_async(const char *app_file, const char *app_func, unsigned app_line
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE5(__func__, "*s*sIuii", app_file, app_func, app_line, dset_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref_always_close(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_DATASET, H5E_CANTDEC, H5I_INVALID_HID,

--- a/src/H5F.c
+++ b/src/H5F.c
@@ -268,8 +268,6 @@ H5Fget_obj_count(hid_t file_id, unsigned types)
         udata.types     = types | H5F_OBJ_LOCAL;
         udata.obj_count = 0;
 
-        /* TBD: Retain lock to protect ID iteration */
-        H5_API_LOCK
         if (types & H5F_OBJ_FILE)
             iter_result = H5I_iterate(H5I_FILE, H5F__get_all_count_cb, &udata, TRUE);
         if (types & H5F_OBJ_DATASET)
@@ -280,7 +278,6 @@ H5Fget_obj_count(hid_t file_id, unsigned types)
             iter_result = H5I_iterate(H5I_DATATYPE, H5F__get_all_count_cb, &udata, TRUE);
         if (types & H5F_OBJ_ATTR)
             iter_result = H5I_iterate(H5I_ATTR, H5F__get_all_count_cb, &udata, TRUE);
-        H5_API_UNLOCK
 
         if (iter_result < 0)
             HGOTO_ERROR(H5E_FILE, H5E_BADITER, (-1), "iteration over IDs failed");
@@ -397,8 +394,6 @@ H5Fget_obj_ids(hid_t file_id, unsigned types, size_t max_objs, hid_t *oid_list /
         udata.oid_list  = oid_list;
         udata.obj_count = 0;
 
-        /* TBD: Retain lock to protect ID iteration */
-        H5_API_LOCK
         if (types & H5F_OBJ_FILE)
             iter_result = H5I_iterate(H5I_FILE, H5F__get_all_ids_cb, &udata, TRUE);
         if (types & H5F_OBJ_DATASET)
@@ -409,7 +404,6 @@ H5Fget_obj_ids(hid_t file_id, unsigned types, size_t max_objs, hid_t *oid_list /
             iter_result = H5I_iterate(H5I_DATATYPE, H5F__get_all_ids_cb, &udata, TRUE);
         if (types & H5F_OBJ_ATTR)
             iter_result = H5I_iterate(H5I_ATTR, H5F__get_all_ids_cb, &udata, TRUE);
-        H5_API_UNLOCK
 
         if (iter_result < 0)
             HGOTO_ERROR(H5E_FILE, H5E_BADITER, (-1), "iteration over IDs failed");
@@ -741,10 +735,8 @@ H5Fcreate_async(const char *app_file, const char *app_func, unsigned app_line, c
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE8(__func__, "*s*sIu*sIuiii", app_file, app_func, app_line, filename, flags, fcpl_id, fapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_FILE, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on file ID");
@@ -937,10 +929,8 @@ H5Fopen_async(const char *app_file, const char *app_func, unsigned app_line, con
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE7(__func__, "*s*sIu*sIuii", app_file, app_func, app_line, filename, flags, fapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_FILE, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on file ID");
@@ -1112,10 +1102,7 @@ H5Fclose(hid_t file_id)
      * When it reaches zero the file will be closed.
      */
 
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
     dec_ref_ret = H5I_dec_app_ref(file_id);
-    H5_API_UNLOCK
 
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTCLOSEFILE, FAIL, "decrementing file ID failed");
@@ -1168,10 +1155,8 @@ H5Fclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
     /* Asynchronously decrement reference count on ID.
      * When it reaches zero the file will be closed.
      */
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
+
     dec_ref_ret = H5I_dec_app_ref_async(file_id, token_ptr);
-    H5_API_UNLOCK
 
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTCLOSEFILE, FAIL, "decrementing file ID failed");
@@ -1621,10 +1606,8 @@ H5Freopen_async(const char *app_file, const char *app_func, unsigned app_line, h
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE5(__func__, "*s*sIuii", app_file, app_func, app_line, file_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref_async(ret_value, NULL);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_FILE, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on file ID");

--- a/src/H5G.c
+++ b/src/H5G.c
@@ -287,10 +287,8 @@ H5Gcreate_async(const char *app_file, const char *app_func, unsigned app_line, h
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE9(__func__, "*s*sIui*siiii", app_file, app_func, app_line, loc_id, name, lcpl_id, gcpl_id, gapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref_always_close(ret_value);
-            H5_API_UNLOCK
             
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_SYM, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on group ID");
@@ -520,10 +518,8 @@ H5Gopen_async(const char *app_file, const char *app_func, unsigned app_line, hid
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE7(__func__, "*s*sIui*sii", app_file, app_func, app_line, loc_id, name, gapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref_always_close(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_SYM, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on group ID");
@@ -936,10 +932,7 @@ H5Gclose(hid_t group_id)
      * reaches zero.
      */
 
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
     dec_ref_ret = H5I_dec_app_ref(group_id);
-    H5_API_UNLOCK
     
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_SYM, H5E_CANTDEC, FAIL, "decrementing group ID failed");
@@ -993,10 +986,7 @@ H5Gclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
      * reaches zero.
      */
 
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
     dec_ref_ret = H5I_dec_app_ref_async(group_id, token_ptr);
-    H5_API_UNLOCK
 
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_SYM, H5E_CANTDEC, FAIL, "decrementing group ID failed");

--- a/src/H5I.c
+++ b/src/H5I.c
@@ -1846,11 +1846,12 @@ H5Iget_file_id(hid_t obj_id)
     else
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, H5I_INVALID_HID, "not an ID of a file object");
 
+done:
+
 #ifdef H5_HAVE_MULTITHREAD
     H5I__exit();
 #endif /* H5_HAVE_MULTITHREAD */
 
-done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5Iget_file_id() */
 

--- a/src/H5Iint.c
+++ b/src/H5Iint.c
@@ -9209,13 +9209,25 @@ H5I__find_id_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
  * Return:      SUCCEED/FAIL
  *              (id will be set to H5I_INVALID_HID on errors or not found)
  *
+ * Changes:     Modified the function to increment the ref count on the
+ *              target entry before calling H5I__find_id_cb().  This 
+ *              should prevent IDs from being deleted out from under 
+ *              H5I__find_id_cb() absent other coding errors.
+ *
+ *              Note that this adds significant overhead.  However absent
+ *              an appropriate free list for VOL connectors, it is 
+ *              necessary.
+ *
+ *                                              JRM 6/2/25
+ *
  *-------------------------------------------------------------------------
  */
 herr_t
 H5I_find_id(const void *object, H5I_type_t type, hid_t *id)
 {
-    H5I_mt_type_info_t *type_info_ptr = NULL;    /* Pointer to the type */
-    herr_t              ret_value = SUCCEED;     /* Return value */
+    H5I_mt_type_info_t      *type_info_ptr = NULL;    /* Pointer to the type */
+    H5I_mt_id_info_kernel_t  info_k;
+    herr_t                   ret_value = SUCCEED;     /* Return value */
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -9249,22 +9261,94 @@ H5I_find_id(const void *object, H5I_type_t type, hid_t *id)
         /* Iterate over IDs for the ID type */
         if ( lfht_get_first(&(type_info_ptr->lfht), &scan_id, &value) ) {
 
-            int ret;
+#if 1 /* test code */
 
             do {
+
                 id_info_ptr = (H5I_mt_id_info_t *)value;
 
+                assert(H5I__ID_INFO == id_info_ptr->tag);
+
+                info_k = atomic_load(&(id_info_ptr->k));
+
+                if (! info_k.marked) {
+
+                    /* Since this iteration may be called in parallel with other
+                     * operations on the target id type, it is possible that the
+                     * target ID will be deleted during the iterate callback.
+                     *
+                     * To prevent this, increment the ref count on the target ID
+                     * before we call the itterate callback, and decrement it again
+                     * when that call returns.
+                     *
+                     * While this isn't fool proof, it should work absent
+                     * coding errors elsewhere.
+                     *
+                     * At present, we do this with calls to H5I_inc_ref_internal()
+                     * and H5I__dec_ref().  This is very inefficient as it requires
+                     * two unnecessary calls to H5I__find_id(), in addition to
+                     * other issues.  This is acceptable for the prototype, but
+                     * we need to do better for the production version.
+                     *
+                     * Note also that the call to H5I_inc_ref_internal() may fail.
+                     * If it does, presume that this is due to the target ID being
+                     * deleted out from under the itteration, and just go on to the
+                     * next ID.
+                     */
+
+                    if ( -1 != H5I_inc_ref_internal(id_info_ptr->id, FALSE) ) {
+
+                        int ret;  /* return value for find id cb */
+
+                        /* inc ref was successful -- call the find callback */
+
+                        ret = H5I__find_id_cb((void *)id_info_ptr, NULL, (void *)&udata);
+
+                        /* decrement the ref count again before we check the find
+                         * callback return value.
+                         */
+                        if ( H5I__dec_ref(id_info_ptr->id, NULL, FALSE) < 0 )
+
+                            HGOTO_ERROR(H5E_ID, H5E_CANTDEC, (-1), "can't decrement ID ref count");
+
+                        /* Now check results of the iteration */
+
+                        if (H5_ITER_ERROR == ret)
+                            HGOTO_ERROR(H5E_ID, H5E_BADITER, FAIL, "iteration failed");
+
+                        if (H5_ITER_STOP == ret)
+                            break;
+
+                    } else {
+
+                        /* ID was deleted out from under us -- update stats and go on
+                         * to the next ID if it exists.
+                         */
+                    }
+                }
+            } while (lfht_get_next(&(type_info_ptr->lfht), scan_id, &scan_id, &value));
+
+#else /* original code */
+
+            int ret;
+ 
+            do {                                                             
+                id_info_ptr = (H5I_mt_id_info_t *)value;
+ 
                 ret = H5I__find_id_cb((void *)id_info_ptr, NULL, (void *)&udata);
-
+ 
                 if (H5_ITER_ERROR == ret)
-
+ 
                     HGOTO_ERROR(H5E_ID, H5E_BADITER, FAIL, "iteration failed");
 
                 if (H5_ITER_STOP == ret)
-
+ 
                     break;
 
             } while (lfht_get_next(&(type_info_ptr->lfht), scan_id, &scan_id, &value));
+
+#endif /* original */
+
         }
 
         *id = udata.ret_id;
@@ -10354,8 +10438,6 @@ H5I__new_mt_type_info(const H5I_class_t *cls, unsigned reserved)
     H5I_mt_type_info_sptr_t new_fl_stail;
     H5I_mt_type_info_sptr_t snext;
     H5I_mt_type_info_sptr_t new_snext;
-    uint64_t shead_sn;
-    uint64_t current_max_sn; 
     uint64_t test_val;
     H5I_mt_type_info_t * ret_value = NULL; /* Return value */
 

--- a/src/H5Iint.c
+++ b/src/H5Iint.c
@@ -493,7 +493,12 @@ H5I_init(void)
     atomic_init(&(H5I_mt_g.num_successful_do_not_disturb_sets), 0ULL);
     atomic_init(&(H5I_mt_g.num_failed_do_not_disturb_sets), 0ULL);
     atomic_init(&(H5I_mt_g.num_do_not_disturb_resets), 0ULL);
-    atomic_init(&(H5I_mt_g.num_do_not_disturb_bypasses), 0ULL);
+    atomic_init(&(H5I_mt_g.num_do_not_disturb_recursions), 0ULL);
+
+    atomic_init(&(H5I_mt_g.global_mutex_acquire_attempts), 0ULL);
+    atomic_init(&(H5I_mt_g.global_mutex_acquire_successes), 0ULL);
+    atomic_init(&(H5I_mt_g.global_mutex_acquire_failures), 0ULL);
+    atomic_init(&(H5I_mt_g.num_deadlock_evasions), 0ULL);
 
     atomic_init(&(H5I_mt_g.num_H5I_entries_via_public_API), 0ULL);
     atomic_init(&(H5I_mt_g.num_H5I_entries_via_internal_API), 0ULL);
@@ -830,7 +835,12 @@ H5I_clear_stats(void)
     atomic_store(&(H5I_mt_g.num_successful_do_not_disturb_sets), 0ULL);
     atomic_store(&(H5I_mt_g.num_failed_do_not_disturb_sets), 0ULL);
     atomic_store(&(H5I_mt_g.num_do_not_disturb_resets), 0ULL);
-    atomic_store(&(H5I_mt_g.num_do_not_disturb_bypasses), 0ULL);
+    atomic_store(&(H5I_mt_g.num_do_not_disturb_recursions), 0ULL);
+
+    atomic_store(&(H5I_mt_g.global_mutex_acquire_attempts), 0ULL);
+    atomic_store(&(H5I_mt_g.global_mutex_acquire_successes), 0ULL);
+    atomic_store(&(H5I_mt_g.global_mutex_acquire_failures), 0ULL);
+    atomic_store(&(H5I_mt_g.num_deadlock_evasions), 0ULL);
 
     atomic_store(&(H5I_mt_g.num_H5I_entries_via_public_API), 0ULL);
     atomic_store(&(H5I_mt_g.num_H5I_entries_via_internal_API), 0ULL);
@@ -1211,8 +1221,17 @@ H5I_dump_stats(FILE * file_ptr)
             (unsigned long long)(atomic_load(&(H5I_mt_g.num_failed_do_not_disturb_sets))));
     fprintf(file_ptr, "H5I_mt_g.num_do_not_disturb_resets                                     = %lld\n", 
             (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_resets))));
-    fprintf(file_ptr, "H5I_mt_g.num_do_not_disturb_bypasses                                   = %lld\n\n", 
-            (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_bypasses))));
+    fprintf(file_ptr, "H5I_mt_g.num_do_not_disturb_recursions                                 = %lld\n\n",
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_recursions))));
+
+    fprintf(file_ptr, "H5I_mt_g.global_mutex_acquire_attempts                                 = %lld\n",
+            (unsigned long long)(atomic_load(&(H5I_mt_g.global_mutex_acquire_attempts))));
+    fprintf(file_ptr, "H5I_mt_g.global_mutex_acquire_successes                                = %lld\n",
+            (unsigned long long)(atomic_load(&(H5I_mt_g.global_mutex_acquire_successes))));
+    fprintf(file_ptr, "H5I_mt_g.global_mutex_acquire_failures                                 = %lld\n",
+            (unsigned long long)(atomic_load(&(H5I_mt_g.global_mutex_acquire_failures))));
+    fprintf(file_ptr, "H5I_mt_g.num_deadlock_evasions                                         = %lld\n\n",
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_deadlock_evasions))));
 
     fprintf(file_ptr, "H5I_mt_g.num_H5I_entries_via_public_API                                = %lld\n", 
             (unsigned long long)(atomic_load(&(H5I_mt_g.num_H5I_entries_via_public_API))));
@@ -1961,9 +1980,45 @@ H5I_dump_nz_stats(FILE * file_ptr, const char * tag)
         fprintf(file_ptr, "H5I_mt_g.num_do_not_disturb_resets                                     = %lld\n", 
                 (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_resets))));
 
-    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_bypasses))) > 0ULL )
-        fprintf(file_ptr, "H5I_mt_g.num_do_not_disturb_bypasses                                   = %lld\n", 
-                (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_bypasses))));
+    if ((unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_recursions))) > 0ULL)
+        fprintf(file_ptr, "H5I_mt_g.num_do_not_disturb_recursions                                 = %lld\n",
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_recursions))));
+
+    /* global mutex acquire / dealock avoidance stats */
+
+    if ((unsigned long long)(atomic_load(&(H5I_mt_g.global_mutex_acquire_attempts))) > 0ULL)
+        fprintf(file_ptr, "H5I_mt_g.global_mutex_acquire_attempts                                 = %lld\n",
+                (unsigned long long)(atomic_load(&(H5I_mt_g.global_mutex_acquire_attempts))));
+
+    if ((unsigned long long)(atomic_load(&(H5I_mt_g.global_mutex_acquire_successes))) > 0ULL)
+        fprintf(file_ptr, "H5I_mt_g.global_mutex_acquire_successes                                = %lld\n",
+                (unsigned long long)(atomic_load(&(H5I_mt_g.global_mutex_acquire_successes))));
+
+    if ((unsigned long long)(atomic_load(&(H5I_mt_g.global_mutex_acquire_failures))) > 0ULL)
+        fprintf(file_ptr, "H5I_mt_g.global_mutex_acquire_failures                                 = %lld\n",
+                (unsigned long long)(atomic_load(&(H5I_mt_g.global_mutex_acquire_failures))));
+
+    if ((unsigned long long)(atomic_load(&(H5I_mt_g.num_deadlock_evasions))) > 0ULL)
+        fprintf(file_ptr, "H5I_mt_g.num_deadlock_evasions                                         = %lld\n",
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_deadlock_evasions))));
+
+    /* active_threads stats */
+
+    if ((unsigned long long)(atomic_load(&(H5I_mt_g.num_H5I_entries_via_public_API))) > 0ULL)
+        fprintf(file_ptr, "H5I_mt_g.num_H5I_entries_via_public_API                                = %lld\n",
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_H5I_entries_via_public_API))));
+
+    if ((unsigned long long)(atomic_load(&(H5I_mt_g.num_H5I_entries_via_internal_API))) > 0ULL)
+        fprintf(file_ptr, "H5I_mt_g.num_H5I_entries_via_internal_API                              = %lld\n",
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_H5I_entries_via_internal_API))));
+
+    if ((unsigned long long)(atomic_load(&(H5I_mt_g.max_active_threads))) > 0ULL)
+        fprintf(file_ptr, "H5I_mt_g.max_active_threads                                            = %lld\n",
+                (unsigned long long)(atomic_load(&(H5I_mt_g.max_active_threads))));
+
+    if ((unsigned long long)(atomic_load(&(H5I_mt_g.times_active_threads_is_zero))) > 0ULL)
+        fprintf(file_ptr, "H5I_mt_g.times_active_threads_is_zero                                  = %lld\n",
+                (unsigned long long)(atomic_load(&(H5I_mt_g.times_active_threads_is_zero))));
 
     FUNC_LEAVE_NOAPI_VOID;
 
@@ -2762,12 +2817,14 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
     hbool_t                 is_candidate;
     hbool_t                 cant_roll_back;
     hbool_t                 do_not_disturb_set;
+    hbool_t                 global_mutex_acquired;
     hbool_t                 mark;
     hbool_t                 done = FALSE;
     hbool_t                 have_global_mutex = TRUE; /*trivially so for single thread builds */
     hbool_t                 cls_is_mt_safe;
     hbool_t                 bool_result;
     int                     pass = 0;
+    H5I_mt_id_info_kernel_t init_info_k;
     H5I_mt_id_info_kernel_t info_k;
     H5I_mt_id_info_kernel_t mod_info_k;
     H5I_mt_id_info_t       *id_info_ptr  = (H5I_mt_id_info_t *)_info;        /* Current ID info being worked with */
@@ -2777,6 +2834,7 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
 
     FUNC_ENTER_NOAPI(FAIL)
 
+    memset(&init_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
     memset(&info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
     memset(&mod_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
 
@@ -2813,15 +2871,21 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
     do {
 
         /* If another thread modified id_info_ptr-k while we are preparing our modified copy,
-         * or if we need to set the do not disturb flag to prevent simultaneous calls to 
-         * the future id discard_cb callback or the regular id free_func, we will have to 
-         * re-run this do-while loop.  Since we start each pass fresh, start by reseting 
-         * all the flags to their initial values.
+         * or if we need to but fail to set the do not disturb flag to prevent simultaneous 
+         * calls to the future id discard_cb callback or the regular id free_func, we will 
+         * have to re-run this do-while loop.  Since we start each pass fresh, start by 
+         * reseting all the flags to their initial values.
          */
         is_candidate       = FALSE;
         cant_roll_back     = FALSE;
         do_not_disturb_set = FALSE;
+        global_mutex_acquired = FALSE;
         mark               = FALSE;
+
+        /* dito the structures for local copies of the kernel */
+        memset(&init_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+        memset(&info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+        memset(&mod_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
 
         /* increment the pass and log retries */
         if ( pass++ >= 1 ) {
@@ -2831,10 +2895,13 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
 
         /* load the atomic kernel from *id_info_ptr into info_k.  Note that this is a snapshot of the 
          * state of *id_info_ptr, and can be changed before we get to writing it back.
+         *
+         * We keep the inital version of the kernel around so we can back out of the do_not_disturb
+         * easily if we fail to acquire the global mutex.
          */
-        info_k = atomic_load(&(id_info_ptr->k));
+        init_info_k = atomic_load(&(id_info_ptr->k));
 
-        if ( info_k.marked ) {
+        if (init_info_k.marked) {
 
             /* this is is already marked for deletion -- nothing to do here */
 
@@ -2850,15 +2917,29 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
             break;
         }
 
-        if ( info_k.do_not_disturb ) {
-#if 0 
-            if ( ( have_global_mutex ) && ( info_k.have_global_mutex ) ) {
+        if (init_info_k.do_not_disturb) {
+#if H5I_BYPASS_HDF5_TID
+           /* since the do not disturb flag is set, info_k.tid_valid must be true */
+           assert(init_info_k.tid_valid);
 
-                bypass_do_not_disturb = TRUE;
+            /* In principle, if init_info_k.tid == pthread_self(), we could bypass
+             * the do_not_disturb_flag and proceed.  However, since H5I__mark_node() will 
+             * modify the kernel, this will cause the reset of the do_not_disturb flag to 
+             * fail.  In principle, this could be dealt with.  However, since this 
+             * issue hasn't arrisen yet, just assert that info_k.tid != H5TS_thread_id().
+             */
+           assert( ! pthread_equal(init_info_k.tid, pthread_self()) );
+#else
+           /* since the do not disturb flag is set, info_k.tid must be non-zero */
+           assert(init_info_k.tid != 0ULL);
 
-                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_bypasses), 1ULL);
-
-            } else {
+            /* In principle, if init_info_k.tid == H5TS_thread_id(), we could bypass
+             * the do_not_disturb_flag and proceed.  However, since H5I__mark_node() will 
+             * modify the kernel, this will cause the reset of the do_not_disturb flag to 
+             * fail.  In principle, this could be dealt with.  However, since this 
+             * issue hasn't arrisen yet, just assert that info_k.tid != H5TS_thread_id().
+             */
+           assert(init_info_k.tid != H5TS_thread_id());
 #endif
 
                 /* Another thread is in the process of performing an operation on the info kernel
@@ -2883,11 +2964,11 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
 #endif
         }
 
-        if ( ( udata->force ) || ( (info_k.count - ((!udata->app_ref) * info_k.app_count)) <= 1 ) ) {
+        if ((udata->force) || ((init_info_k.count - ((!udata->app_ref) * init_info_k.app_count)) <= 1)) {
 
             is_candidate = TRUE;
 
-            if ( ( info_k.is_future ) || ( udata->type_info->cls->free_func ) ) {
+            if ((init_info_k.is_future) || (udata->type_info->cls->free_func)) {
 
                 cant_roll_back = TRUE;
             }
@@ -2905,14 +2986,23 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
 
         if ( cant_roll_back ) {
 
-            mod_info_k.count             = info_k.count;
-            mod_info_k.app_count         = info_k.app_count;
-            mod_info_k.object            = info_k.object;
+            /* we must set the do_not_disturb flag */
 
-            mod_info_k.marked            = info_k.marked;
+            mod_info_k.count     = init_info_k.count;
+            mod_info_k.app_count = init_info_k.app_count;
+            mod_info_k.object    = init_info_k.object;
+#if H5I_BYPASS_HDF5_TID
+            mod_info_k.tid       = pthread_self();
+            mod_info_k.tid_valid = TRUE;
+#else
+            mod_info_k.tid       = H5TS_thread_id();
+
+            assert(mod_info_k.tid > 0ULL);
+#endif
+            mod_info_k.marked            = init_info_k.marked;
             mod_info_k.do_not_disturb    = TRUE;
-            mod_info_k.is_future         = info_k.is_future;
-            mod_info_k.have_global_mutex = have_global_mutex;
+            mod_info_k.is_future         = init_info_k.is_future;
+            mod_info_k.have_global_mutex = ( ( have_global_mutex ) || ( ! cls_is_mt_safe ) );
 
             /* We don't want multiple threads trying to either realize or dispose of the 
              * data associated with the future id or trying to free the data associated 
@@ -2922,7 +3012,7 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
              * flag.  If successful, this will prevent any other threads from modifying 
              * id_info_ptr->k until after it is set back to FALSE.
              */
-            if ( ! atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k ) ) {
+            if ( ! atomic_compare_exchange_strong(&(id_info_ptr->k), &init_info_k, mod_info_k) ) {
 
                 /* Some other thread changed the value of id_info_ptr->k since we last read
                  * it.  Thus we must return to the beginning of the do loop and start 
@@ -2939,10 +3029,6 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
 
                 do_not_disturb_set = TRUE;
 
-#if 0 /* JRM */
-                /* make info_k into a copy of the global kernel */
-                info_k.do_not_disturb = TRUE;
-#else /* JTM */
                 /* On the face of it, it would seem that we could just update info_k
                  * to match mod_info_k, and use it in the next atomic_compare_exchange_strong()
                  * call.  However, for reason or reasons unknown, this doesn't work.
@@ -2955,12 +3041,21 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
                 assert(info_k.count             == mod_info_k.count);
                 assert(info_k.app_count         == mod_info_k.app_count);
                 assert(info_k.object            == mod_info_k.object);
+#if H5I_BYPASS_HDF5_TID
+                assert(info_k.tid_valid == mod_info_k.tid_valid);
+
+                if ( info_k.tid_valid ) {
+
+                    assert( pthread_equal(info_k.tid, pthread_self()) );
+                }
+#else
+                assert(info_k.tid == mod_info_k.tid);
+#endif
 
                 assert(info_k.marked            == mod_info_k.marked);
                 assert(info_k.do_not_disturb    == mod_info_k.do_not_disturb);
                 assert(info_k.is_future         == mod_info_k.is_future);
                 assert(info_k.have_global_mutex == mod_info_k.have_global_mutex);
-#endif /* JRM */
 
                 /* update stats */
                 atomic_fetch_add(&(H5I_mt_g.num_successful_do_not_disturb_sets), 1ULL);
@@ -2973,26 +3068,140 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
 
         assert( ( do_not_disturb_set ) || ( ! cant_roll_back ) );
 
+        if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
+
+            /* Since the class is not mult-thread safe, and we don't currently
+             * hold it, we must obtain the the global mutex before proceeding.  
+             *
+             * If we were able to enforce lock ordering between locking an ID and 
+             * obtaining the global mutex, we would simply do this via H5_API_LOCK.
+             *
+             * While this still works if we don't have to lock the target ID
+             * (i.e. the cant_roll_back flag is false, and the ID was not locked
+             * on entry -- always true in this function), there is the potential 
+             * for a deadlock if the do_not_disturb flag is aready set.
+             *
+             * We resolve this by using the H5TS_mutex_acquire() call to attempt
+             * to obtain the global mutex without blocking.  
+             *
+             * If H5TS_mutex_acquire() succeeds, we invoke the callback and then 
+             * drop the global mutex as usual.
+             *
+             * If, however, H5TS_mutex_acquire() fails to obtain the global mutex,
+             * we must clear the do not disturb flag on the target id, either 
+             * thread yield or sleep a bit, and return to the beginning of the 
+             * do loop.  
+             */
+
+             if ( cant_roll_back ) {
+
+                assert( do_not_disturb_set );
+
+                atomic_fetch_add(&(H5I_mt_g.global_mutex_acquire_attempts), 1ULL);
+
+                if ( H5TS_mutex_acquire(&H5_g.init_lock, 1, &global_mutex_acquired) < 0 ) {
+
+                    /* the call to H5TS_mutex_acquire() returned an error.  Drop the
+                     * do not disturb flag on the target ID if set in this function, and
+                     * throw an error.
+                     */
+
+                    /* since we have the do_not_disturb flag, the following
+                     * atomic_compare_exchange_strong() must succeed.
+                     */
+                    assert(mod_info_k.do_not_disturb);
+                    assert(mod_info_k.have_global_mutex);
+                    assert(init_info_k.do_not_disturb);
+                    assert(init_info_k.have_global_mutex);
+
+                    /* reset the kernel to its initial value */
+
+                    bool_result = atomic_compare_exchange_strong(&(id_info_ptr->k), &mod_info_k, init_info_k);
+
+                    assert(bool_result);
+
+                    atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
+
+                    HGOTO_ERROR(H5E_INTERNAL, H5E_SYSERRSTR, FAIL, "H5TS_mutex_acquire reported failure");
+
+                } else { /* H5TS_mutex_acquire() completed without error */
+
+                    if ( ! global_mutex_acquired ) {
+#if 0
+                        fprintf(stderr, "%s: H5TS_mutex_acquire() failed to acquire global mutex\n",
+                                "H5I__mark_node()");
+#endif
+                        atomic_fetch_add(&(H5I_mt_g.global_mutex_acquire_failures), 1ULL);
+
+                        /* the attempt to acquire the global mutex failed -- presumably because
+                         * some other thread holds it.
+                         *
+                         * This may or may not be a deadlock -- but since we can't tell, we will
+                         * assume it is.  Drop the do_not_disturb flag on the target ID, update
+                         * stats, sleep a little, and retry.
+                         */
+
+                        /* since we have the do_not_disturb flag, the following
+                         * atomic_compare_exchange_strong() must succeed.
+                         */
+                        assert( mod_info_k.do_not_disturb );
+                        assert( mod_info_k.have_global_mutex );
+                        assert( ! init_info_k.do_not_disturb );
+                        assert( ! init_info_k.have_global_mutex );
+
+                        bool_result = atomic_compare_exchange_strong(&(id_info_ptr->k), &mod_info_k, 
+                                                                     init_info_k);
+                        assert(bool_result);
+
+                        atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
+                        atomic_fetch_add(&(H5I_mt_g.num_deadlock_evasions), 1ULL);
+
+                        sleep(1);
+
+                        continue;
+
+                    } else { /* global mutext acquired */
+
+                        /* success -- update stats  */
+                        atomic_fetch_add(&(H5I_mt_g.global_mutex_acquire_successes), 1ULL);
+                    }
+                }
+            } else {
+
+                assert( ! do_not_disturb_set );
+
+                H5_API_LOCK
+
+                /* Set global_mutex_acquired to TRUE so that we know to drop the global mutex when 
+                 * we are done.
+                 */
+               global_mutex_acquired = TRUE;
+            }
+        } /* if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) */
+
+        assert( ( cls_is_mt_safe ) || ( have_global_mutex || global_mutex_acquired ) );
+
         if ( info_k.is_future ) {
 
             assert(do_not_disturb_set);
 
-            /* Discard the future object */
-            if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
+            if ( global_mutex_acquired ) {
 
                 atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_discard_cb), 1ULL);
-                H5_API_LOCK
+            }
+
+            /* Discard the future object */
+
                 H5_GCC_CLANG_DIAG_OFF("cast-qual")
                 result = (id_info_ptr->discard_cb)((void *)info_k.object);
                 H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+            /* drop the global mutex if it was acquired */
+            if ( global_mutex_acquired ) {
+
                 H5_API_UNLOCK
+
                 atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_discard_cb), 1ULL);
-
-            } else {
-
-                H5_GCC_CLANG_DIAG_OFF("cast-qual")
-                result = (id_info_ptr->discard_cb)((void *)info_k.object);
-                H5_GCC_CLANG_DIAG_ON("cast-qual")
             }
 
             if ( result < 0 ) {
@@ -3047,21 +3256,21 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
 
                 assert(do_not_disturb_set);
 
-                if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
+                if ( global_mutex_acquired ) {
 
                     atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_free_func), 1ULL);
-                    H5_API_LOCK
-                    H5_GCC_CLANG_DIAG_OFF("cast-qual")
-                    result = (udata->type_info->cls->free_func)((void *)info_k.object, H5_REQUEST_NULL);
-                    H5_GCC_CLANG_DIAG_ON("cast-qual")
+                }
+
+                H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                result = (udata->type_info->cls->free_func)((void *)info_k.object, H5_REQUEST_NULL);
+                H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+                /* drop the global mutex if it was acquired */
+                if ( global_mutex_acquired ) {
+
                     H5_API_UNLOCK
+
                     atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_free_func), 1ULL);
-
-                } else {
-
-                    H5_GCC_CLANG_DIAG_OFF("cast-qual")
-                    result = (udata->type_info->cls->free_func)((void *)info_k.object, H5_REQUEST_NULL);
-                    H5_GCC_CLANG_DIAG_ON("cast-qual")
                 }
 
                 if ( result < 0 ) {
@@ -3136,6 +3345,11 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
                 mod_info_k.count             = 0;
                 mod_info_k.app_count         = 0;
                 mod_info_k.object            = NULL;
+#if H5I_BYPASS_HDF5_TID
+                mod_info_k.tid_valid = FALSE;
+#else
+                mod_info_k.tid       = 0ULL;
+#endif
 
                 mod_info_k.marked            = TRUE;
                 mod_info_k.do_not_disturb    = FALSE;  
@@ -3147,6 +3361,11 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
                 mod_info_k.count             = info_k.count;
                 mod_info_k.app_count         = info_k.app_count;
                 mod_info_k.object            = info_k.object;
+#if H5I_BYPASS_HDF5_TID
+                mod_info_k.tid_valid = FALSE;
+#else
+                mod_info_k.tid       = 0ULL;
+#endif
 
                 mod_info_k.marked            = info_k.marked;
                 mod_info_k.do_not_disturb    = FALSE;  
@@ -4040,6 +4259,10 @@ H5I_subst(hid_t id, const void *new_object)
         id_info_ptr = NULL;
         old_object = NULL;
 
+        memset(&info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+        memset(&mod_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+
+
         /* increment the pass and log retries */
         if ( pass++ >= 1 ) {
 
@@ -4069,36 +4292,32 @@ H5I_subst(hid_t id, const void *new_object)
         }
 
         if ( info_k.do_not_disturb ) {
-#if 0
-            if ( ( have_global_mutex ) && ( info_k.have_global_mutex ) ) {
 
-                bypass_do_not_disturb = TRUE;
+            /* Another thread is in the process of performing an operation on the info kernel
+             * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
+             * regular id free_func.
+             *
+             * Thus we must wait until that thread is done and then re-start the operation -- which
+             * may be moot by that point.
+             */
 
-                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_bypasses), 1ULL);
+            /* update stats */
+            atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
 
-            } else {
-#endif 
-                /* Another thread is in the process of performing an operation on the info kernel
-                 * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
-                 * regular id free_func.
-                 *
-                 * Thus we must wait until that thread is done and then re-start the operation -- which
-                 * may be moot by that point.
-                 */
+            /* need to do better than this.  Want to call pthread_yield(),
+             * but that call doesn't seem to be supported anymore.
+             */
+            sleep(1);
 
-                /* update stats */
-                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
-
-                /* need to do better than this.  Want to call pthread_yield(),
-                 * but that call doesn't seem to be supported anymore.
-                 */
-                sleep(1);
-
-                continue;
-#if 0
-            }
-#endif
+            continue;
         }
+
+        assert( ! info_k.do_not_disturb );
+#if H5I_BYPASS_HDF5_TID
+        assert( ! info_k.tid_valid );
+#else
+        assert( 0ULL == info_k.tid );
+#endif
 
         old_object = info_k.object;
 
@@ -4106,12 +4325,19 @@ H5I_subst(hid_t id, const void *new_object)
         mod_info_k.count          = info_k.count;
         mod_info_k.app_count      = info_k.app_count;
         mod_info_k.object         = new_object;
+#if H5I_BYPASS_HDF5_TID
+        mod_info_k.tid       = info_k.tid;
+        mod_info_k.tid_valid = info_k.tid_valid;
 
-        mod_info_k.marked         = info_k.marked;;
-        mod_info_k.do_not_disturb = info_k.do_not_disturb;;
+        assert( ( ! mod_info_k.tid_valid ) || ( pthread_equal(mod_info_k.tid, info_k.tid) ) );
+#else
+        mod_info_k.tid       = info_k.tid;
+#endif
+
+        mod_info_k.marked = info_k.marked;
+        mod_info_k.do_not_disturb = info_k.do_not_disturb;
         mod_info_k.is_future      = info_k.is_future;
 
-        mod_info_k.object = new_object;
 
         if ( atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k) ) {
 
@@ -4813,6 +5039,9 @@ H5I__remove_common(H5I_type_info_t *type_info_ptr, hid_t id)
     /* Delete or mark the node */
     do {
 
+        memset(&info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+        memset(&mod_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+
         /* increment the pass and log retries */
         if ( pass++ >= 1 ) {
 
@@ -4877,6 +5106,11 @@ H5I__remove_common(H5I_type_info_t *type_info_ptr, hid_t id)
                 mod_info_k.count             = 0;
                 mod_info_k.app_count         = 0;
                 mod_info_k.object            = NULL;
+#if H5I_BYPASS_HDF5_TID
+                mod_info_k.tid_valid = FALSE;
+#else
+                mod_info_k.tid       = 0ULL;
+#endif
 
                 mod_info_k.marked            = TRUE;
                 mod_info_k.do_not_disturb    = FALSE;
@@ -5176,9 +5410,11 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
     hbool_t                  do_not_disturb_set;
     hbool_t                  marked_for_deletion;
     hbool_t                  have_global_mutex = TRUE; /* trivially so in single thread builds */
+    hbool_t                 global_mutex_acquired;
     hbool_t                  cls_is_mt_safe;
     hbool_t                  bool_result;
     int                      pass                = 0;
+    H5I_mt_id_info_kernel_t base_info_k;
     H5I_mt_id_info_kernel_t  info_k;
     H5I_mt_id_info_kernel_t  mod_info_k;
     H5I_mt_id_info_t        *id_info_ptr         = NULL; /* Pointer to the ID */
@@ -5187,9 +5423,6 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
     int                      ret_value           = 0;    /* Return value */
 
     FUNC_ENTER_PACKAGE
-
-    memset(&info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
-    memset(&mod_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
 
 #if H5I_MT_DEBUG
     fprintf(stdout, "   H5I__dec_ref(0x%llx, reguest, app) called. \n", (unsigned long long)id);
@@ -5244,6 +5477,11 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
 
         do_not_disturb_set  = FALSE;
         marked_for_deletion = FALSE;
+        global_mutex_acquired   = FALSE;
+
+        memset(&base_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+        memset(&info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+        memset(&mod_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
 
         /* increment the pass and log retries */
         if ( pass++ >= 1 ) {
@@ -5251,9 +5489,9 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
             atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__retries), 1ULL);
         }
 
-        info_k = atomic_load(&(id_info_ptr->k));
+        base_info_k = atomic_load(&(id_info_ptr->k));
 
-        if ( info_k.marked ) {
+        if (base_info_k.marked) {
 
             /* this is is already marked for deletion -- nothing to do here */
 
@@ -5270,44 +5508,79 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
             HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "can't locate ID");
         }
 
-        if ( info_k.do_not_disturb ) {
+        if (base_info_k.do_not_disturb) {
+#if H5I_BYPASS_HDF5_TID
+            if ( ( base_info_k.tid_valid ) && (  pthread_equal(base_info_k.tid, pthread_self()) ) ) {
+#else
+            if ( base_info_k.tid == H5TS_thread_id() ) {
+#endif
+                /* this thread has already set the do not disturb flag on this ID.  Thus,
+                 * to avoid a deadlock, we must bypass the do_not_disturb flag.
+                 *
+                 * Note that at present, if the kernel of the ID has changed when the
+                 * do not disturb flag is droped higher up the call stack, that operation
+                 * will change.
+                 *
+                 * As long as this is only a matter of bracketing inc ref / dec ref calls,
+                 * this will be OK.  However, if net changes are made, we will have to
+                 * come up with a better solution.
+                 *
+                 * Ideally, this will be getting rid of locks on IDs entirely.
+                 */
 
-            /* Another thread is in the process of performing an operation on the info kernel
-             * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
-             * regular id callback that must be serialized.
-             *
-             * Thus we must wait until that thread is done and then re-start the operation -- which
-             * may be moot by that point.
-             */
+                assert( base_info_k.count > 1 );
 
-            /* update stats */
-            atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
+                assert( base_info_k.have_global_mutex );
 
-            /* need to do better than this.  Want to call pthread_yield(),
-             * but that call doesn't seem to be supported anymore.
-             */
-            sleep(1);
+                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_recursions), 1ULL);
 
-            continue;
+            } else {
+
+                /* Another thread is in the process of performing an operation on the info kernel
+                 * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
+                 * regular id callback that must be serialized.
+                 *
+                 * Thus we must wait until that thread is done and then re-start the operation -- which
+                 * may be moot by that point.
+                 */
+
+                /* update stats */
+                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
+
+                /* need to do better than this.  Want to call pthread_yield(),
+                 * but that call doesn't seem to be supported anymore.
+                 */
+                sleep(1);
+
+                continue;
+            }
         }
 
-        if ( ( info_k.count > 1 ) || ( NULL == type_info_ptr->cls->free_func ) ) {
+        if ((base_info_k.count > 1) || (NULL == type_info_ptr->cls->free_func)) {
 
             /* Either count > 1 or the free function for the class is undefined.
-             * In either case, we can roll back the operation an re-try if the 
+             * In either case, we can roll back the operation and re-try if the
              * global copy of the kernel has changed since we read it at the 
              * top of the do/while loop. 
              */
-            mod_info_k.count             = info_k.count;
-            mod_info_k.app_count         = info_k.app_count;
-            mod_info_k.object            = info_k.object;
+            mod_info_k.count     = base_info_k.count;
+            mod_info_k.app_count = base_info_k.app_count;
+            mod_info_k.object    = base_info_k.object;
+#if H5I_BYPASS_HDF5_TID
+            mod_info_k.tid       = base_info_k.tid;
+            mod_info_k.tid_valid = base_info_k.tid_valid;
 
-            mod_info_k.marked            = info_k.marked;
-            mod_info_k.do_not_disturb    = info_k.do_not_disturb;
-            mod_info_k.is_future         = info_k.is_future;
-            mod_info_k.have_global_mutex = FALSE;
+            assert( ( ! mod_info_k.tid_valid ) || ( pthread_equal(base_info_k.tid, mod_info_k.tid) ) );
+#else
+            mod_info_k.tid       = base_info_k.tid;
+#endif
 
-            if ( info_k.count > 1 ) {
+            mod_info_k.marked            = base_info_k.marked;
+            mod_info_k.do_not_disturb    = base_info_k.do_not_disturb;
+            mod_info_k.is_future         = base_info_k.is_future;
+            mod_info_k.have_global_mutex = base_info_k.have_global_mutex;;
+
+            if (base_info_k.count > 1) {
 
                 mod_info_k.count--;
 
@@ -5330,6 +5603,11 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
                 mod_info_k.count             = 0;
                 mod_info_k.app_count         = 0;
                 mod_info_k.object            = NULL;
+#if H5I_BYPASS_HDF5_TID
+                mod_info_k.tid_valid = FALSE;
+#else
+                mod_info_k.tid       = 0ULL;
+#endif
 
                 mod_info_k.marked            = TRUE;
                 mod_info_k.do_not_disturb    = FALSE;
@@ -5339,7 +5617,7 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
                 marked_for_deletion = TRUE;
             }
 
-            if ( atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k) ) {
+            if (atomic_compare_exchange_strong(&(id_info_ptr->k), &base_info_k, mod_info_k)) {
 
                 if ( marked_for_deletion ) {
 
@@ -5393,19 +5671,26 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
              *       mutex before calling the free_func() and drop if after the call if we 
              *       don't have the mutex already.
              *
-             *    2) Call the free_func().  If the class is not multi-thread safe and
-             *       we don't already hold the globla mutex, we must obtain it before the 
-             *       call, and drop it afterwards.
+             *    2) If the class is not MT safe (!cls_is_mt_safe) and we don't already
+             *       hold the global mutext, we must obtain the global mutex before we call 
+             *       the free func.  Since we can't enforce lock ordering, attempt to obtain 
+             *       the global mutex with H5TS_mutex_acquire().
              * 
-             *       On success, go on to 3) below.  
+             *       It this fails, it is possible that we have a deadlock -- to avoid this,
+             *       drop the do_not_disturb flag on the target ID, wait a bit, and retry.
+             *
+             *    3) Call the free_func(), and then drop the global mutex if it was obtained
+             *       in 2) above.  
+             *
+             *       If the free_func() succeeded, go on to 3) below.
              *
              *       On failure, reset the do_not_disturb flag and return -1.  Do
              *       not flag an error
              *
-             *    3) Set the marked flag, reset the do_not_disturb flag, and set
+             *    4) Set the marked flag, reset the do_not_disturb flag, and set
              *       the return value to zero.
              * 
-             *    4) If H5I_mt_g.marking_array[H5I_TYPE(id)] is zero, remove the ID from 
+             *    5) If H5I_mt_g.marking_array[H5I_TYPE(id)] is zero, remove the ID from
              *       the lock free hash table, and release the associated instance of 
              *       H5I_mt_id_info_t to the free list.
              *
@@ -5418,9 +5703,17 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
              */
 
             /* attempt to set the do_not_disturb flag */
-            mod_info_k.count             = info_k.count;
-            mod_info_k.app_count         = info_k.app_count;
-            mod_info_k.object            = info_k.object;
+            mod_info_k.count     = base_info_k.count;
+            mod_info_k.app_count = base_info_k.app_count;
+            mod_info_k.object    = base_info_k.object;
+#if H5I_BYPASS_HDF5_TID
+            mod_info_k.tid       = pthread_self();
+            mod_info_k.tid_valid = TRUE;
+#else
+            mod_info_k.tid       = H5TS_thread_id();
+
+            assert(mod_info_k.tid > 0ULL);
+#endif
 
             mod_info_k.marked            = info_k.marked;
             mod_info_k.do_not_disturb    = TRUE;
@@ -5435,7 +5728,7 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
              * successful, this will prevent any other threads from modifying
              * id_info_ptr->k until after it is set back to FALSE.
              */
-            if ( ! atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k) ) {
+            if (!atomic_compare_exchange_strong(&(id_info_ptr->k), &base_info_k, mod_info_k)) {
 
                 /* Some other thread changed the value of id_info_ptr->k since we last read
                  * it.  Thus we must return to the beginning of the do loop and start
@@ -5468,6 +5761,12 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
                 assert(info_k.count             == mod_info_k.count);
                 assert(info_k.app_count         == mod_info_k.app_count);
                 assert(info_k.object            == mod_info_k.object);
+#if H5I_BYPASS_HDF5_TID
+                assert( pthread_equal(info_k.tid, pthread_self()) );
+                assert( info_k.tid_valid == mod_info_k.tid_valid );
+#else
+                assert(info_k.tid == mod_info_k.tid);
+#endif
 
                 assert(info_k.marked            == mod_info_k.marked);
                 assert(info_k.do_not_disturb    == mod_info_k.do_not_disturb);
@@ -5486,6 +5785,106 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
 
             assert( do_not_disturb_set );
 
+            if ( ( ! have_global_mutex )  && ( ! cls_is_mt_safe ) )  {
+
+                /* Since the class is not mult-thread safe, and we don't currently
+                 * hold it, we must obtain the the global mutex before proceeding.
+                 *
+                 * If we were able to enforce lock ordering between locking an ID and
+                 * obtaining the global mutex, we would simply do this via H5_API_LOCK.
+                 *
+                 * While this would still work if we knew that the free func would 
+                 * succeed, that is not presently the case.  Thus there is a potential
+                 * for deadlock if the do_not_disturb flag is aready set.
+                 *
+                 * We resolve this by using the H5TS_mutex_acquire() call to attempt
+                 * to obtain the global mutex without blocking.
+                 *
+                 * If H5TS_mutex_acquire() succeeds, we invoke the free func and then
+                 * drop the global mutex as usual.
+                 *
+                 * If, however, H5TS_mutex_acquire() fails to obtain the global mutex,
+                 * we must clear the do not disturb flag on the target id, either
+                 * thread yield or sleep a bit, and return to the beginning of the
+                 * do loop.
+                 */
+
+                assert( do_not_disturb_set );
+
+                atomic_fetch_add(&(H5I_mt_g.global_mutex_acquire_attempts), 1ULL);
+
+                if ( H5TS_mutex_acquire(&H5_g.init_lock, 1, &global_mutex_acquired) < 0 ) {
+
+                    /* the call to H5TS_mutex_acquire() returned an error.  Drop the
+                     * do not disturb flag on the target ID if set in this function, and
+                     * throw an error.
+                     */
+
+                    /* since we have the do_not_disturb flag, the following
+                     * atomic_compare_exchange_strong() must succeed.
+                     */
+                    assert(mod_info_k.do_not_disturb);
+                    assert(mod_info_k.have_global_mutex);
+                    assert(base_info_k.do_not_disturb);
+                    assert(base_info_k.have_global_mutex);
+
+                    /* reset the kernel to its initial value */
+
+                    bool_result = atomic_compare_exchange_strong(&(id_info_ptr->k), &mod_info_k, base_info_k);
+
+                    assert(bool_result);
+
+                    atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
+
+                    HGOTO_ERROR(H5E_INTERNAL, H5E_SYSERRSTR, FAIL, "H5TS_mutex_acquire reported failure");
+
+                } else { /* H5TS_mutex_acquire() completed without error */
+
+                    if ( ! global_mutex_acquired ) {
+#if 0
+                        fprintf(stderr, "%s: H5TS_mutex_acquire() failed to acquire global mutex\n",
+                                "H5I__dec_ref()");
+#endif
+                        atomic_fetch_add(&(H5I_mt_g.global_mutex_acquire_failures), 1ULL);
+
+                        /* the attempt to acquire the global mutex failed -- presumably because
+                         * some other thread holds it.
+                         *
+                         * This may or may not be a deadlock -- but since we can't tell, we will
+                         * assume it is.  Drop the do_not_disturb flag on the target ID, update
+                         * stats, sleep a little, and retry.
+                         */
+
+                        /* since we have the do_not_disturb flag, the following
+                         * atomic_compare_exchange_strong() must succeed.
+                         */
+                        assert( mod_info_k.do_not_disturb );
+                        assert( mod_info_k.have_global_mutex );
+                        assert( ! base_info_k.do_not_disturb );
+                        assert( ! base_info_k.have_global_mutex );
+
+                        bool_result = atomic_compare_exchange_strong(&(id_info_ptr->k), &mod_info_k,
+                                                                     base_info_k);
+                        assert(bool_result);
+
+                        atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
+                        atomic_fetch_add(&(H5I_mt_g.num_deadlock_evasions), 1ULL);
+
+                        sleep(1);
+
+                        continue;
+
+                    } else { /* global mutext acquired */
+
+                        /* success -- update stats  */
+                        atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__global_mutex_locks_for_free_func), 1ULL);
+                        atomic_fetch_add(&(H5I_mt_g.global_mutex_acquire_successes), 1ULL);
+                    }
+                }
+            } /* if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) */
+ 
+            assert( ( cls_is_mt_safe ) || ( have_global_mutex || global_mutex_acquired ) );
+
             atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__calls_to_free_func), 1ULL);
 
             /* Note that the free_func may call back into H5I.  As long as it doesn't try
@@ -5495,21 +5894,15 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
              * manageable as we have access to the code.  For external users (either user 
              * programmer or VOL connectors), we must document this.
              */
-            if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
 
-                atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__global_mutex_locks_for_free_func), 1ULL);
-                H5_API_LOCK
-                H5_GCC_CLANG_DIAG_OFF("cast-qual")
-                result = type_info_ptr->cls->free_func((void *)info_k.object, request);
-                H5_GCC_CLANG_DIAG_ON("cast-qual")
+            H5_GCC_CLANG_DIAG_OFF("cast-qual")
+            result = type_info_ptr->cls->free_func((void *)info_k.object, request);
+            H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+            if ( global_mutex_acquired ) {
+
                 H5_API_UNLOCK
                 atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__global_mutex_unlocks_for_free_func), 1ULL);
-
-            } else {
-
-                H5_GCC_CLANG_DIAG_OFF("cast-qual")
-                result = type_info_ptr->cls->free_func((void *)info_k.object, request);
-                H5_GCC_CLANG_DIAG_ON("cast-qual")
             }
 
             if ( result >= 0 ) {
@@ -5522,6 +5915,11 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
                 mod_info_k.count             = 0;
                 mod_info_k.app_count         = 0;
                 mod_info_k.object            = NULL;
+#if H5I_BYPASS_HDF5_TID
+                mod_info_k.tid_valid = FALSE;
+#else
+                mod_info_k.tid       = 0ULL;
+#endif
 
                 mod_info_k.marked            = TRUE;
                 mod_info_k.do_not_disturb    = FALSE;
@@ -5539,16 +5937,39 @@ H5I__dec_ref(hid_t id, void **request, hbool_t app)
                  */
                 atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__free_func_failed), 1ULL);
 
+#if H5I_BYPASS_HDF5_TID
+                mod_info_k.tid_valid         = FALSE;
+#else
+                mod_info_k.tid               = 0ULL;
+#endif
                 mod_info_k.do_not_disturb    = FALSE;
                 mod_info_k.have_global_mutex = FALSE;
                 ret_value = -1;
-
             }
 
             /* since we have the do_not_disturb flag, the following atomic_compare_exchange_strong()
              * must succeed.
              */
+#if 0 /* JRM */
+            {
+                H5I_mt_id_info_kernel_t tmp_info_k;
+
+                tmp_info_k = atomic_load(&(id_info_ptr->k));
+
+                if ( 0 != memcmp(&tmp_info_k, &info_k, sizeof(H5I_mt_id_info_kernel_t)) ) {
+
+                    fprintf(stderr, "\n\nH5I_dec_ref(): compare_echange_strong for id_info_ptr->id = 0x%lld will fail.\n\n", 
+                            (long long)(id_info_ptr->id));
+                }
+            }
+#endif /* JRM */
             bool_result = atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k);
+#if 0 /* JRM */
+            if ( ! bool_result ) {
+
+                fprintf(stderr, "\n\nH5I_dec_ref(): bool_result == FALSE, id_info_ptr->id = 0x%lld.\n\n", (long long)(id_info_ptr->id));
+            }
+#endif /* JRM */
             assert(bool_result);
 
             atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
@@ -6358,9 +6779,6 @@ H5I_inc_ref_internal(hid_t id, hbool_t app_ref)
 
     FUNC_ENTER_NOAPI((-1))
 
-    memset(&info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
-    memset(&mod_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
-
 #if H5I_MT_DEBUG
     fprintf(stdout, "   H5I_inc_ref((id = 0x%llx, app_ref = %d) called. \n", 
               (unsigned long long)id, (int)app_ref);
@@ -6388,6 +6806,9 @@ H5I_inc_ref_internal(hid_t id, hbool_t app_ref)
 
     do {
 
+        memset(&info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+        memset(&mod_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+
         /* increment the pass and log retries */
         if ( pass++ >= 1 ) {
 
@@ -6414,30 +6835,62 @@ H5I_inc_ref_internal(hid_t id, hbool_t app_ref)
         }
 
         if ( info_k.do_not_disturb ) {
+#if H5I_BYPASS_HDF5_TID
+            if ( ( info_k.tid_valid ) && (  pthread_equal(info_k.tid, pthread_self()) ) ) {
+#else
+            if ( info_k.tid == H5TS_thread_id() ) {
+#endif
+                /* this thread has already set the do not disturb flag on this ID.  Thus,
+                 * to avoid a deadlock, we must bypass the do_not_disturb flag.  
+                 *
+                 * Note that at present, if the kernel of the ID has changed when the 
+                 * do not disturb flag is droped higher up the call stack, that operation
+                 * will change.
+                 *
+                 * As long as this is only a matter of bracketing inc ref / dec ref calls,
+                 * this will be OK.  However, if net changes are made, we will have to 
+                 * come up with a better solution.
+                 *
+                 * Ideally, this will be getting rid of locks on IDs entirely.
+                 */
+                assert( info_k.have_global_mutex );
 
-            /* Another thread is in the process of performing an operation on the info kernel
-             * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
-             * regular id callback that must be serialized.
-             *
-             * Thus we must wait until that thread is done and then re-start the operation -- which
-             * may be moot by that point.
-             */
+                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_recursions), 1ULL);
 
-            /* update stats */
-            atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
+            } else {
 
-            /* need to do better than this.  Want to call pthread_yield(),
-             * but that call doesn't seem to be supported anymore.
-             */
-            sleep(1);
+                /* Another thread is in the process of performing an operation on the info kernel
+                 * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
+                 * regular id callback that must be serialized.
+                 *
+                 * Thus we must wait until that thread is done and then re-start the operation -- which
+                 * may be moot by that point.
+                 */
 
-            continue;
+                /* update stats */
+                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
+
+                /* need to do better than this.  Want to call pthread_yield(),
+                 * but that call doesn't seem to be supported anymore.
+                 */
+                sleep(1);
+
+                continue;
+            }
         }
 
         /* Set mod_info_k to reflect the ref_count increment */
         mod_info_k.count             = info_k.count + 1;
         mod_info_k.app_count         = info_k.app_count;
         mod_info_k.object            = info_k.object;
+#if H5I_BYPASS_HDF5_TID
+        mod_info_k.tid       = info_k.tid;
+        mod_info_k.tid_valid = info_k.tid_valid;
+
+        assert( ( ! mod_info_k.tid_valid ) || ( pthread_equal(mod_info_k.tid, info_k.tid) ) );
+#else
+        mod_info_k.tid       = info_k.tid;
+#endif
 
         mod_info_k.marked            = info_k.marked;
         mod_info_k.do_not_disturb    = info_k.do_not_disturb;
@@ -6978,16 +7431,61 @@ done:
  *
  *              Updated for multi-thread.
  *
+ *              The use of internal iteration is problematic, as we have
+ *              no control over the activities of the callback.  In 
+ *              principle this wouldn't be a problem if the entire HDF5
+ *              library was multi-thread safe and lock free.  Unfortunately,
+ *              this will not be the case for years if ever.
+ *
+ *              For this reason this function should be depreceated and 
+ *              replaced with support for external iteration -- thus 
+ *              avoiding the possibility of any interaction between the
+ *              callback and the iteration code.
+ *
  * Return:      Success:    H5_ITER_CONT (0) or H5_ITER_STOP (1)
  *              Failure:    H5_ITER_ERROR (-1)
+ *
+ * Changes:     The initial multi-thread impleementation of this 
+ *              function set the do not disturb flag to prevent the 
+ *              ID from being deleted out from under the callback and 
+ *              to give the callback exclusive access to ID and its
+ *              associated buffer.
+ *
+ *              While this worked well at first, when we extended the 
+ *              multi-thread effort to the VOL layer this approach 
+ *              resulted lock ordering issues.  Specifically, some
+ *              calls to H5I_iterate() occur under the global mutex,
+ *              and others outside it -- which breaks the ID, global 
+ *              mutex lock ordering.
+ *
+ *              The correct solution is to stop locking IDs.  Unfortunately
+ *              this can't be done until we either make the free functions
+ *              always succeed, or we create a mechanism that allows us
+ *              determine whether the free func will succeed.
+ *
+ *              Fortunately, we can avoid locking IDs here.  Do this by
+ *              wrapping calls to H5I__iterate_cb() in ref count increments
+ *              and decrements -- which prevents deletion of the ID during
+ *              the call to H5I__iterate_cb() (assuming no coding errors
+ *              in ref count management, or overlapping discards of the 
+ *              target ID type). 
+ *
+ *              In principle, all callbacks manipulating the buffer 
+ *              associated with the ID should be thread safe -- but that
+ *              will not be the case until the library is completely 
+ *              multi-thread safe.  Until then, we wrap callbacks in the
+ *              global mutex if it isn't already held.
+ *
+ *                                              JRM -- 3/12/25
  *
  *-------------------------------------------------------------------------
  */
 static int
 H5I__iterate_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
 {
+    hbool_t                 done = FALSE;
     hbool_t                  have_global_mutex;
-    hbool_t                  bool_result;
+    hbool_t                 drop_global_mutex = FALSE;
     H5I_mt_id_info_t        *id_info_ptr       = (H5I_mt_id_info_t *)_item;  /* Pointer to the ID info */
     H5I_iterate_ud_t        *udata             = (H5I_iterate_ud_t *)_udata; /* User data for callback */
     H5I_mt_id_info_kernel_t  info_k;
@@ -6995,8 +7493,6 @@ H5I__iterate_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
     int                      ret_value         = H5_ITER_CONT;               /* Callback return value */
 
     FUNC_ENTER_PACKAGE_NOERR
-
-    memset(&info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
 
 #if H5I_MT_DEBUG
     fprintf(stdout, "\n\n   H5I__iterate_cb() called. \n\n\n");
@@ -7015,186 +7511,167 @@ H5I__iterate_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
         atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_calls__without_global_mutex), 1ULL);
     }
 
-    /* read the current value of the id info kernel */
-    info_k = atomic_load(&(id_info_ptr->k));
 
-    /* Only invoke the callback function if this ID has not been marked for deletion, is visible 
-     * externally and its reference count is positive.
+    /* The call to H5I__iterate_cb() was wrapped in a pair of calls to increment and then
+     * then decrement the reference count.  Under normal circumstances, this should ensure 
+     * that the entry will not be deleted out from under us.
      *
-     * While the user_func (and all the callbacks defined in the type) should be thread safe,
-     * for now, use the do_not_disturb flag to ensure that user_func has exclusive access
-     * to the object -- at least from within H5I.  (Note, however, that the object can still 
-     * be looked up by the user and accessed outside the H5I code.  Similarly, the user 
-     * may have a copy of the pointer, and be able to access its data structure at will 
-     * directly))  
+     * However, there are two scenarios where this need not be the case.
      *
-     * If the limited protection given to the object associated with the ID is not sufficient, 
-     * the client object will have to be made multi-thread safe.  Indeed, this should be 
-     * the end state -- but unless and until the native VOL is made thread safe, this 
-     * limited protection seems a reasonable middle ground 
+     * The obvious one is a coding error elsewhere, that inserts spurious ref count decrements.
+     * Unfortunately, there isn't much we can do about this other than try to detect it.
      * 
-     * As per the other uses of the do_not_disturb flag, it is possible for the user_func to 
-     * trigger a deadlock if it attempts to access the current ID via H5I either directly 
-     * or through some sequence of calls.
+     * The less obvious occurs when an ID type is destroyed.  Here IDs are deleted regardless of 
+     * their reference counts.
+     *
+     * For the HDF5 library proper, the presumption at present is that shut down will 
+     * be single thread -- making this case moot.
+     *
+     * However, discards of user ID types can happen whenever.  Ideally, the data structures
+     * and callbacks used in such user ID typs will be designed to handle this case gracefully.
+     * Failing that, the issue must be avoided through careful coding.
+     *
+     * Here again there isn't much we can do other than to try to detect the issue.
+     *
+     * In both cases, we attempt to detect the issue by asserting that the ref count is positive.
+     *
+     * 
+     * Note that even if it is successful in blocking deletion of the IDs under consideration, 
+     * wrapping the target ID in a ref count increment / decrement doesn't prevent concurrent 
+     * access to the void pointer associated with the ID -- indeed, it is possible for value 
+     * of the void pointer to be changed at any time.
+     *
+     * Again, this would not be a problem if all clients of H5I, and all callback functions
+     * supplied to the iterate function, were multithread safe.  However, this is not the 
+     * case, and likely will not be for some time if ever.  Thus, in addition to ensuring that the 
+     * target ID will not be deleted out from under the callback, we need some method to maintain
+     * mutual exclusion on the target of the void pointer associated with the target ID.
+     *
+     * Initially this was done using the do not disturb flag.  While this worked when all calls
+     * to H5I_iterate() were under the global mutex, moving the global mutex below the VOL layer
+     * made it possible for some calls to H5I_interate() to be under the global mutex, and others
+     * above -- exposing potential lock ordering issues where sometimes the global lock is obtained
+     * before the lock on the target ID, and sometimes afterwards.
+     *
+     * To resolve this, stop using the do not disturb flag, and wrap both the unwrap call 
+     * and the callback in the global mutex.
+     *
+     * Note that this is not a complete solution.  It is still possible for the void pointer 
+     * associated with the ID to be modified by another thread even if the global mutex is 
+     * held.  At present, I don't believe this is a problem, as to my knowlege, the only 
+     * place that void pointers are modified is in H5P when property list classes are modified.
+     * Thus, I don't think this is a problem for now.  That said, the ultimate solution is 
+     * make all the callback multi-thread safe.
      */
-    if ( ( ! info_k.marked ) && ( ( ( ! udata->app_ref ) || ( info_k.app_count > 0 ) ) ) ) {
 
-        hbool_t                  done = FALSE;
-        hbool_t                  bypass_do_not_disturb;
-        hbool_t                  do_not_disturb_set = FALSE;
-        int                      pass                = 0;
-        H5I_type_t               type                = udata->obj_type;
-        H5I_mt_id_info_kernel_t  mod_info_k;
-        void                    *object;
-        herr_t                   cb_ret_val;
+    do {
 
-        memset(&mod_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+        memset(&info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
 
-        do {
-            bypass_do_not_disturb = FALSE;
+        if ( ! have_global_mutex ) {
 
-            /* increment the pass and log retries */
-            if ( pass++ >= 1 ) {
+            atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__global_mutex_locks_for_user_func), 1ULL);
+            H5_API_LOCK
+            drop_global_mutex = TRUE;
+        }
 
-                atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__retries), 1ULL);
-            }
-
+        /* read the current value of the id info kernel */
             info_k = atomic_load(&(id_info_ptr->k));
 
             if ( info_k.marked ) {
 
-                /* the ID has been marked for deletion since we started, update stats 
-                 * and return without calling the user_func()
-                 */
-                atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__marked_during_call), 1ULL);
+            /* ID was deleted out from under us -- update stats and go on
+             * to the next ID if it exists.
+             */
+            assert( H5_ITER_CONT == ret_value );
+
+            done = TRUE;
+
+            if ( drop_global_mutex ) {
+
+                H5_API_UNLOCK
+                drop_global_mutex = FALSE;
+            }
 
                 break;
             }
 
             if ( info_k.do_not_disturb ) {
+#if H5I_BYPASS_HDF5_TID
+            if ( ( info_k.tid_valid ) && (  pthread_equal(info_k.tid, pthread_self()) ) ) {
+#else
+            if ( info_k.tid == H5TS_thread_id() ) {
+#endif
+                /* this thread has already set the do not disturb flag on this ID.  Thus,
+                 * to avoid a deadlock, we must bypass the do_not_disturb flag.
+                 *
+                 * Note that at present, if the kernel of the ID has changed when the
+                 * do not disturb flag is droped higher up the call stack, that operation
+                 * will fail.
+                 *
+                 * As long as this is only a matter of bracketing inc ref / dec ref calls,
+                 * this will be OK.  However, if net changes are made, we will have to
+                 * come up with a better solution.
+                 *
+                 * Ideally, this will be getting rid of locks on IDs entirely.
+                 */
+                assert( info_k.have_global_mutex );
 
-                if ( ( have_global_mutex ) && ( info_k.have_global_mutex ) ) {
+                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_recursions), 1ULL);
 
-                    bypass_do_not_disturb = TRUE;
+            } else {
 
-                    atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_bypasses), 1ULL);
+                /* Another thread has the do not disturb flag set. 
+                 *
+                 * Drop the global mutex if we didn't have it on entry, wait a bit, and try again. 
+                 *
+                 * Note that the other thread will drop the do not disturb and try again if it needs
+                 * the global mutex.  Thus thus sleep and retry should not result in a deadlock even 
+                 * if we had the global mutex on entry.
+                 */
 
-                } else {
+                if ( drop_global_mutex ) {
 
-                    /* Another thread is in the process of performing an operation on the info kernel
-                     * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
-                     * regular id callback that must be serialized.
-                     *
-                     * Thus we must wait until that thread is done and then re-start the operation -- which
-                     * may be moot by that point.
-                     */
+                    H5_API_UNLOCK
+                    drop_global_mutex = FALSE;
+                }
 
                     /* update stats */
                     atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
 
-                    /* need to do better than this.  Want to call pthread_yield(),
-                     * but that call doesn't seem to be supported anymore.
-                     */
                     sleep(1);
 
                     continue;
                 }
             }
 
-            if ( ! bypass_do_not_disturb ) {
+        /* If we get this far, verify that the reference count on the target id is positive. */
+        assert( info_k.count > 0 );
 
-                /* attempt to set the do_not_disturb flag */
-                mod_info_k.count             = info_k.count;
-                mod_info_k.app_count         = info_k.app_count;
-                mod_info_k.object            = info_k.object;
 
-                mod_info_k.marked            = info_k.marked;
-                mod_info_k.do_not_disturb    = TRUE;
-                mod_info_k.is_future         = info_k.is_future;
+        /* Only invoke the callback function if this ID has not been marked for deletion, is visible
+         * externally and its reference count is positive. 
+         *
+         * While the user_func (and all the callbacks defined in the type) should be thread safe,
+         * for now, we use the global mutext to attempt to ensure that the user_func has exclusive access
+         * to the object.  Note, however, that the object can still be looked up by the user and accessed 
+         * outside the H5I code.  Similarly, the user may have a copy of the pointer, and be able to access 
+         * its data structure at will directly.
+         *
+         * The following boolean expression is partially redundant, since we have already verified 
+         * that info_k.marked is FALSE.  Leave it for now.
+         */
+        if ( ( ! info_k.marked ) && ( ( ( ! udata->app_ref ) || ( info_k.app_count > 0 ) ) ) ) {
 
-                /* set mod_inf_k.have_global_mutex to TRUE since if we don't have the global
-                 * mutext, we will grab it before calling the user function, and drop it as soon
-                 * as it returns.
-                 */
-                mod_info_k.have_global_mutex = have_global_mutex;
+            H5I_type_t              type               = udata->obj_type;
+            void                   *object;
+            herr_t                  cb_ret_val;
 
-                /* We want to ensure that no other thread inside H5I does anything with 
-                 * the object while we call the user_func on the objec on the object.  
-                 * Note that this is only a partial solution, but it is the best we can 
-                 * do in H5I.
-                 *
-                 * To do this, try to set the do_not_disturb flag in the kernl.   If
-                 * successful, this will prevent any other threads from modifying
-                 * id_info_ptr->k until after it is set back to FALSE.  In particluar,
-                 * no thread in H5I will call any function on the object associated 
-                 * with the ID until it successfully sets the do_not_disturb flag.
-                 */
-                if ( ! atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k) ) {
-
-                    /* Some other thread changed the value of id_info_ptr->k since we last read
-                     * it.  Thus we must return to the beginning of the do loop and start
-                     * again.  Note that it is possible that by that time, there will be
-                     * nothing left to do.
-                     */
-    
-                    /* update stats */
-                    atomic_fetch_add(&(H5I_mt_g.num_failed_do_not_disturb_sets), 1ULL);
-    
-                    continue;
-    
-                } else {
-    
-                    do_not_disturb_set = TRUE;
-    
-#if 0 /* JRM */
-                    /* make info_k into a copy of the global kernel */
-                    info_k.do_not_disturb = TRUE;
-#else /* JTM */
-                    /* On the face of it, it would seem that we could just update info_k
-                     * to match mod_info_k, and use it in the next atomic_compare_exchange_strong()
-                     * call.  However, for reason or reasons unknown, this doesn't work.
-                     *
-                     * Instead, we reload info_k after the atomic_compare_exchange_strong(),
-                     * and verify that it contains the expected values.
-                     */
-                    info_k = atomic_load(&(id_info_ptr->k));
-
-                    assert(info_k.count             == mod_info_k.count);
-                    assert(info_k.app_count         == mod_info_k.app_count);
-                    assert(info_k.object            == mod_info_k.object);
-
-                    assert(info_k.marked            == mod_info_k.marked);
-                    assert(info_k.do_not_disturb    == mod_info_k.do_not_disturb);
-                    assert(info_k.is_future         == mod_info_k.is_future);
-                    assert(info_k.have_global_mutex == mod_info_k.have_global_mutex);
-#endif /* JRM */
-
-                    /* prepare to reset the do_not_disturb flag */
-                    mod_info_k.do_not_disturb    = FALSE;
-                    mod_info_k.have_global_mutex = FALSE;
-
-                    /* update stats */
-                    atomic_fetch_add(&(H5I_mt_g.num_successful_do_not_disturb_sets), 1ULL);
-
-#if H5I_MT_DEBUG_DO_NOT_DISTURB
-                    fprintf(stdout, "H5I__iterate_cb() set do not disturb on id = 0x%llx.\n",
-                            (unsigned long long)(id_info_ptr->id));
-#endif /* H5I_MT_DEBUG_DO_NOT_DISTURB */
-                }
-            } /* if ( ! bypass_do_not_disturb ) */
-
-            assert( ( do_not_disturb_set ) || ( bypass_do_not_disturb ) );
-
-            /* The stored object pointer might be an H5VL_object_t, in which
-             * case we'll need to get the wrapped object struct (H5F_t *, etc.).
-             */
-#if 0 
-            H5_GCC_CLANG_DIAG_OFF("cast-qual")
-            object = H5I__unwrap((void *)info_k.object, type, &object); /* may hit global mutex */
-            H5_GCC_CLANG_DIAG_ON("cast-qual")
-#endif 
             /* H5I__unwrap() can fail -- for now at least.  Handle this by treating any 
              * failure as a callback failure.  
+             *
+             * Note also that H5I__unwrap() grabs the global mutex.  This is redundant in 
+             * this case at least, and should be repaired in the production version.
              */
             H5_GCC_CLANG_DIAG_OFF("cast-qual")
             result = H5I__unwrap((void *)info_k.object, type, &object);
@@ -7208,67 +7685,47 @@ H5I__iterate_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
 
                 atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_calls), 1ULL);
 
-                /* Invoke callback function.  Grab the global mutex if we don't have it already */
-                if ( ! have_global_mutex ) {
+                cb_ret_val = (*udata->user_func)((void *)object, id_info_ptr->id, udata->user_udata);
 
-                    atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__global_mutex_locks_for_user_func), 1ULL);
-                    H5_API_LOCK
-                    cb_ret_val = (*udata->user_func)((void *)object, id_info_ptr->id, udata->user_udata);
-                    H5_API_UNLOCK
-                    atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__global_mutex_unlocks_for_user_func), 1ULL);
+
+                /* Set the return value based on the callback's return value */
+                if (cb_ret_val > 0) {
+
+                    atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_iter_stops), 1ULL);
+  
+                    ret_value = H5_ITER_STOP; /* terminate iteration early */
+
+                } else if (cb_ret_val < 0) {
+
+                    atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_fails), 1ULL);
+
+                    ret_value = H5_ITER_ERROR; /* indicate failure (which terminates iteration) */
 
                 } else {
 
-                    cb_ret_val = (*udata->user_func)((void *)object, id_info_ptr->id, udata->user_udata);
+                    atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_successes), 1ULL);
                 }
             }
+        } else {
 
-            /* Set the return value based on the callback's return value */
-            if (cb_ret_val > 0) {
+            atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_skips), 1ULL);
+        }
 
-                atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_iter_stops), 1ULL);
+        if ( drop_global_mutex ) {
 
-                ret_value = H5_ITER_STOP; /* terminate iteration early */
+            H5_API_UNLOCK
 
-            } else if (cb_ret_val < 0) {
+            drop_global_mutex = FALSE;
 
-                atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_fails), 1ULL);
+            atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__global_mutex_unlocks_for_user_func), 1ULL);
+        }
 
-                ret_value = H5_ITER_ERROR; /* indicate failure (which terminates iteration) */
+        done = TRUE;
 
-            } else {
+    } while ( ! done );
 
-                atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_successes), 1ULL);
-            }
-
-            if ( ! bypass_do_not_disturb ) {
-
-                /* since we have the do_not_disturb flag, the following atomic_compare_exchange_strong()
-                 * must succeed.
-                 */
-                assert(info_k.do_not_disturb);
-
-                assert( ! mod_info_k.do_not_disturb );
-
-                bool_result = atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k);
-                assert(bool_result);
-
-                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
-
-#if H5I_MT_DEBUG_DO_NOT_DISTURB
-                fprintf(stdout, "H5I__iterate_cb() reset do not disturb on id = 0x%llx.\n",
-                        (unsigned long long)(id_info_ptr->id));
-#endif /* H5I_MT_DEBUG_DO_NOT_DISTURB */
-            }
-
-            /* If execution gets this far, we are done with the do/while loop */
-            done = TRUE;
-
-        } while ( ! done );
-    } else {
-
-        atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_skips), 1ULL);
-    }
+    /* verify that we droped the global mutex if we grabbed it */
+    assert( ! drop_global_mutex);
 
     FUNC_LEAVE_NOAPI(ret_value)
 
@@ -7347,7 +7804,20 @@ H5I__iterate_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
  *              udata as arguments and return non-zero to terminate
  *              siteration, and zero to continue.
  *
+ *
  *              Updated for multi-thread.
+ *
+ *              The use of internal iteration is problematic, as we have
+ *              no control over the activities of the callback.  In 
+ *              principle this wouldn't be a problem if the entire HDF5
+ *              library was multi-thread safe and lock free.  Unfortunately,
+ *              this will not be the case for years if ever.
+ *
+ *              For this reason this function should be depreceated and 
+ *              replaced with support for external iteration -- thus 
+ *              avoiding the possibility of any interaction between the
+ *              callback and the iteration code.
+ *
  *
  * Limitation:  Currently there is no way to start the iteration from
  *              where a previous iteration left off.
@@ -7367,6 +7837,25 @@ H5I__iterate_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
  *              change when we get to the production version.
  * 
  *                                              JRM -- 07/04/24
+ *
+ *              Modified the function to increment the ref count on the
+ *              target entry before calling H5I__iterate_cb().  Prior to 
+ *              this change H5I__iterate_cb() was setting the do_not_disturb
+ *              flag to ensure that the entry didn't get deleted out from
+ *              under the call, and to ensure that the target wasn't 
+ *              modified during the call.
+ *
+ *              While this was fine for external calls only, this results
+ *              in a deadlock if there are conurrent itterations both 
+ *              inside and outside the global mutex.  To fix this, we 
+ *              do the ref count increment and decrement in 
+ *              H5I__iterate_internal(), and grab the global mutex 
+ *              before calling the supplied H5I_search_func_t.  Note
+ *              that this adds significant overhead.  Assuming we keep
+ *              the H5I_iterate() private API, we should allow for 
+ *              thread safe search functions.
+ *      
+ *                                              JRM 3/11/25
  *
  *-------------------------------------------------------------------------
  */
@@ -7440,17 +7929,64 @@ H5I_iterate_internal(H5I_type_t type, H5I_search_func_t func, void *udata, hbool
             do {
                 id_info_ptr = (H5I_mt_id_info_t *)value;
 
+                assert(H5I__ID_INFO == id_info_ptr->tag);
+
                 info_k = atomic_load(&(id_info_ptr->k));
 
                 if (! info_k.marked) {
 
-                    int ret = H5I__iterate_cb((void *)id_info_ptr, NULL, (void *)&iter_udata);
+                    /* Since this iteration may be called in parallel with other 
+                     * operations on the target id type, it is possible that the 
+                     * target ID will be deleted during the iterate callback.  
+                     * 
+                     * To prevent this, increment the ref count on the target ID
+                     * before we call the itterate callback, and decrement it again
+                     * when that call returns.
+                     *
+                     * While this isn't fool proof, it should work absent 
+                     * coding errors elsewhere.
+                     *
+                     * At present, we do this with calls to H5I_inc_ref_internal()
+                     * and H5I__dec_ref().  This is very inefficient as it requires
+                     * two unnecessary calls to H5I__find_id(), in addition to 
+                     * other issues.  This is acceptable for the prototype, but
+                     * we need to do better for the production version.
+                     *
+                     * Note also that the call to H5I_inc_ref_internal() may fail.
+                     * If it does, presume that this is due to the target ID being
+                     * deleted out from under the itteration, and just go on to the 
+                     * next ID.
+                     */
 
-                    if (H5_ITER_ERROR == ret)
-                        HGOTO_ERROR(H5E_ID, H5E_BADITER, FAIL, "iteration failed");
+                    if ( -1 != H5I_inc_ref_internal(id_info_ptr->id, FALSE) ) {
 
-                    if (H5_ITER_STOP == ret)
-                        break;
+                        int ret;  /* return value for iterate cb */
+
+                        /* inc ref was successful -- call the iterate callback */
+
+                        ret = H5I__iterate_cb((void *)id_info_ptr, NULL, (void *)&iter_udata);
+
+                        /* decrement the ref count again before we check the iterate 
+                         * callback return value.
+                         */
+                        if ( H5I__dec_ref(id_info_ptr->id, NULL, FALSE) < 0 )
+
+                            HGOTO_ERROR(H5E_ID, H5E_CANTDEC, (-1), "can't decrement ID ref count");
+
+                        /* Now check results of the iteration */
+
+                        if (H5_ITER_ERROR == ret)
+                            HGOTO_ERROR(H5E_ID, H5E_BADITER, FAIL, "iteration failed");
+
+                        if (H5_ITER_STOP == ret)
+                            break;
+
+                    } else {
+
+                        /* ID was deleted out from under us -- update stats and go on 
+                         * to the next ID if it exists.
+                         */
+                    }
                 }
             } while (lfht_get_next(&(type_info_ptr->lfht), id, &id, &value));
         }
@@ -7823,6 +8359,7 @@ H5I__find_id(hid_t id)
     hbool_t                 do_not_disturb_set;
     hbool_t                 done = FALSE;
     hbool_t                 have_global_mutex = TRUE; /* trivially true in the serial case */
+    hbool_t                 global_mutex_acquired;
     hbool_t                 cls_is_mt_safe;
     hbool_t                 bool_result;
     int                     pass = 0;
@@ -7832,6 +8369,7 @@ H5I__find_id(hid_t id)
     H5I_mt_id_info_t       *id_info_ptr        = NULL; /* ID's info */
     H5I_mt_id_info_t       *dup_id_info_ptr;
     H5I_mt_id_info_t       *last_id_info_ptr   = NULL; /* ID's info */
+    H5I_mt_id_info_kernel_t init_info_k;
     H5I_mt_id_info_kernel_t info_k;
     H5I_mt_id_info_kernel_t mod_info_k;
     H5I_mt_id_info_t       *ret_value          = NULL; /* Return value */
@@ -7846,6 +8384,12 @@ H5I__find_id(hid_t id)
 
 #if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
 
+    /* We don't throw an error if H5TS_have_mutex() fails, since H5I__find_id() 
+     * doesn't have an error reporting mechanism -- it either finds the target
+     * or not.  
+     *
+     * Think on improving this in the production version.
+     */
     if ( H5TS_have_mutex(&H5_g.init_lock, &have_global_mutex) < 0 )
 
         HGOTO_DONE(NULL);
@@ -7863,14 +8407,21 @@ H5I__find_id(hid_t id)
 
     /* Check arguments */
     type = H5I_TYPE(id);
-    if (type <= H5I_BADID || (int)type >= atomic_load(&(H5I_mt_g.next_type)))
+    if ( type <= H5I_BADID || (int)type >= atomic_load(&(H5I_mt_g.next_type)) ) {
+
         HGOTO_DONE(NULL);
+    }
 
     do {
 
         do_not_disturb_set = FALSE;
+        global_mutex_acquired = FALSE;
         type_info_ptr = NULL;
         id_info_ptr = NULL;
+
+        memset(&init_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+        memset(&info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+        memset(&mod_info_k, 0, sizeof(H5I_mt_id_info_kernel_t));
 
         /* increment the pass and log retries */
         if ( pass++ >= 1 ) {
@@ -7911,9 +8462,9 @@ H5I__find_id(hid_t id)
 
         if ( id_info_ptr ) {
 
-            info_k = atomic_load(&(id_info_ptr->k));
+            init_info_k = atomic_load(&(id_info_ptr->k));
 
-            if ( info_k.marked ) {
+            if (init_info_k.marked) {
 
                 /* the ID is marked for deletion -- nothing to do here.  Set
                  * id_info_ptr to NULL and break out of the loop
@@ -7929,7 +8480,7 @@ H5I__find_id(hid_t id)
              * negatives in the test bed.  Thus do the thread yield if info_k.do_not_disturb is TRUE,
              * regardless of the value of info_k.is_future.
              */
-            if ( info_k.do_not_disturb ) {
+            if (init_info_k.do_not_disturb) {
 
                 /* It is possible that this call into H5I is recursive.  If so, it is possible to
                  * deadlock on the do_not_discurb flag.  To avoid this, we check to see if the 
@@ -7941,9 +8492,18 @@ H5I__find_id(hid_t id)
                  * the regression tests.  A more general solution is needed for the production 
                  * version.
                  */
-                if ( ( have_global_mutex ) && ( info_k.have_global_mutex ) ) {
+#if H5I_BYPASS_HDF5_TID
+                if ( ( have_global_mutex ) && ( pthread_equal(init_info_k.tid, pthread_self()) ) ) {
 
-                    atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_bypasses), 1ULL);
+                    assert( init_info_k.tid_valid );
+#else
+                if ( ( have_global_mutex ) && ( init_info_k.tid == H5TS_thread_id()) ) {
+
+                    assert( 0 != init_info_k.tid );
+#endif
+                    assert( init_info_k.have_global_mutex );
+
+                    atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_recursions), 1ULL);
 
                 } else {
 
@@ -7967,7 +8527,7 @@ H5I__find_id(hid_t id)
                 }
             }
 
-            if ( info_k.is_future ) {
+            if ( init_info_k.is_future ) {
 
                 /* we must try to resolve the future ID.  This requires 
                  * the following three operations:
@@ -8044,22 +8604,44 @@ H5I__find_id(hid_t id)
                  * thread may have realized the ID.
                  */
 
-                mod_info_k.count             = info_k.count;
-                mod_info_k.app_count         = info_k.app_count;
-                mod_info_k.object            = info_k.object;
+                mod_info_k.count     = init_info_k.count;
+                mod_info_k.app_count = init_info_k.app_count;
+                mod_info_k.object    = init_info_k.object;
+#if H5I_BYPASS_HDF5_TID
+                mod_info_k.tid_valid = FALSE;
+#else
+                mod_info_k.tid       = 0ULL;
+#endif
 
-                mod_info_k.marked            = info_k.marked;
+                mod_info_k.marked            = init_info_k.marked;
                 mod_info_k.do_not_disturb    = TRUE;
-                mod_info_k.is_future         = info_k.is_future;
+                mod_info_k.is_future         = init_info_k.is_future;
+                mod_info_k.have_global_mutex = FALSE;
 
-                /* set mod_info_k.have_global_mutex to TRUE if either this thread has the 
-                 * global mutex or the class is not multi-thread safe.  Set mod_info_k.have_global_mutex
-                 * to TRUE in the latter case since we must grab the global mutex before calling
+                /* Overwrite mod_info_k.have_global_mutex and and mod_info_k.tid with TRUE and 
+                 * H5TS_thread_id() respectively if either this thread has the global mutex or 
+                 * the class is not multi-thread safe.  
+                 *
+                 * Do this in  the latter case since we must grab the global mutex before calling
                  * the realize callback and drop it when it returns.
                  */
-                mod_info_k.have_global_mutex = ((have_global_mutex) || (! cls_is_mt_safe));
+                if ( ( have_global_mutex ) || ( ! cls_is_mt_safe ) ) {
 
-                if ( ! atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k ) ) {
+#if H5I_BYPASS_HDF5_TID
+                    mod_info_k.tid               = pthread_self();
+                    mod_info_k.tid_valid         = TRUE;
+
+                    mod_info_k.have_global_mutex = TRUE;
+#else
+                    mod_info_k.tid               = H5TS_thread_id();
+
+                    mod_info_k.have_global_mutex = TRUE;
+
+                    assert( 0 < mod_info_k.tid );
+#endif
+                }
+
+                if (!atomic_compare_exchange_strong(&(id_info_ptr->k), &init_info_k, mod_info_k)) {
 
                     /* Some other thread changed the value of id_info_ptr->k since we last read
                      * it.  Thus we must return to the beginning of the do loop and start
@@ -8076,10 +8658,6 @@ H5I__find_id(hid_t id)
 
                     do_not_disturb_set = TRUE;
 
-#if 0 /* JRM */
-                    /* make info_k into a copy of the global kernel */
-                    info_k.do_not_disturb = TRUE;
-#else /* JTM */
                     /* On the face of it, it would seem that we could just update info_k
                      * to match mod_info_k, and use it in the next atomic_compare_exchange_strong()
                      * call.  However, for reason or reasons unknown, this doesn't work.
@@ -8092,17 +8670,28 @@ H5I__find_id(hid_t id)
                     assert(info_k.count             == mod_info_k.count);
                     assert(info_k.app_count         == mod_info_k.app_count);
                     assert(info_k.object            == mod_info_k.object);
+#if H5I_BYPASS_HDF5_TID
+                    assert( info_k.tid_valid == mod_info_k.tid_valid );
+                    assert( ( ! mod_info_k.tid_valid ) || ( pthread_equal(info_k.tid, mod_info_k.tid) ) );
+#else
+                    assert(info_k.tid == mod_info_k.tid);
+#endif
 
                     assert(info_k.marked            == mod_info_k.marked);
                     assert(info_k.do_not_disturb    == mod_info_k.do_not_disturb);
                     assert(info_k.is_future         == mod_info_k.is_future);
                     assert(info_k.have_global_mutex == mod_info_k.have_global_mutex);
-#endif /* JRM */
+
 
                     /* setup mod_info_k to reset the do_not_disturb flag.  If we are successful
                      * at realizing the future ID, we will make further changes to mod_info_k
                      * before we use it to overwrite id_info_ptr->k.
                      */
+#if H5I_BYPASS_HDF5_TID
+                    mod_info_k.tid_valid         = FALSE;
+#else
+                    mod_info_k.tid               = 0ULL;
+#endif
                     mod_info_k.do_not_disturb    = FALSE;
                     mod_info_k.have_global_mutex = FALSE;
 
@@ -8114,6 +8703,115 @@ H5I__find_id(hid_t id)
                               (unsigned long long)(id_info_ptr->id));
 #endif /* H5I_MT_DEBUG_DO_NOT_DISTURB */
                 }
+
+                if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
+
+                    /* Since the class is not mult-thread safe, and we don't currently
+                     * hold it, we must obtain the the global mutex before proceeding.
+                     *
+                     * If we were able to enforce lock ordering between locking an ID and
+                     * obtaining the global mutex, we would simply do this via H5_API_LOCK.
+                     *
+                     * While this still works if we don't have to lock the target ID
+                     * (i.e. the cant_roll_back flag is false, and the ID was not locked
+                     * on entry -- always true in this function), there is the potential
+                     * for a deadlock if the do_not_disturb flag is aready set.
+                     *
+                     * We resolve this by using the H5TS_mutex_acquire() call to attempt
+                     * to obtain the global mutex without blocking.
+                     *
+                     * If H5TS_mutex_acquire() succeeds, we invoke the callback and then
+                     * drop the global mutex as usual.
+                     *
+                     * If, however, H5TS_mutex_acquire() fails to obtain the global mutex,
+                     * we must clear the do not disturb flag on the target id, either
+                     * thread yield or sleep a bit, and return to the beginning of the
+                     * do loop.
+                     */
+    
+                    assert( do_not_disturb_set );
+
+                    atomic_fetch_add(&(H5I_mt_g.global_mutex_acquire_attempts), 1ULL);
+    
+                    if ( H5TS_mutex_acquire(&H5_g.init_lock, 1, &global_mutex_acquired) < 0 ) {
+    
+                        /* the call to H5TS_mutex_acquire() returned an error.  Drop the
+                         * do not disturb flag on the target ID if set in this function, and
+                         * throw an error.
+                         */
+    
+                        /* since we have the do_not_disturb flag, the following
+                         * atomic_compare_exchange_strong() must succeed.
+                         */
+                        assert( mod_info_k.do_not_disturb );
+                        assert( mod_info_k.have_global_mutex );
+                        assert( ! init_info_k.do_not_disturb );
+                        assert( ! init_info_k.have_global_mutex );
+    
+                        /* reset the kernel to its initial value */
+    
+                        bool_result = atomic_compare_exchange_strong(&(id_info_ptr->k), &mod_info_k, 
+                                                                     init_info_k);
+    
+                        assert(bool_result);
+    
+                        atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
+
+                        /* we should throw an error here, but H5I__find_id() doesn't let us in 
+                         * its current form.  Fix this in the production version.
+                         *
+                         * For now, just throw an assertion, and call HGOTO_DONE(NULL).
+                         *
+                         * In production mode, this should cause the function return failure.
+                         */
+                        assert(FALSE);
+                        HGOTO_DONE(NULL);
+
+                    } else { /* H5TS_mutex_acquire() completed without error */
+    
+                        if ( ! global_mutex_acquired ) {
+#if 0
+                            fprintf(stderr, "%s: H5TS_mutex_acquire() failed to acquire global mutex\n",
+                                    "H5I__find_id()");
+#endif
+                            atomic_fetch_add(&(H5I_mt_g.global_mutex_acquire_failures), 1ULL);
+
+                            /* the attempt to acquire the global mutex failed -- presumably because
+                             * some other thread holds it.
+                             *
+                             * This may or may not be a deadlock -- but since we can't tell, we will
+                             * assume it is.  Drop the do_not_disturb flag on the target ID, update
+                             * stats, sleep a little, and retry.
+                             */
+    
+                            /* since we have the do_not_disturb flag, the following
+                             * atomic_compare_exchange_strong() must succeed.
+                             */
+                            assert( mod_info_k.do_not_disturb );
+                            assert( mod_info_k.have_global_mutex );
+                            assert( ! init_info_k.do_not_disturb );
+                            assert( ! init_info_k.have_global_mutex );
+    
+                            bool_result = atomic_compare_exchange_strong(&(id_info_ptr->k), &mod_info_k,
+                                                                         init_info_k);
+                            assert(bool_result);
+    
+                            atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
+                            atomic_fetch_add(&(H5I_mt_g.num_deadlock_evasions), 1ULL);
+    
+                            sleep(1);
+    
+                            continue;
+    
+                        } else { /* global mutext acquired */
+    
+                            /* success -- update stats  */
+                            atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_realize_cb), 
+                                             1ULL);
+                            atomic_fetch_add(&(H5I_mt_g.global_mutex_acquire_successes), 1ULL);
+                        }
+                    }
+                } /* if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) */
             }
 
             assert( ( ! info_k.is_future ) || ( do_not_disturb_set ) );
@@ -8127,31 +8825,16 @@ H5I__find_id(hid_t id)
                 const void * actual_object = NULL;
                 const void * future_object = NULL;
 
+                assert( ( have_global_mutex ) || ( global_mutex_acquired ) );
+
                 atomic_fetch_add(&(H5I_mt_g.H5I__find_id__num_calls_to_realize_cb), 1ULL);
                     
                 /* Invoke the realize callback, to get the actual object.  If this
                  * call fails, we must reset the do_not_disturb flag and return NULL
-                 *
-                 * If we don't have the global mutex, and the class is not multi-thread
-                 * safe, grab the global mutex before the call and drop it immediately 
-                 * afterwards.
                  */
-                if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
-
-                    atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_realize_cb), 1ULL);
-                    H5_API_LOCK
-                    H5_GCC_CLANG_DIAG_OFF("cast-qual")
-                    result = (id_info_ptr->realize_cb)((void *)info_k.object, &actual_id);
-                    H5_GCC_CLANG_DIAG_ON("cast-qual")
-                    H5_API_UNLOCK
-                    atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_realize_cb), 1ULL);
-
-                } else {
-
-                    H5_GCC_CLANG_DIAG_OFF("cast-qual")
-                    result = (id_info_ptr->realize_cb)((void *)info_k.object, &actual_id);
-                    H5_GCC_CLANG_DIAG_ON("cast-qual")
-                }
+                H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                result = (id_info_ptr->realize_cb)((void *)info_k.object, &actual_id);
+                H5_GCC_CLANG_DIAG_ON("cast-qual")
 
                 if ( result < 0 ) {
 
@@ -8209,26 +8892,16 @@ H5I__find_id(hid_t id)
 
                     atomic_fetch_add(&(H5I_mt_g.H5I__find_id__num_calls_to_discard_cb), 1ULL);
 
-                    /* Discard the future object.  If we don't hold the global mutex and 
-                     * the class is not multi-thread safe, grab the global mutex before 
-                     * the call to the discard_cb, and drop it immediately on return.
-                     */
-                    if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
+                    if ( global_mutex_acquired ) {
 
                         atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_discard_cb), 1ULL);
-                        H5_API_LOCK
-                        H5_GCC_CLANG_DIAG_OFF("cast-qual")
-                        result = (id_info_ptr->discard_cb)((void *)future_object);
-                        H5_GCC_CLANG_DIAG_ON("cast-qual")
-                        H5_API_UNLOCK
-                        atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_discard_cb), 1ULL);
-
-                    } else {
-
-                        H5_GCC_CLANG_DIAG_OFF("cast-qual")
-                        result = (id_info_ptr->discard_cb)((void *)future_object);
-                        H5_GCC_CLANG_DIAG_ON("cast-qual")
                     }
+
+                    /* Discard the future object. */
+                    atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_discard_cb), 1ULL);
+                    H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                    result = (id_info_ptr->discard_cb)((void *)future_object);
+                    H5_GCC_CLANG_DIAG_ON("cast-qual")
 
                     if ( result < 0 ) {
 
@@ -8260,6 +8933,16 @@ H5I__find_id(hid_t id)
                     }
 
                     future_object = NULL;
+                }
+
+                /* drop the global mutex if it was acquired */
+                if ( global_mutex_acquired ) {
+                    
+                    H5_API_UNLOCK
+                    
+                    atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_realize_cb), 1ULL);
+                    atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_discard_cb), 1ULL);
+
                 }
             }
 
@@ -8774,6 +9457,11 @@ H5I__discard_mt_id_info(H5I_mt_id_info_t * id_info_ptr)
     assert(0 == info_k.count);
     assert(0 == info_k.app_count);
     assert(NULL == info_k.object);
+#if H5I_BYPASS_HDF5_TID
+    assert(FALSE == info_k.tid_valid);
+#else
+    assert(0ULL == info_k.tid);
+#endif
     assert(TRUE == info_k.marked);
     assert(FALSE == info_k.do_not_disturb);
     assert(FALSE == info_k.is_future);
@@ -9050,7 +9738,7 @@ H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * o
     hbool_t result;
     H5I_mt_id_info_t * id_info_ptr = NULL;
     H5I_mt_id_info_sptr_t fl_shead;
-    H5I_mt_id_info_sptr_t new_fl_shead;;
+    H5I_mt_id_info_sptr_t new_fl_shead;
     H5I_mt_id_info_sptr_t test_fl_shead;
     H5I_mt_id_info_sptr_t fl_stail;
     H5I_mt_id_info_sptr_t new_fl_stail;
@@ -9063,9 +9751,15 @@ H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * o
     FUNC_ENTER_NOAPI(NULL)
 
     memset(&new_k, 0, sizeof(H5I_mt_id_info_kernel_t));
+
     new_k.count = count;
     new_k.app_count = app_count;
     new_k.object = object;
+#if H5I_BYPASS_HDF5_TID
+    new_k.tid_valid         = FALSE;
+#else
+    new_k.tid               = 0ULL;
+#endif
     new_k.marked = FALSE;
     new_k.do_not_disturb = FALSE;
     new_k.is_future = is_future;
@@ -9257,7 +9951,7 @@ H5I__clear_mt_type_info_free_list(void)
     H5I_mt_type_info_sptr_t fl_head;
     H5I_mt_type_info_sptr_t null_snext = {NULL, 0ULL};
     H5I_mt_type_info_t    * fl_head_ptr;
-    H5I_mt_type_info_t    * type_info_ptr;;
+    H5I_mt_type_info_t    * type_info_ptr;
     herr_t                  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_NOAPI(FAIL)
@@ -9650,7 +10344,7 @@ H5I__discard_mt_type_info(H5I_mt_type_info_t * type_info_ptr)
 static H5I_mt_type_info_t * 
 H5I__new_mt_type_info(const H5I_class_t *cls, unsigned reserved)
 {
-    hbool_t fl_search_done = FALSE;;
+    hbool_t fl_search_done = FALSE;
     hbool_t result;
     H5I_mt_type_info_t * type_info_ptr = NULL;
     H5I_mt_type_info_sptr_t fl_shead;

--- a/src/H5Ipkg.h
+++ b/src/H5Ipkg.h
@@ -29,6 +29,13 @@
 /* Package Private Macros */
 /**************************/
 
+/* To route around the HDF5 thread ID code (i.e. avoid the use of H5TS_thread_id() 
+ * set H5I_BYPASS_HDF5_TID to 1.  This configures the multi-thread version of H5I
+ * to use the pthreads thread ID facilities instead -- hopefully bypassing the 
+ * segfault in the multi-thread API tests.
+ */
+#define H5I_BYPASS_HDF5_TID 1
+
 /*
  * Number of bits to use for ID Type in each ID. Increase if more types
  * are needed (though this will decrease the number of available IDs per
@@ -893,6 +900,29 @@ typedef struct H5I_suint64_t {
  *      H5T_is_named().
  *
  *
+ * Statistics on the behaviour of the H5I_get_first/next() functions. 
+ *
+ * H5I_get_first__num_calls: Number of times that H5I_get_first() is called.
+ *
+ * H5I_get_first__type_empty; Number of times that H5I_get_first() is called 
+ *      on an empty id type.
+ *
+ * H5I_get_first__ids_deleted_in_progress: Number of times that an id is 
+ *      found as the first id in the type, and then deleted before the 
+ *      associated void pointer is un-wrapped.  Note that this condition
+ *      is only tested for if H5I__UNWRAP_IS_NOOP(type) is FALSE.
+ *
+ * H5I_get_next__num_calls; Number of times that H5I_get_next() is called.
+ *
+ * H5I_get_next__no_next_id: Number of times that H5I_get_next() is called
+ *      on an id type with no remaining un-visited ids.
+ *
+ * H5I_get_next__ids_deleted_in_progress: Number of times that an id is
+ *      found as the next id in the type, and then deleted before the
+ *      associated void pointer is un-wrapped.  Note that this condition
+ *      is only tested for if H5I__UNWRAP_IS_NOOP(type) is FALSE.
+ *
+ *
  * Statistics on operations on the do not disturb flag.  See the discussion of 
  * the this fields and the kernel in the comments on H5I_mt_id_info_t for further 
  * details.
@@ -913,8 +943,44 @@ typedef struct H5I_suint64_t {
  *      this operation will always succeed.  If it doesn't, it should trigger an 
  *      assertion failure.
  *
- * num_do_not_disturb_bypasses:  Number of times that a do_not_disturb has been 
- *      bypassed.  At present, this is permitted for read only accesses to IDs.
+ * num_do_not_disturb_recursions: Number of times that a thread skips setting 
+ *      and then re-setting the do_not_disturb flag because the do_not_disturb
+ *      flag is already set by the thread.
+ *
+ *      Note that at present, there must be no net change in the kernel of 
+ *      the target ID by the time the do_not_disturg flag is droped.
+ *
+ *
+ * Global mutex acquire / dealock avoidance stats 
+ *
+ * Interaction with the existing non multi-thread makes it impossible to maintain 
+ * lock ordering between the global mutex and the do not disturb flag on individual 
+ * IDs.  This in turn opens the possibility of deadlocks.
+ *
+ * To address this issue, we use H5TS_mutex_acquire() to obtain the global mutex
+ * whenever we already hold the do_not_disturb flag on the target ID.  This function
+ * attempts to obtain the global mutex, but returns immediately regardless of 
+ * success.  If this attempt to obtain the global mutex fails, we drop the 
+ * do_not_disturb flag on the target ID, wait a bit, and try again so as to 
+ * avoid the potential deadlock.
+ *
+ * The following fields are used to collect statistics on this method of deadlock
+ * avoidance.
+ *
+ * global_mutex_acquire_attempts: Number of calls to H5TS_mutex_acquire().
+ *
+ * global_mutex_acquire_successes: Number of times H5TS_mutex_acquire() successfully 
+ *      obtains the global mutex.
+ *
+ * global_mutex_acquire_failures: Number of times H5TS_mutex_acquire() fails to 
+ *      obtain the global mutex without reporting any errors.
+ *
+ * num_deadlock_evasions: Number of times a potential deadlock is detected and 
+ *      avoided.  At present this means that the do_not_disturb is held on an 
+ *      ID, that continued processing requires the global mutex, and that the 
+ *      attempt to obtain the global mutex via H5TS_mutex_acquire() fails.  In
+ *      this case, the do_not_disturb is droped to avoid the potential mutex,
+ *      and then retried.
  *
  *
  * Statistics on H5I entries and numbers of threads active in H5I.
@@ -1151,12 +1217,26 @@ typedef struct H5I_mt_t {
     _Atomic uint64_t H5I_is_file_object__global_mutex_locks_for_H5T_is_named;
     _Atomic uint64_t H5I_is_file_object__global_mutex_unlocks_for_H5T_is_named;
 
+    /* H5I_get_first/next() stats */
+    _Atomic uint64_t H5I_get_first__num_calls;
+    _Atomic uint64_t H5I_get_first__type_empty;
+    _Atomic uint64_t H5I_get_first__ids_deleted_in_progress;
+    _Atomic uint64_t H5I_get_next__num_calls;
+    _Atomic uint64_t H5I_get_next__no_next_id;
+    _Atomic uint64_t H5I_get_next__ids_deleted_in_progress;
+
     /* do not disturb flag stats */
     _Atomic uint64_t num_do_not_disturb_yields;
     _Atomic uint64_t num_successful_do_not_disturb_sets;
     _Atomic uint64_t num_failed_do_not_disturb_sets;
     _Atomic uint64_t num_do_not_disturb_resets;
-    _Atomic uint64_t num_do_not_disturb_bypasses;
+    _Atomic uint64_t num_do_not_disturb_recursions;
+
+    /* global mutex acquire / dealock avoidance stats */
+    _Atomic uint64_t global_mutex_acquire_attempts;
+    _Atomic uint64_t global_mutex_acquire_successes;
+    _Atomic uint64_t global_mutex_acquire_failures;
+    _Atomic uint64_t num_deadlock_evasions;
 
     /* active_threads stats */
     _Atomic uint64_t num_H5I_entries_via_public_API;
@@ -1244,6 +1324,13 @@ typedef struct H5I_mt_t {
  * 
  *      We do this by adding three flags to the kernel -- the already defined 
  *      marked flag, the new do_not_disturb flag, and the new have_global_mutex flag.
+ *
+ *      While it wasn't immediately apparent, this notion of locking IDs also introduced
+ *      lock ordering issues which appear unavoidable as long as portions of the HDF5 
+ *      library are not multi-thread safe.. Resolving these for the prototype required 
+ *      the additons of an additional thread ID field (tid), which is used to store the ID 
+ *      of the thread that set the the do_not_disturb flag.
+ *      
  *      We then proceed via the appropriate protocol as given below. 
  * 
  *      In the cases where roll backs are possible, proceed as follows: 
@@ -1253,16 +1340,17 @@ typedef struct H5I_mt_t {
  *       2) Check to see if the marked flag is set.  If so, issue an ID doesn’t exist 
  *          error and return. 
  * 
- *       3) Check to see if the do_not_disturb flag is set.  If so, and either the 
- *          have_global_mutex flag is not set, or the thread does not hold the 
- *          global mutex, do a thread yield or sleep, and return to 1) above. 
+ *       3) Check to see if the do_not_disturb flag is set.  
  *
- *          If the thread holds the global mutex, and the have_global_mutex flag
- *          is set, the current thread is the thread that caused the do_not_disturb
- *          flag to be set, and may proceed.  As shall be seen, while reading the 
- *          will not cause problems, modifying it will.  To date, this is not a 
- *          problem in all cases encounterd to date, but it will have to be addressed
- *          for the production version.
+ *          If it is, and k.tid does not match the ID of the current thread, 
+ *          do a thread yield or sleep, and return to 1) above.
+ *
+ *          If it is, and k.tid does match the ID of the current thread, the 
+ *          current thread is the thread that caused the do_not_disturb
+ *          flag to be set, and may proceed.  As shall be seen, while reading will
+ *          not cause problems, modifying the kernel will.  To date, this is not 
+ *          a problem in all cases encounterd to date, but it will have to be 
+ *          addressed for the production version.
  *  
  *       4) Perform the desired operations (i.e ref count increment or decrement, or 
  *          object pointer overwite on the local copy of the kernel.  If the ref 
@@ -1288,18 +1376,17 @@ typedef struct H5I_mt_t {
  *       2) Check to see if the marked flag is set.  If so, issue an ID doesn’t exist 
  *          error and return. 
  * 
- *       3) Check to see if the do_not_disturb flag is set.  If so, and either the
- *          have_global_mutex flag is not set, or the thread does not hold the
- *          global mutex, do a thread yield or sleep, and return to 1) above.
+ *       3) Check to see if the do_not_disturb flag is set.
  *
- *          If the thread holds the global mutex, and the have_global_mutex flag
- *          is set, the current thread is the thread that caused the do_not_disturb
- *          flag to be set, and may proceed.  As shall be seen, while reading the
- *          kernel will not cause problems, modifying it will.  As a result, such
- *          threads must skip the remainder of this protocol.  
+ *          If it is, and k.tid does not match the ID of the current thread,
+ *          do a thread yield or sleep, and return to 1) above.
  *
- *          To date, this is not a problem in all cases encounterd, but it will 
- *          have to be addressed in the production version.
+ *          If it is, and k.tid does match the ID of the current thread, the
+ *          current thread is the thread that caused the do_not_disturb
+ *          flag to be set, and may proceed.  As shall be seen, while reading will
+ *          not cause problems, modifying the kernel will.  To date, this is not  
+ *          a problem in all cases encounterd to date, but it will have to be 
+ *          addressed for the production version.
  * 
  *       4) Check to see if the desired operation is still pending (i.e. if the 
  *          operation is converting a future ID to a real ID, is the is_future flag 
@@ -1308,41 +1395,64 @@ typedef struct H5I_mt_t {
  * 
  *          Otherwise: 
  * 
- *       5) Set the do_not_disturb flag and the have_global_mutex flag as well if 
- *          either the global mutex is already held, or if the callback is not thread
- *          safe (always for now) in the local copy of the kernel, and attempt 
- *          to overwrite the global copy of the kernel with the local copy via a 
- *          compare_exchange_strong(). 
+ *       5) In the locak copy of the kernel, set the do_not_disturb flag to TRUE, 
+ *          and the tid field to the ID of the current thread.  
+ *
+ *          Also in the locka copy, set the have_global_mutex flag as well if either 
+ *          the global mutex is already held, or if the callback is not thread safe 
+ *          (always for now).  Then attempt to overwrite the global copy of the 
+ *          kernel with the local copy via a compare_exchange_strong().
  * 
  *          If this fails, do a thread yield or sleep, and return to 1. 
  * 
  *          If it succeeds, we know that a thread has exclusive access to the kernel until 
- *          we reset the do_not_disturb flag on the global copy, as no new thread 
+ *          we reset the do_not_disturb flag on the global copy, as no other thread
  *          looking at the kernel will proceed beyond reading the flag, and the 
  *          compare_exchange_strong() of any existing thread attempting to modify the 
  *          kernel will fail -- sending it back to step 1. 
  * 
- *       6) Attempt to perform the desired operation. 
+ *       6) If the callback is not thread safe, and the current thread doesn't 
+ *          already hold the global mutex, we must attempt to obtain it.  
  * 
- *          If this fails, reset the do_not_disturb and the have_global_mutex flags in 
- *          the local copy of the kernel, overwrite the global copy of the kernel with 
- *          the local copy via a compare_exchange_strong(), and report the failure of 
- *          the operation if appropriate.
+ *          If we could maintain lock ordering, we would simply block until we 
+ *          obtain it.  Unfortunately, because we have to interface with the 
+ *          non multi-thread safe sections of the HDF5 library, we can't maintian
+ *          lock ordering betwee locks on IDs and the global mutext.
  * 
- *          Observe that the call to compare_exchange_strong() must succeed, per the 
- *          argument given in the final paragraph in 5 above.  Note that we use 
- *          compare_exchange_strong() in this case only as a sanity check.  Assuming  
- *          my analysis is correct, we could simply use atomic_store() on  
- *          architectures where compare_exchange_strong() is not available.   
- *          Unfortunately, the rest of the algorithm does depend on 
- *          compare_exchange_strong(), so it will have to be re-worked for those
- *          architectures. 
+ *          Thus we must attempt to acquire the global mutext, and not block if 
+ *          it is not available.
  * 
- *          If the operation succeeds, update the kernel accordingly, reset the 
- *          do_not_disturb and have_global_mutex flags in the local copy of the kernel, 
- *          and overwrite the global copy of the kernel with the local copy via a 
- *          compare_exchange_strong().  As before this operation must succeed, and we
- *          are done. 
+ *          If the attempt to acquire the global mutex succeeeds, we proceed to 
+ *          7).  Otherwise, we reset the do_not_disturb flag, set the tid to zero,
+ *          and reset the have global mutex flag if they were modified in step 5).  
+ *          Do this with a compare exchange strong, which must succeed.  Then
+ *          do a thread yield or sleep, and goto 1).
+ *
+ *       7) Attempt to perform the desired operation.
+ *
+ *          If this fails, clean up as follwos:
+ *
+ *          a) If the kernel was modified in 5), reset the tid and the 
+ *             do_not_disturb and have_global_mutex flags in the local copy of 
+ *             the kernel, and overwrite the global copy of the kernel with the 
+ *             local copy via a compare_exchange_strong().  Note that this 
+ *             operation must succeed -- the compare_exchange_strong() is for 
+ *             sanity checking.
+ *
+ *          b) If the global mutext was obtained in 6), release it.
+ *
+ *          c) Report failure of the operation if appropriate.
+ *
+ *          if it succeeds: 
+ *
+ *          a) Update the local copy of the kernel as appropriate.  If the 
+ *             kernel was modified in 5) above, also reset the tid and the 
+ *             do_not_disturb and have_global_mutex flags in the local copy of 
+ *             the kernel, and overwrite the global copy of the kernel with the 
+ *             local copy via a compare_exchange_strong().  As before, this 
+ *             operation must succeed.
+ *
+ *          b) If the global mutext was obtained in 6), release it.
  * 
  *      An atomic instance of H5I_mt_id_info_kernel_t is used to instantiate the 
  *      kernel mentioned above.  It maintains its fields as a single atomic object. 
@@ -1351,12 +1461,12 @@ typedef struct H5I_mt_t {
  *      objective is to avoid explicit locking (and thus lock ordering concerns) this 
  *      is fine -- for now at least. 
  *
- *      Note that if we combined all the booleans in a flags field, 
+ *      Note that if we combined all the booleans in a flags field, removed the tid,
  *      and reduced the size of the count and app_count integers, we could fit the 
  *      H5I_mt_id_info_kernel_t into 128 bits, allowing true atomic operation on 
  *      many (most) more modern CPUs.  However, that is an optimization for another 
  *      day, as is re-working the future ID feature into something more multi-thread
- *      friendly.
+ *      friendly, and making the result of the free_func predictable..
  * 
  *      Since H5I_mt_id_info_kernel_t is only used either in H5I_mt_id_info_t, or to 
  *      stage reads and writes of the kernal in that structure, its fields are 
@@ -1373,6 +1483,16 @@ typedef struct H5I_mt_t {
  * 
  *      k.object: Pointer to void.  Points to the data (if any) associated with
  *           this ID. 
+ *
+ *      k.tid: ID of the thread that set the do_not_disturb flag.  This is necessary
+ *           for now to allow correct recursive access to an ID whose do_not_disturb
+ *           flag has been set.  
+ *
+ *           The ID stored in this field is obtained via calls to H5TS_thread_id(),
+ *           
+ *           The field is only valid wehn the do_not_distrub flag is set.  For 
+ *           clarity, the fields should be initialized to zero, and be returned 
+ *           to this value whenever the do_not_disturb flag is reset.
  * 
  *      k.marked: Boolean flag indicating whether this instance of H5I_mt_id_info_t 
  *           has been marked for deletion.  Once set, this flag is never re-set, and 
@@ -1391,21 +1511,13 @@ typedef struct H5I_mt_t {
  *           k.do_not_disturb is set to TRUE, and the setting thread has the HDF5
  *           global mutex at the time.
  * 
- *           This field is a temporary hack designed allow HDF5 callbacks to access 
- *           the index without deadlocking.  Thus, when the do_not_disturb flag is 
- *           detected, it can be ignored if the have_global_mutex flag is set and the 
- *           current thread has the global mutext.
- *
- *           If the do_not_disturb flag is not replaced with an off the shelf recursive
- *           lock, this field will almost certainly be replace with a thread ID stored in
- *           H5I_mt_id_info_t proper, and set whenever k.do_not_disturb is set.  While
- *           this will make k.do_not_disturb into a recursive lock, it will also 
- *           require additional logic to allow for the possibility that the kernel 
- *           has been modified while the k.do_not_disturb flag is set.
+ *           This field was a temporary hack designed allow HDF5 callbacks to access
+ *           the index without deadlocking.  For now, it has been replaced with the 
+ *           tid field, and it will probably be removed soon.
  * 
  *      If we followed the single thread version of H5I exactly, the realize_cb and 
  *      discard_cb would have to be atomic since they are set to NULL when is_future 
- *      is set to FALSE.  However, that doesn't seem necessary, so the are non-atomic 
+ *      is set to FALSE.  However, that doesn't seem necessary, so they are non-atomic
  *      fields in H5I_mt_id_info_t.  This should be OK, as the only time they are
  *      modified is when the instance of H5I_mt_id_info_t is being initialized prior 
  *      to insertion into the index.  Since only one thread has access at that point, 
@@ -1470,6 +1582,12 @@ typedef struct H5I_mt_id_info_kernel_t {
     unsigned                  count;      /* Ref. count for this ID */
     unsigned                  app_count;  /* Ref. count of application visible IDs */
     const void              * object;     /* Pointer associated with the ID */
+#if H5I_BYPASS_HDF5_TID
+    pthread_t   tid;
+    hbool_t     tid_valid;
+#else
+    uint64_t    tid;     
+#endif
 
     hbool_t                   marked;     /* Marked for deletion */
     hbool_t                   do_not_disturb;  

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -200,10 +200,8 @@ H5Oopen_async(const char *app_file, const char *app_func, unsigned app_line, hid
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE7(__func__, "*s*sIui*sii", app_file, app_func, app_line, loc_id, name, lapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref_always_close(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_OHDR, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on object ID");
@@ -337,10 +335,8 @@ H5Oopen_by_idx_async(const char *app_file, const char *app_func, unsigned app_li
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE10(__func__, "*s*sIui*sIiIohii", app_file, app_func, app_line, loc_id, group_name, idx_type, order, n, lapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref_always_close(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_OHDR, H5E_CANTDEC, H5I_INVALID_HID, "can't decrement count on object ID");
@@ -2022,10 +2018,7 @@ H5Oclose(hid_t object_id)
     if (H5O__close_check_type(object_id) <= 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTRELEASE, FAIL, "not a valid object");
 
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
     dec_ref_ret = H5I_dec_app_ref(object_id);
-    H5_API_UNLOCK
 
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTRELEASE, FAIL, "unable to close object");
@@ -2078,10 +2071,8 @@ H5Oclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
     /* Asynchronously decrement reference count on ID.
      * When it reaches zero the object will be closed.
      */
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
+
     dec_ref_ret = H5I_dec_app_ref_async(object_id, token_ptr);
-    H5_API_UNLOCK
 
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTCLOSEFILE, FAIL, "decrementing object ID failed");

--- a/src/H5TS.c
+++ b/src/H5TS.c
@@ -31,6 +31,7 @@
 #include "H5private.h"   /* Generic Functions                        */
 #include "H5Eprivate.h"  /* Error handling                           */
 #include "H5MMprivate.h" /* Memory management                        */
+#include "H5TSprivate.h"
 
 #if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
 
@@ -55,7 +56,6 @@ typedef void *(*H5TS_thread_cb_t)(void *);
 /* Local Prototypes */
 /********************/
 static void   H5TS__key_destructor(void *key_val);
-static herr_t H5TS__mutex_acquire(H5TS_mutex_t *mutex, unsigned int lock_count, bool *acquired);
 static herr_t H5TS__mutex_unlock(H5TS_mutex_t *mutex, unsigned int *lock_count);
 
 static void H5TS_tid_destructor(void *_v);
@@ -396,7 +396,7 @@ H5TS_pthread_first_thread_init(void)
 #endif /* H5_HAVE_WIN_THREADS */
 
 /*--------------------------------------------------------------------------
- * Function:    H5TS__mutex_acquire
+ * Function:    H5TS_mutex_acquire
  *
  * Purpose:     Attempts to acquire a mutex lock, without blocking
  *
@@ -408,12 +408,12 @@ H5TS_pthread_first_thread_init(void)
  * Return:      Non-negative on success / Negative on failure
  *--------------------------------------------------------------------------
  */
-static herr_t
-H5TS__mutex_acquire(H5TS_mutex_t *mutex, unsigned int lock_count, bool *acquired)
+herr_t
+H5TS_mutex_acquire(H5TS_mutex_t *mutex, unsigned int lock_count, bool *acquired)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_PACKAGE_NAMECHECK_ONLY
+    FUNC_ENTER_NOAPI_NAMECHECK_ONLY
 
 #ifdef H5_HAVE_WIN_THREADS
     EnterCriticalSection(&mutex->CriticalSection);
@@ -449,7 +449,7 @@ H5TS__mutex_acquire(H5TS_mutex_t *mutex, unsigned int lock_count, bool *acquired
 #endif /* H5_HAVE_WIN_THREADS */
 
     FUNC_LEAVE_NOAPI_NAMECHECK_ONLY(ret_value)
-} /* end H5TS__mutex_acquire() */
+} /* end H5TS_mutex_acquire() */
 
 /*--------------------------------------------------------------------------
  * Function:    H5TSmutex_acquire
@@ -466,7 +466,7 @@ herr_t
 H5TSmutex_acquire(unsigned int lock_count, bool *acquired){
     FUNC_ENTER_API_NAMECHECK_ONLY
 
-        FUNC_LEAVE_API_NAMECHECK_ONLY(H5TS__mutex_acquire(&H5_g.init_lock, lock_count, acquired))}
+        FUNC_LEAVE_API_NAMECHECK_ONLY(H5TS_mutex_acquire(&H5_g.init_lock, lock_count, acquired))}
 /* end H5TSmutex_acquire() */
 
 /*--------------------------------------------------------------------------

--- a/src/H5TSprivate.h
+++ b/src/H5TSprivate.h
@@ -146,6 +146,7 @@ H5_DLL herr_t H5TS_cancel_count_inc(void);
 H5_DLL herr_t H5TS_cancel_count_dec(void);
 /* (Only used in the multi-thread build) */
 H5_DLL herr_t H5TS_have_mutex(H5TS_mutex_t *mutex, bool *have_mutex_ptr);
+H5_DLL herr_t H5TS_mutex_acquire(H5TS_mutex_t *mutex, unsigned int lock_count, bool *acquired);
 
 /* Testing routines */
 H5_DLL H5TS_thread_t H5TS_create_thread(void *(*func)(void *), H5TS_attr_t *attr, void *udata);

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -742,10 +742,8 @@ H5Topen_async(const char *app_file, const char *app_func, unsigned app_line, hid
         if (H5ES_insert(es_id, vol_obj->connector, token,
                         H5ARG_TRACE7(__func__, "*s*sIui*sii", app_file, app_func, app_line, loc_id, name, tapl_id, es_id)) < 0) {
             /* clang-format on */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref_always_close(ret_value);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDEC, H5I_INVALID_HID,

--- a/src/H5VL.c
+++ b/src/H5VL.c
@@ -478,10 +478,8 @@ H5VLclose(hid_t vol_id)
         HGOTO_ERROR(H5E_VOL, H5E_BADTYPE, FAIL, "not a VOL connector");
 
     /* Decrement the ref count on the ID, possibly releasing the VOL connector */
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
+
     dec_ref_ret = H5I_dec_app_ref(vol_id);
-    H5_API_UNLOCK
 
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "unable to close VOL connector ID");
@@ -527,20 +525,16 @@ H5VLunregister_connector(hid_t vol_id)
         HGOTO_ERROR(H5E_VOL, H5E_BADVALUE, FAIL, "unregistering the native VOL connector is not allowed");
 
     /* The H5VL_class_t struct will be freed by this function */
-    /* TBD: Retain lock to protect ID iteration */
-    H5_API_LOCK
+
     dec_ref_ret = H5I_dec_app_ref(vol_id);
-    H5_API_UNLOCK
 
     if (dec_ref_ret < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "unable to unregister VOL connector");
     
 done:
     if (native_id != H5I_INVALID_HID) {
-        /* TBD: Retain lock to protect ID iteration */
-        H5_API_LOCK
+
         dec_ref_ret = H5I_dec_ref(native_id);
-        H5_API_UNLOCK
 
         if (dec_ref_ret < 0)
             HDONE_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "unable to decrement count on native_id");

--- a/src/H5VLcallback.c
+++ b/src/H5VLcallback.c
@@ -3880,18 +3880,18 @@ H5VL__file_open_find_connector_cb(H5PL_type_t plugin_type, const void *plugin_in
 
 done:
     if (ret_value != H5_ITER_STOP) {
-        /* TBD: Retain lock to protect ID iteration */
+
         if (fapl_id >= 0) {
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref(fapl_id);
-            H5_API_UNLOCK
+
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, H5_ITER_ERROR, "can't close fapl");
         }
         if (connector_id >= 0) {
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_app_ref(connector_id);
-            H5_API_UNLOCK
+
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, H5_ITER_ERROR, "can't close VOL connector ID");
         }

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -102,15 +102,15 @@ static herr_t H5VL__get_registered_connector(H5VL_get_connector_ud_t *op_data, b
 
 #define H5I_DEC_REF(id, app_ref)                                                                                 \
     {                                                                                                            \
-        /* Retain lock to protect ID iteration */                                                                \
+                                                                                                             \
         int dec_ref_ret = 0;                                                                                     \
-        H5_API_LOCK                                                                                              \
+                                                                                                             \
         if (app_ref) {                                                                                           \
             dec_ref_ret = H5I_dec_app_ref(id);                                                                   \
         } else {                                                                                                 \
             dec_ref_ret = H5I_dec_ref(id);                                                                       \
         }                                                                                                        \
-        H5_API_UNLOCK                                                                                            \
+                                                                                                             \
         if (dec_ref_ret < 0)                                                                                     \
             HGOTO_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "can't decrement ID ref count");                             \
     }
@@ -279,10 +279,9 @@ H5VL_term_package(void)
             } /* end if */
             else {
                 /* Destroy the VOL connector ID group */
-                /* TBD: Retain lock to protect ID iteration */
-                H5_API_LOCK
+
                 n += (H5I_dec_type_ref(H5I_VOL) > 0);
-                H5_API_UNLOCK
+
             } /* end else */
         }     /* end else */
     }         /* end else */
@@ -455,10 +454,8 @@ done:
                 HDONE_ERROR(H5E_VOL, H5E_CANTRELEASE, FAIL, "can't free VOL connector info");
         if (connector_id != H5I_INVALID_HID) {
             /* The H5VL_class_t struct will be freed by this function */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_ref(connector_id);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "unable to unregister VOL connector");
@@ -636,11 +633,9 @@ H5VL_conn_copy(H5VL_connector_prop_t *connector_prop)
 
 done:
     if (ret_value < 0 && conn_id_incr) {
-        /* TBD: Retain lock to protect ID iteration */
-        H5_API_LOCK
-        dec_ref_ret = H5I_dec_ref(connector_prop->connector_id);
-        H5_API_UNLOCK
 
+        dec_ref_ret = H5I_dec_ref(connector_prop->connector_id);
+ 
         if (dec_ref_ret < 0)
             HDONE_ERROR(H5E_PLIST, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector ID");
     }
@@ -677,10 +672,8 @@ H5VL_conn_free(const H5VL_connector_prop_t *connector_prop)
                                 "unable to release VOL connector info object");
 
             /* Decrement reference count for connector ID */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_ref(connector_prop->connector_id);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HGOTO_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "can't decrement reference count for connector ID");
@@ -828,10 +821,8 @@ done:
     if (NULL == ret_value) {
         /* Decrement VOL connector ID ref count on error */
         if (conn_id_incr) {
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_ref(connector_id);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_VOL, H5E_CANTDEC, NULL, "unable to decrement ref count on VOL connector");
@@ -984,10 +975,8 @@ done:
     if (!ret_value) {
         /* Decrement VOL connector ID ref count on error */
         if (conn_id_incr) {
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             dec_ref_ret = H5I_dec_ref(connector_id);
-            H5_API_UNLOCK
 
             if (dec_ref_ret < 0)
                 HDONE_ERROR(H5E_VOL, H5E_CANTDEC, NULL, "unable to decrement ref count on VOL connector");
@@ -1071,10 +1060,7 @@ H5VL_conn_dec_rc(H5VL_t *connector)
     if (0 == connector->nrefs)
 #endif
     {
-        /* TBD: Retain lock to protect ID iteration */
-        H5_API_LOCK
         dec_ref_ret = H5I_dec_ref(connector->id);
-        H5_API_UNLOCK
 
         if (dec_ref_ret < 0)
             HGOTO_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector");
@@ -1420,10 +1406,8 @@ H5VL__get_registered_connector_mt(H5VL_get_connector_ud_t *op_data, bool inc_ref
             HGOTO_ERROR(H5E_VOL, H5E_BADITER, H5I_INVALID_HID, "maximum number of retries on search reached");
 
         /* Check if connector is already registered */
-        /* TBD: Retain lock to protect ID iteration */
-        H5_API_LOCK
+
         id_iter_ret = H5I_get_first(H5I_VOL, &vol_id_1, (void **)&vol_class_1, false);
-        H5_API_UNLOCK
 
         if (id_iter_ret < 0)
             HGOTO_ERROR(H5E_VOL, H5E_BADITER, H5I_INVALID_HID, "can't retrieve first VOL ID for iteration");
@@ -1456,10 +1440,8 @@ H5VL__get_registered_connector_mt(H5VL_get_connector_ud_t *op_data, bool inc_ref
         /* Iterate through connector IDs */
         while (true) {
             /* Get next ID and release current ID */
-            /* TBD: Retain lock to protect ID iteration */
-            H5_API_LOCK
+
             id_iter_ret = H5I_get_next(H5I_VOL, vol_id_1, &vol_id_2, (void **)&vol_class_2, false);
-            H5_API_UNLOCK
 
             if (id_iter_ret < 0) {
                 H5I_DEC_REF(vol_id_1, app_ref);

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -2171,6 +2171,8 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5VL_vol_object() */
 
+#if 1 /* JRM */
+
 /*-------------------------------------------------------------------------
  * Function:    H5VL_object_data
  *
@@ -2189,14 +2191,56 @@ H5VL_object_data(const H5VL_object_t *vol_obj)
 
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
+    /* Check for 'get_object' callback in connector with checks for NULL
+     * pointers along the way.  If found, return NULL -- otherwise 
+     * proceed as before.
+     */
+    if ( ( NULL == vol_obj ) || ( NULL == vol_obj->connector ) || ( NULL == vol_obj->connector->cls ) ) {
+
+        ret_value = NULL;
+
+    } else if ( vol_obj->connector->cls->wrap_cls.get_object ) {
+
+        ret_value = (vol_obj->connector->cls->wrap_cls.get_object)(vol_obj->data);
+
+    } else {
+
+        ret_value = vol_obj->data;
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5VL_object_data() */
+
+#else /* JRM */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5VL_object_data
+ *          
+ * Purpose:     Correctly retrieve the 'data' field for a VOL object (H5VL_object),
+ *              even for nested / stacked VOL connectors.
+ *      
+ * Return:      Success:        object pointer
+ *              Failure:        NULL
+ *
+ *-------------------------------------------------------------------------
+ */     
+void *      
+H5VL_object_data(const H5VL_object_t *vol_obj)
+{
+    void *ret_value = NULL;
+    
+    FUNC_ENTER_NOAPI_NOINIT_NOERR
+
     /* Check for 'get_object' callback in connector */
     if (vol_obj->connector->cls->wrap_cls.get_object)
         ret_value = (vol_obj->connector->cls->wrap_cls.get_object)(vol_obj->data);
     else
         ret_value = vol_obj->data;
-
+ 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5VL_object_data() */
+
+#endif /* JRM */
 
 /*-------------------------------------------------------------------------
  * Function:    H5VL_object_unwrap

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -2271,6 +2271,7 @@ H5VL_object_data(const H5VL_object_t *vol_obj)
     bool  done = FALSE;
 #ifdef H5_HAVE_MULTITHREAD
     bool  decrement_ref_count = FALSE;
+    _Atomic size_t * rc_ptr;
 #endif /* H5_HAVE_MULTITHREAD */
     void *ret_value = NULL;
 
@@ -2320,15 +2321,30 @@ H5VL_object_data(const H5VL_object_t *vol_obj)
          *
          * This is only possible in the multi-thread 
          * build, so only compile this code in that case.
+         *
+         * Since vol_obj is constant, we must cast 
+         * away the constant qualifier in this operation.
+         * Epicycles are to keep clang happy.
          */
+        size_t old_rc;
 
-        if ( atomic_fetch_add(&(vol_obj->rc), 1) <= 0 ) {
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        rc_ptr = (_Atomic size_t *)(&(vol_obj->rc));
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        old_rc = atomic_fetch_add(rc_ptr, 1);
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+        if ( old_rc <= 0 ) {
 
             /* the reference count was decremented out from under us.  
              *
              * Increment the ref count and set done to TRUE.
              */
-            atomic_fetch_sub(&(vol_obj->rc), 1);
+            H5_GCC_CLANG_DIAG_OFF("cast-qual")
+            atomic_fetch_sub(rc_ptr, 1);
+            H5_GCC_CLANG_DIAG_ON("cast_qual")
 
             done = TRUE;
 
@@ -2367,7 +2383,9 @@ H5VL_object_data(const H5VL_object_t *vol_obj)
 #ifdef H5_HAVE_MULTITHREAD
     if ( decrement_ref_count ) {
 
-        atomic_fetch_sub(&(vol_obj->rc), 1);
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        atomic_fetch_sub(rc_ptr, 1);
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
 
     }
 #endif /* H5_HAVE_MULTITHREAD */

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -93,6 +93,10 @@ static herr_t         H5VL__new_vol_wrapper(const H5VL_object_t *vol_obj, H5VL_w
 
 #ifdef H5_HAVE_MULTITHREAD
 static herr_t H5VL__get_registered_connector_mt(H5VL_get_connector_ud_t *op_data, bool inc_ref, bool app_ref);
+static herr_t H5VL__init_H5VL_mt_g(void);
+static H5VL_object_t * H5VL__alloc_vol_obj(void);
+static herr_t H5VL__clear_vol_obj_free_list(void);
+static herr_t H5VL__discard_vol_obj(H5VL_object_t * vol_obj_ptr);
 #else
 static int    H5VL__get_connector_cb(void *obj, hid_t id, void *_op_data);
 static herr_t H5VL__get_registered_connector_st(H5VL_get_connector_ud_t *op_data, bool inc_ref, bool app_ref);
@@ -122,6 +126,14 @@ static herr_t H5VL__get_registered_connector(H5VL_get_connector_ud_t *op_data, b
 /*****************************/
 /* Library Private Variables */
 /*****************************/
+
+/* Declared extern in H5VLpkg.h and documented there */
+#ifdef H5_HAVE_MULTITHREAD
+
+H5VL_mt_t              H5VL_mt_g;
+
+#endif /* H5_HAVE_MULTITHREAD */                                      
+
 
 /*******************/
 /* Local Variables */
@@ -174,6 +186,13 @@ H5VL_init_phase1(void)
     /* Initialize the ID group for the VL IDs */
     if (H5I_register_type(H5I_VOL_CLS) < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "unable to initialize H5VL interface");
+
+#ifdef H5_HAVE_MULTITHREAD
+
+    if (H5VL__init_H5VL_mt_g() < 0)
+        HGOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "unable to initialize H5VL_mt_g");
+
+#endif /* H5_HAVE_MULTITHREAD */
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -285,6 +304,38 @@ H5VL_term_package(void)
             } /* end else */
         }     /* end else */
     }         /* end else */
+
+#ifdef H5_HAVE_MULTITHREAD
+    {
+        herr_t result;
+        int64_t vol_objs_active;
+
+        vol_objs_active = atomic_load(&(H5VL_mt_g.vol_objs_active));
+
+        assert(vol_objs_active >= 0);
+
+        if ( 0 == vol_objs_active ) {
+
+            /* the number of active instances of H5VL_object_t has dropped to zero.
+             * If we have not done so already we can take down the vol object free
+             * list.
+             *
+             * Note the hidden assumption that we are running single thread by 
+             * the time we get to this point.
+             */
+            H5VL_mt_vol_obj_sptr_t vol_obj_fl_shead;
+
+            vol_obj_fl_shead = atomic_load(&(H5VL_mt_g.vol_obj_fl_shead));
+
+            if ( vol_obj_fl_shead.ptr ) { /* i.e. the free list still exists */
+
+                /* discard the contents of the vol object free list */
+                result = H5VL__clear_vol_obj_free_list();
+                assert( result >= 0 );
+            }
+        }
+    }
+#endif /* H5_HAVE_MULTITHREAD */
 
     FUNC_LEAVE_NOAPI(n)
 } /* end H5VL_term_package() */
@@ -541,8 +592,21 @@ H5VL__new_vol_obj(H5I_type_t type, void *object, H5VL_t *vol_connector, hbool_t 
     conn_rc_incr = TRUE;
 
     /* Create the new VOL object */
+#ifdef H5_HAVE_MULTITHREAD
+
+    if ( NULL == (new_vol_obj = H5VL__alloc_vol_obj()) )
+        HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, NULL, "can't allocate memory for VOL object");
+
+    assert(H5VL__VOL_OBJ_TAG == new_vol_obj->tag);
+    assert(!atomic_load(&(new_vol_obj->on_fl)));
+
+#else /* H5_HAVE_MULTITHREAD */
+
     if (NULL == (new_vol_obj = H5FL_CALLOC_MT(H5VL_object_t)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, NULL, "can't allocate memory for VOL object");
+
+#endif /* H5_HAVE_MULTITHREAD */
+
     new_vol_obj->connector = vol_connector;
     if (wrap_obj) {
         if (NULL == (new_vol_obj->data = H5VL__wrap_obj(object, type)))
@@ -903,8 +967,21 @@ H5VL_create_object(void *object, H5VL_t *vol_connector)
 
     /* Set up VOL object for the passed-in data */
     /* (Does not wrap object, since it's from a VOL callback) */
+
+#ifdef H5_HAVE_MULTITHREAD
+
+    if (NULL == (ret_value = H5VL__alloc_vol_obj()) )
+        HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, NULL, "can't allocate memory for VOL object");
+
+    assert(H5VL__VOL_OBJ_TAG == ret_value->tag);
+    assert(!atomic_load(&(ret_value->on_fl)));
+
+#else /* H5_HAVE_MULTITHREAD */
+
     if (NULL == (ret_value = H5FL_CALLOC_MT(H5VL_object_t)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTALLOC, NULL, "can't allocate memory for VOL object");
+
+#endif /* H5_HAVE_MULTITHREAD */
 
     /* Bump the reference count on the VOL connector */
     H5VL_conn_inc_rc(vol_connector);
@@ -912,7 +989,7 @@ H5VL_create_object(void *object, H5VL_t *vol_connector)
     ret_value->connector = vol_connector;
     ret_value->data      = object;
 #ifdef H5_HAVE_MULTITHREAD
-    atomic_init(&ret_value->rc, 1);
+    atomic_store(&ret_value->rc, 1);
 #else
     ret_value->rc   = 1;
 #endif
@@ -1167,8 +1244,12 @@ H5VL_free_object(H5VL_object_t *vol_obj)
 
         /* Sanity Check */
         assert(atomic_load(&vol_obj->rc) == 0);
-
+#if 1 /* JRM */
+        if ( H5VL__discard_vol_obj(vol_obj) < 0 )
+            HGOTO_ERROR(H5E_VOL, H5E_SYSTEM, FAIL, "unable to release vol object to the mt free list");
+#else /* JRM */
         vol_obj = H5FL_FREE_MT(H5VL_object_t, vol_obj); 
+#endif /* JRM */
     }
 
 #else
@@ -2187,10 +2268,84 @@ done:
 void *
 H5VL_object_data(const H5VL_object_t *vol_obj)
 {
+    bool  done = FALSE;
+#ifdef H5_HAVE_MULTITHREAD
+    bool  decrement_ref_count = FALSE;
+#endif /* H5_HAVE_MULTITHREAD */
     void *ret_value = NULL;
 
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
+    /* added code to validate the supplied *vol_obj.  
+     *
+     * Prior to these updated, this function was causing seg faults when 
+     * the vol_obj field pointed to an instance of H5VL_object_t that 
+     * had been deallocated.
+     *
+     * Repaired this in two ways:
+     *
+     * First set up a multi-thread safe free list to avoid referencing 
+     * deallocated instance of H5VL_object_t in this function.
+     *
+     * Second, we check the ref count on the supplied instance of 
+     * H5VL_object_t.  If it has dropped to zero, the instance of 
+     * H5VL_object_t has been discarded.  According to comments 
+     * elsewhere which I have not validated, this is a one way 
+     * process -- so in this case, we simply return NULL.
+     */
+    if ( NULL == vol_obj ) {
+
+        done = TRUE;
+
+#ifdef H5_HAVE_MULTITHREAD
+    } else if ( atomic_load(&(vol_obj->rc)) <= 0 ) {
+
+        assert(H5VL__VOL_OBJ_TAG == vol_obj->tag);
+
+#else /* H5_HAVE_MULTITHREAD */
+    } else if ( vol_obj->rc <= 0 ) {
+#endif /* H5_HAVE_MULTITHREAD */
+
+        done = TRUE;
+
+    } else {
+
+#ifdef H5_HAVE_MULTITHREAD
+
+        /* *vol_obj has (or had) a positive ref count.  
+         * To avoid the possibility of the entry being 
+         * deleted out from under us, increment the 
+         * ref count if this is a multi-thread build,
+         * and decrement it again before returning.
+         *
+         * This is only possible in the multi-thread 
+         * build, so only compile this code in that case.
+         */
+
+        if ( atomic_fetch_add(&(vol_obj->rc), 1) <= 0 ) {
+
+            /* the reference count was decremented out from under us.  
+             *
+             * Increment the ref count and set done to TRUE.
+             */
+            atomic_fetch_sub(&(vol_obj->rc), 1);
+
+            done = TRUE;
+
+        } else {
+
+            decrement_ref_count = TRUE;
+        } 
+
+#endif /* H5_HAVE_MULTITHREAD */
+    }
+    
+    if ( done ) { 
+
+        /* error detected above -- set ret_value to NULL */
+        ret_value = NULL;
+
+    } else 
     /* Check for 'get_object' callback in connector with checks for NULL
      * pointers along the way.  If found, return NULL -- otherwise 
      * proceed as before.
@@ -2207,6 +2362,15 @@ H5VL_object_data(const H5VL_object_t *vol_obj)
 
         ret_value = vol_obj->data;
     }
+
+
+#ifdef H5_HAVE_MULTITHREAD
+    if ( decrement_ref_count ) {
+
+        atomic_fetch_sub(&(vol_obj->rc), 1);
+
+    }
+#endif /* H5_HAVE_MULTITHREAD */
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5VL_object_data() */
@@ -3395,3 +3559,652 @@ H5VL_get_cap_flags(const H5VL_connector_prop_t *connector_prop, uint64_t *cap_fl
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5VL_get_cap_flags() */
+
+#ifdef H5_HAVE_MULTITHREAD 
+
+/*-------------------------------------------------------------------------
+ * Function:    H5VL__init_H5VL_mt_g()
+ *
+ * Purpose:     Initialize the various fields of H5VL_mt_g.  
+ *
+ *              In particular, set up the free list.
+ *
+ * Return:      Success:        Non-negative
+ *              Failure:        Negative
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5VL__init_H5VL_mt_g(void) 
+{
+    H5VL_object_t * vol_obj_ptr = NULL;
+    H5VL_mt_vol_obj_sptr_t init_vol_obj_sptr = {NULL, 0ULL};
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    /* initialize the id info free list */
+
+    atomic_init(&(H5VL_mt_g.vol_obj_fl_shead), init_vol_obj_sptr);
+    atomic_init(&(H5VL_mt_g.vol_obj_fl_stail), init_vol_obj_sptr);
+    atomic_init(&(H5VL_mt_g.vol_obj_fl_len), 0ULL);
+    atomic_init(&(H5VL_mt_g.max_desired_vol_obj_fl_len), H5VL__MAX_DESIRED_OBJECT_FL_LEN);
+    atomic_init(&(H5VL_mt_g.vol_obj_next_sn), 1ULL);
+    atomic_init(&(H5VL_mt_g.vol_obj_max_realloc_sn), 0ULL);
+
+    /* allocate the initial entry in the vol object free list and initialize the vol object free list */
+    vol_obj_ptr = H5VL__alloc_vol_obj();
+    if ( NULL == vol_obj_ptr)
+        HGOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "Can't initialize vol object free list -- 1");
+
+    assert(H5VL__VOL_OBJ_TAG == vol_obj_ptr->tag);
+
+    atomic_store(&(vol_obj_ptr->serial_num), 1);
+
+    atomic_store(&(vol_obj_ptr->on_fl), TRUE);
+    atomic_store(&(vol_obj_ptr->serial_num), 1ULL);
+
+    init_vol_obj_sptr.ptr = vol_obj_ptr;
+    init_vol_obj_sptr.sn  = 1ULL;
+
+    atomic_store(&(H5VL_mt_g.vol_obj_fl_shead), init_vol_obj_sptr);
+    atomic_store(&(H5VL_mt_g.vol_obj_fl_stail), init_vol_obj_sptr);
+    atomic_store(&(H5VL_mt_g.vol_obj_fl_len), 1ULL);
+    atomic_store(&(H5VL_mt_g.vol_obj_next_sn), 2ULL);
+    atomic_init(&(H5VL_mt_g.vol_objs_active), 0LL);
+
+
+    /* initialize stats */
+    atomic_init(&(H5VL_mt_g.max_vol_obj_fl_len), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_structs_alloced_from_heap), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_structs_alloced_from_fl), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_structs_freed), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_structs_added_to_fl), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_fl_tail_update_cols), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_fl_head_update_cols), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_fl_append_cols), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_fl_alloc_req_denied_due_to_empty), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_fl_head_sn_is_zero), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_sn_assigned), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_serial_num_resets), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_structs_alloced_from_heap), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_fl_alloc_req_denied_due_to_no_reallocable_entries), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_fl_alloc_req_denied_due_to_empty), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_fl_frees_skipped_due_to_empty), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_fl_frees_skipped_due_to_fl_too_small), 0ULL);
+    atomic_init(&(H5VL_mt_g.num_vol_obj_fl_frees_skipped_due_to_no_reallocable_entries), 0ULL);
+    atomic_init(&(H5VL_mt_g.H5VL__alloc_vol_obj__num_calls), 0ULL);
+    atomic_init(&(H5VL_mt_g.H5VL__clear_vol_obj_free_list__num_calls), 0ULL);
+    atomic_init(&(H5VL_mt_g.H5VL__discard_vol_obj__num_calls), 0ULL);
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5VLL__init_H5VL_mt_g() */
+
+
+/************************************************************************
+ *
+ * H5VL__alloc_vol_obj
+ *
+ *     Test to see if an instance of H5VL_mt_id_info_t is available on the
+ *     vol object free list.  If there is, remove it from the free list, 
+ *     re-initialize it, and return a pointer to it.
+ *
+ *     Otherwise, allocate and initialize an instance of struct
+ *     H5VL_object_t and return a pointer to the instance of
+ *     H5VL_object_t to the caller.
+ *
+ *     Return a pointer to the new instance on success, and NULL on
+ *     failure.
+ *
+ *                                          JRM -- 6/14/25
+ *
+ ************************************************************************/
+
+static H5VL_object_t * 
+H5VL__alloc_vol_obj(void)
+{
+    hbool_t fl_search_done = FALSE;;
+    hbool_t result;
+    H5VL_object_t * vol_obj_ptr = NULL;
+    H5VL_mt_vol_obj_sptr_t fl_shead;
+    H5VL_mt_vol_obj_sptr_t new_fl_shead;
+    H5VL_mt_vol_obj_sptr_t test_fl_shead;
+    H5VL_mt_vol_obj_sptr_t fl_stail;
+    H5VL_mt_vol_obj_sptr_t new_fl_stail;
+    H5VL_mt_vol_obj_sptr_t snext;
+    H5VL_mt_vol_obj_sptr_t new_snext;
+    H5VL_object_t * ret_value = NULL; /* Return value */
+
+    FUNC_ENTER_NOAPI(NULL)
+
+    atomic_fetch_add(&(H5VL_mt_g.H5VL__alloc_vol_obj__num_calls), 1ULL);
+
+    fl_shead = atomic_load(&(H5VL_mt_g.vol_obj_fl_shead));
+
+    /* test to see if the free list has been initialized */
+
+    if ( NULL == fl_shead.ptr ) {
+
+        /* free list is not yet initialized */
+        fl_search_done = TRUE;
+    }
+
+
+    while ( ! fl_search_done ) {
+
+        fl_shead = atomic_load(&(H5VL_mt_g.vol_obj_fl_shead));
+        fl_stail = atomic_load(&(H5VL_mt_g.vol_obj_fl_stail));
+
+        assert(fl_shead.ptr);
+        assert(fl_stail.ptr);
+
+        snext = atomic_load(&(fl_shead.ptr->fl_snext));
+
+        test_fl_shead = atomic_load(&(H5VL_mt_g.vol_obj_fl_shead));
+
+        if ( ( test_fl_shead.ptr == fl_shead.ptr ) && ( test_fl_shead.sn == fl_shead.sn ) ) {
+
+            uint64_t serial_num;
+
+            if ( fl_shead.ptr == fl_stail.ptr ) {
+
+                if ( NULL == snext.ptr ) {
+
+                    /* the free list is empty */
+                    atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_alloc_req_denied_due_to_empty), 1);
+                    fl_search_done = TRUE;
+                    break;
+                }
+
+                /* attempt to set H5VL_mt_g.vol_obj_fl_stail to snext.  It doesn't
+                 * matter whether we succeed or fail, as if we fail, it
+                 * just means that some other thread beat us to it.
+                 *
+                 * that said, it doesn't hurt to collect stats
+                 */
+                new_fl_stail.ptr = snext.ptr;
+                new_fl_stail.sn  = fl_stail.sn + 1;
+                if ( ! atomic_compare_exchange_strong(&(H5VL_mt_g.vol_obj_fl_stail), &fl_stail, new_fl_stail) ) {
+
+                    atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_tail_update_cols), 1ULL);
+                }
+            } else if ( ( 0 < (serial_num = atomic_load(&(fl_shead.ptr->serial_num))) ) &&
+                        ( serial_num >= atomic_load(&(H5VL_mt_g.vol_obj_max_realloc_sn)) ) ) {
+
+                /* if serial_num is zero, it should have already been removed from the free
+                 * list by another thread -- if so, the following attempt to remove if from
+                 * the free list will fail.  If this is not the case, we will catch the error
+                 * after we successfully remove the entry.
+                 */
+
+                /* No reallocable entries available -- just update stats and quit */
+                atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_alloc_req_denied_due_to_no_reallocable_entries), 1ULL);
+                fl_search_done = TRUE; 
+
+            } else {
+
+                /* set up new_fl_shead now in case we need it later.  */
+                new_fl_shead.ptr = snext.ptr;
+                new_fl_shead.sn  = fl_shead.sn + 1;
+
+                if ( ! atomic_compare_exchange_strong(&(H5VL_mt_g.vol_obj_fl_shead), &fl_shead, new_fl_shead) ) {
+
+                    /* the attempt to remove the first item from the free list
+                     * failed.  Update stats and try again.
+                     */
+                    atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_head_update_cols), 1ULL);
+
+                } else {
+
+                    /* first has been removed from the free list.  Set fl_node_ptr to first,
+                     * update stats, and exit the loop by setting fl_search_done to true.
+                     */
+                    vol_obj_ptr = fl_shead.ptr;
+
+                    assert(H5VL__VOL_OBJ_TAG == vol_obj_ptr->tag);
+
+                    assert(atomic_load(&(vol_obj_ptr->on_fl)));
+                    atomic_store(&(vol_obj_ptr->on_fl), FALSE);
+
+                    assert( 0 < atomic_load(&(vol_obj_ptr->serial_num ) ) );
+
+                    /* the above assert only exists in production builds.  If vol_obj_ptr->serial_num
+                     * is zero and we get this far, increment H5VL_mt_g.num_vol_obj_fl_head_sn_is_zero.
+                     */
+                    if ( 0 == atomic_load(&(vol_obj_ptr->serial_num)) ) {
+
+                        atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_head_sn_is_zero), 1ULL);
+
+                        /* should we throw an error here? */
+                    }
+                    atomic_store(&(vol_obj_ptr->serial_num), 0ULL);
+
+                    new_snext.ptr = NULL;
+                    new_snext.sn  = snext.sn + 1;
+
+                    result = atomic_compare_exchange_strong(&(vol_obj_ptr->fl_snext), &snext, new_snext);
+                    assert(result);
+
+                    /* instance of H5VL_object_t removed from the free list -- update stats */
+                    atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_structs_alloced_from_fl), 1ULL);
+
+                    /* the following assignements should be safe, as only one thread 
+                     * (this one) should be able to access *vol_obj_ptr at this time.
+                     * 
+                     * That said, don't be surprised if thread sanitizers whine at this point.
+                     */
+                    vol_obj_ptr->data = NULL;
+                    vol_obj_ptr->connector = NULL;
+                    assert(0 == atomic_load(&(vol_obj_ptr->rc)));
+
+                    fl_search_done = true;
+                }
+            }
+        }
+    } /* while ( ! fl_search_done ) */
+
+    if ( NULL == vol_obj_ptr ) {
+
+        H5VL_mt_vol_obj_sptr_t init_object_sptr = {NULL, 0ULL};
+
+        vol_obj_ptr = (H5VL_object_t *)malloc(sizeof(H5VL_object_t));
+
+        if ( NULL == vol_obj_ptr )
+            HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, NULL, "ID info allocation failed");
+
+        vol_obj_ptr->tag = H5VL__VOL_OBJ_TAG;
+        atomic_init(&(vol_obj_ptr->on_fl), FALSE);
+        atomic_init(&(vol_obj_ptr->fl_snext), init_object_sptr);
+        atomic_init(&(vol_obj_ptr->serial_num), 0ULL);
+        vol_obj_ptr->data = NULL;
+        vol_obj_ptr->connector = NULL;
+        atomic_init(&vol_obj_ptr->rc, 0);
+
+        /* instance of H5VL_object_t allocated -- update stats */
+        atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_structs_alloced_from_heap), 1ULL);
+    }
+
+    assert(vol_obj_ptr);
+
+    /* Set return value */
+    ret_value = vol_obj_ptr;
+
+    if ( ret_value ) {
+
+        int64_t old_vol_objs_active;
+
+        old_vol_objs_active = atomic_fetch_add(&(H5VL_mt_g.vol_objs_active), 1LL);
+
+        assert( 0 <= old_vol_objs_active );
+    } 
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5VL__alloc_vol_obj() */
+
+
+/************************************************************************
+ *
+ * H5VL__clear_vol_obj_free_list
+ *
+ *     Discard all entries on the vol object free list in preparation for 
+ *     shutdown.  
+ *
+ *     Note that this function assumes that no other threads are active 
+ *     in H5VL, and that it is therefore safe to ignore 
+ *     H5VL_mt_g.id_max_realloc_sn and H5VL_mt_g.type_max_realloc_sn. 
+ *
+ *                                          JRM -- 6/15/25
+ *
+ ************************************************************************/
+
+static herr_t
+H5VL__clear_vol_obj_free_list(void)
+{
+    uint64_t               test_val;
+    H5VL_mt_vol_obj_sptr_t fl_head;
+    H5VL_mt_vol_obj_sptr_t null_snext = {NULL, 0ULL};
+    H5VL_object_t        * fl_head_ptr;
+    H5VL_object_t        * vol_obj_ptr;;
+    herr_t                 ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    atomic_fetch_add(&(H5VL_mt_g.H5VL__clear_vol_obj_free_list__num_calls), 1ULL);
+
+    fl_head = atomic_load(&(H5VL_mt_g.vol_obj_fl_shead));
+    fl_head_ptr = fl_head.ptr;
+
+    if ( ( ! fl_head_ptr ) ||  ( 0ULL == atomic_load(&(H5VL_mt_g.vol_obj_fl_len)) ) )
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "H5VL_mt_g.vol_obj_fl_shead.ptr == NULL -- H5VL_mt_g not initialized?");
+
+
+    while ( fl_head_ptr ) {
+
+        vol_obj_ptr = fl_head_ptr;
+
+        assert(H5VL__VOL_OBJ_TAG == vol_obj_ptr->tag);
+        assert(atomic_load(&(vol_obj_ptr->on_fl)));
+
+        fl_head = atomic_load(&(vol_obj_ptr->fl_snext));
+        fl_head_ptr = fl_head.ptr;
+
+        /* prepare *vol_obj_ptr for discard */
+        vol_obj_ptr->tag = H5VL__INVALID_VOL_OBJ_TAG;
+        atomic_store(&(vol_obj_ptr->fl_snext), null_snext);
+
+        free(vol_obj_ptr);
+
+        atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_structs_freed), 1ULL);
+        test_val = atomic_fetch_sub(&(H5VL_mt_g.vol_obj_fl_len), 1ULL);
+        assert( test_val > 0ULL);
+    }
+
+    atomic_store(&(H5VL_mt_g.vol_obj_fl_shead), null_snext);
+    atomic_store(&(H5VL_mt_g.vol_obj_fl_stail), null_snext);
+
+    assert(0 == atomic_load(&(H5VL_mt_g.vol_obj_fl_len)));
+    assert(0 == atomic_load(&(H5VL_mt_g.vol_obj_fl_len)));
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5VL__clear_vol_obj_free_list() */
+
+
+/************************************************************************
+ *
+ * H5VL__discard_vol_obj
+ *
+ *     Append the supplied instance of H5VL_object_t to the vol object
+ *     free list and increment H5VL_mt_g.vol_obj_fl_len.
+ *
+ *     If the free list length exceeds H5VL_mt_g.max_desired_vol_obj_fl_len, 
+ *     attempt the remove the entry at the head of the vol object free 
+ *     list from the free list, and discard it and decrement 
+ *     H5VL_mt_g.vol_obj_fl_len if successful.
+ *
+ *                                          JRM -- 6/15/25
+ *
+ ************************************************************************/
+
+static herr_t 
+H5VL__discard_vol_obj(H5VL_object_t * vol_obj_ptr)
+{
+    hbool_t done = FALSE;
+    hbool_t on_fl = FALSE;
+    hbool_t try_to_free_an_entry = FALSE;
+    hbool_t result;
+    int64_t old_vol_objs_active;
+    uint64_t fl_len;
+    uint64_t max_fl_len;
+    uint64_t test_val;
+    H5VL_mt_vol_obj_sptr_t snext = {NULL, 0ULL};
+    H5VL_mt_vol_obj_sptr_t new_snext;
+    H5VL_mt_vol_obj_sptr_t fl_shead;
+    H5VL_mt_vol_obj_sptr_t fl_stail;
+    H5VL_mt_vol_obj_sptr_t fl_snext;
+    H5VL_mt_vol_obj_sptr_t new_fl_snext;
+    H5VL_mt_vol_obj_sptr_t new_fl_shead;
+    H5VL_mt_vol_obj_sptr_t new_fl_stail;
+    H5VL_mt_vol_obj_sptr_t test_fl_shead;
+    H5VL_mt_vol_obj_sptr_t test_fl_stail;
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI_NOERR
+
+    atomic_fetch_add(&(H5VL_mt_g.H5VL__discard_vol_obj__num_calls), 1ULL);
+
+    assert(vol_obj_ptr);
+    assert(H5VL__VOL_OBJ_TAG == vol_obj_ptr->tag);
+    assert(0 == atomic_load(&(vol_obj_ptr->rc)));
+
+    assert(!atomic_load(&(vol_obj_ptr->on_fl)));
+    assert(0 == atomic_load(&(vol_obj_ptr->serial_num)));
+
+    snext = atomic_load(&(vol_obj_ptr->fl_snext));
+    new_snext.ptr = NULL;
+    new_snext.sn = snext.sn + 1;
+
+    atomic_store(&(vol_obj_ptr->fl_snext), new_snext);
+
+    result = atomic_compare_exchange_strong(&(vol_obj_ptr->on_fl), &on_fl, TRUE);
+    assert( result );
+
+    atomic_store(&(vol_obj_ptr->serial_num), atomic_fetch_add(&(H5VL_mt_g.vol_obj_next_sn), 1ULL));
+
+    /* update stats */
+    atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_sn_assigned), 1ULL);
+
+    while ( ! done ) {
+
+        fl_stail = atomic_load(&(H5VL_mt_g.vol_obj_fl_stail));
+
+        assert(fl_stail.ptr);
+
+        fl_snext = atomic_load(&(fl_stail.ptr->fl_snext));
+
+        test_fl_stail = atomic_load(&(H5VL_mt_g.vol_obj_fl_stail));
+
+        if ( ( test_fl_stail.ptr == fl_stail.ptr ) && ( test_fl_stail.sn == fl_stail.sn ) ) {
+
+            if ( NULL == fl_snext.ptr ) {
+
+                /* attempt to append vol_obj_ptr by setting fl_tail->fl_snext.ptr to vol_obj_ptr.
+                 * If this succeeds, update stats and attempt to set H5VL_mt_g.vol_obj_fl_stail.ptr
+                 * to vol_obj_ptr as well.  This may or may not succeed, but in either
+                 * case we are done.
+                 */
+                new_fl_snext.ptr = vol_obj_ptr;
+                new_fl_snext.sn  = fl_snext.sn + 1;
+                if ( atomic_compare_exchange_strong(&(fl_stail.ptr->fl_snext), &fl_snext, new_fl_snext) ) {
+
+                    atomic_fetch_add(&(H5VL_mt_g.vol_obj_fl_len), 1);
+                    atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_structs_added_to_fl), 1);
+
+                    new_fl_stail.ptr = vol_obj_ptr;
+                    new_fl_stail.sn  = fl_stail.sn + 1;
+                    if ( ! atomic_compare_exchange_strong(&(H5VL_mt_g.vol_obj_fl_stail), 
+                                                          &fl_stail, new_fl_stail) ) {
+
+                        atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_tail_update_cols), 1);
+                    }
+
+                    /* if appropriate, attempt to update H5VL_mt_g.max_vol_obj_fl_len.  In the
+                     * event of a collision, just ignore it and go on, as I don't see any
+                     * reasonable way to recover.
+                     */
+                    if ( (fl_len = atomic_load(&(H5VL_mt_g.vol_obj_fl_len))) >
+                         (max_fl_len = atomic_load(&(H5VL_mt_g.max_vol_obj_fl_len))) ) {
+
+                        atomic_compare_exchange_strong(&(H5VL_mt_g.max_vol_obj_fl_len), &max_fl_len, fl_len);
+                    }
+
+                    done = true;
+
+                } else {
+
+                    /* append failed -- update stats and try again */
+                    atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_append_cols), 1);
+
+                }
+            } else {
+
+                /* attempt to set lfht_ptr->fl_stail to fl_next.  It doesn't
+                 * matter whether we succeed or fail, as if we fail, it
+                 * just means that some other thread beat us to it.
+                 *
+                 * that said, it doesn't hurt to collect stats
+                 */
+                new_fl_stail.ptr = fl_snext.ptr;
+                new_fl_stail.sn  = fl_stail.sn + 1;
+                if ( ! atomic_compare_exchange_strong(&(H5VL_mt_g.vol_obj_fl_stail), &fl_stail, new_fl_stail) ) {
+
+                    atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_tail_update_cols), 1);
+                }
+            }
+        }
+    }
+
+    /* update the number of active instances of H5VL_object_t */
+
+    old_vol_objs_active = atomic_fetch_sub(&(H5VL_mt_g.vol_objs_active), 1LL);
+
+    assert( 1 <= old_vol_objs_active );
+
+
+    /* Test to see if H5VL_mt_g.vol_obj_fl_len is greater than H5VL_mt_g.max_desired_vol_obj_fl_len.
+     *
+     * Note that this doesn't mean that there is a entry available for discard -- we will check this 
+     * later.
+     */
+
+    /* must rework this assert for the possibility that these fields will wrap around */
+    assert(atomic_load(&(H5VL_mt_g.vol_obj_max_realloc_sn)) <= atomic_load(&(H5VL_mt_g.vol_obj_next_sn)));
+
+    if ( atomic_load(&(H5VL_mt_g.vol_obj_fl_len)) > atomic_load(&(H5VL_mt_g.max_desired_vol_obj_fl_len)) ) {
+
+        try_to_free_an_entry = TRUE;
+
+    } else {
+
+        atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_frees_skipped_due_to_fl_too_small), 1ULL);
+    }
+
+    if ( try_to_free_an_entry ) {
+
+        uint64_t serial_num;
+
+        done = FALSE;
+
+        while ( ! done ) {
+
+            fl_shead = atomic_load(&(H5VL_mt_g.vol_obj_fl_shead));
+            fl_stail = atomic_load(&(H5VL_mt_g.vol_obj_fl_stail));
+
+            assert(fl_shead.ptr);
+            assert(fl_stail.ptr);
+
+            fl_snext = atomic_load(&(fl_shead.ptr->fl_snext));
+
+            test_fl_shead = atomic_load(&(H5VL_mt_g.vol_obj_fl_shead));
+
+            if ( ( test_fl_shead.ptr == fl_shead.ptr ) && ( test_fl_shead.sn == fl_shead.sn ) ) {
+
+                if ( fl_shead.ptr == fl_stail.ptr ) {
+
+                    if ( NULL == fl_snext.ptr ) {
+
+                        /* the free list is empty */
+                        atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_frees_skipped_due_to_empty), 1);
+                        done = TRUE;
+                        break;
+                    }
+
+                    /* attempt to set H5VL_mt_g.vol_obj_fl_stail to fl_snext.  It doesn't
+                     * matter whether we succeed or fail, as if we fail, it
+                     * just means that some other thread beat us to it.
+                     *
+                     * that said, it doesn't hurt to collect stats
+                     */
+                    assert(fl_snext.ptr);
+                    new_fl_stail.ptr = fl_snext.ptr;
+                    new_fl_stail.sn  = fl_stail.sn + 1;
+                    if ( ! atomic_compare_exchange_strong(&(H5VL_mt_g.vol_obj_fl_stail), &fl_stail, 
+                                                          new_fl_stail) ) {
+
+                        atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_tail_update_cols), 1ULL);
+                    }
+                } else if ( ( 0 < (serial_num = atomic_load(&(fl_shead.ptr->serial_num))) ) &&
+                            ( serial_num >= atomic_load(&(H5VL_mt_g.vol_obj_max_realloc_sn)) ) ) {
+
+                    /* if serial_num is zero, it should have already been removed from the free
+                     * list by another thread -- if so, the following attempt to remove if from
+                     * the free list will fail.  If this is not the case, we will catch the error
+                     * after we successfully remove the entry.
+                     */
+
+                    /* No reallocable entries available -- just update stats and quit */
+                    atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_frees_skipped_due_to_no_reallocable_entries), 1ULL);
+                    done = TRUE; 
+
+                } else {
+
+                    /* set up new_fl_shead */
+                    assert(fl_snext.ptr);
+                    new_fl_shead.ptr = fl_snext.ptr;
+                    new_fl_shead.sn  = fl_shead.sn + 1;
+
+                    if ( ! atomic_compare_exchange_strong(&(H5VL_mt_g.vol_obj_fl_shead), 
+                                                          &fl_shead, new_fl_shead) ) {
+
+                        /* the attempt to remove the first item from the free list
+                         * failed.  Update stats and try again.
+                         */
+                        atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_head_update_cols), 1ULL);
+
+                    } else {
+
+                        H5VL_mt_vol_obj_sptr_t null_snext = {NULL, 0ULL};
+
+                        /* first has been removed from the free list.  Set vol_obj_ptr to fl_shead.ptr,
+                         * discard *vol_obj_ptr, update stats, and exit the loop by setting done to true.
+                         */
+                        vol_obj_ptr = fl_shead.ptr;
+
+                        assert(H5VL__VOL_OBJ_TAG == vol_obj_ptr->tag);
+                        assert(atomic_load(&(vol_obj_ptr->on_fl)));
+                        assert(0 < atomic_load(&(vol_obj_ptr->serial_num)));
+
+                        /* the above assert only exists in production builds.  If vol_obj_ptr->serial_num
+                         * is zero and we get this far, increment H5VL_mt_g.num_vol_obj_fl_head_sn_is_zero.
+                         */
+                        if ( 0 == atomic_load(&(vol_obj_ptr->serial_num)) ) {
+
+                            atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_fl_head_sn_is_zero), 1ULL);
+
+                            /* should we throw an error here? */
+                        }
+
+                        /* Note that we don't check to see if vol_obj_ptr->serial_num < 
+                         * H5VL_mt_g.id_max_realloc_sn.  This was already checked above.  
+                         * Further, the algorithm for maintaining H5VL_mt_g.id_max_realloc_sn
+                         * allows its value to bounce around a bit -- making it possible that 
+                         * we would get a false assertion failure.
+                         */
+
+                        atomic_store(&(vol_obj_ptr->serial_num), 0ULL);
+                        atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_serial_num_resets), 1ULL);
+
+                        /* prepare *if_info_ptr for discard */
+                        vol_obj_ptr->tag = H5VL__INVALID_VOL_OBJ_TAG;
+                        atomic_store(&(vol_obj_ptr->fl_snext), null_snext);
+
+                        free(vol_obj_ptr);
+
+                        /* update stats */
+                        atomic_fetch_add(&(H5VL_mt_g.num_vol_obj_structs_freed), 1ULL);
+
+                        test_val = atomic_fetch_sub(&(H5VL_mt_g.vol_obj_fl_len), 1ULL);
+                        assert( test_val > 0ULL);
+
+                        done = true;
+                    }
+                }
+            }
+        } /* while ( ! done ) */
+    } /* if ( try_to_free_entry ) */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5VL__discard_vol_obj() */
+
+
+#endif /* H5_HAVE_MULTITHREAD */

--- a/src/H5VLpkg.h
+++ b/src/H5VLpkg.h
@@ -40,9 +40,207 @@
 /* Package Private Typedefs */
 /****************************/
 
+#ifdef H5_HAVE_MULTITHREAD
+
+/****************************************************************************************
+ *
+ * struct H5VL_mt_t
+ *
+ * A single, global instance of H5VL_mt_t is used to collect all global variables that
+ * required for the multi-thread version of H5VL.  
+ *
+ * It is also used to maintain related statistics.
+ *
+ * Fields are discussed individually below.
+ *
+ *
+ * H5VL_object_t free list:  Since pointers to instances of H5VL_object_t may persist
+ * after the associated instance has been discarded, we must maintain a free list of
+ * same to avoid accessing freed memory on the heap.  
+ *
+ * vol_obj_fl_shead: Atomic instance of struct H5VL_mt_vol_obj_sptr_t, which contains
+ *      a pointer (ptr) to the head of the id info free list, and a serial number (sn)
+ *      which must be incremented each time a new value is assigned to vol_obj_fl_shead.
+ *
+ *      The objective here is to prevent ABA bugs.
+ *
+ *      Note that once initialized, the vol object free list will always contain at least
+ *      one entry, and is logically empty if vol_obj_fl_shead.ptr == vol_obj_fl_stail.ptr
+ *      != NULL.
+ *
+ * vol_obj_fl_stail: Atomic instance of struct H5VL_mt_vol_obj_sptr_t, which contains
+ *      a pointer (ptr) to the tail of the vol object free list, and a serial number (sn)
+ *      which must be incremented each time a new value is assigned to vol_obj_fl_stail.
+ *
+ *      The objective here is to prevent ABA bugs.
+ *
+ * vol_obj_fl_len: Atomic unsigned integer used to maintain a count of the number of
+ *      entries in the vol object free list.  Note that due to the delay between free list
+ *      insertions and deletions, and the update of this field, this count may be off
+ *      for brief periods of time.
+ *
+ *      Recall that the free list must always contain at least one entry.  Thus, when
+ *      correct, vol_obj_fl_len will be one greater than the number of entries on the 
+ *      free list.
+ *
+ * max_desired_vol_obj_fl_len: Unsigned integer field containing the desired maximum
+ *      vol object free list length.  This is of necessity a soft limit as entries cannot
+ *      be removed from the head of the free list unless they are re-allocable.
+ *
+ * vol_obj_next_sn: Atomic uint64_t containing the serial number for the next entry on the 
+ *      vol object free list. Whenever an entry is added to the vol object free list, that 
+ *      entry's serial_num field is set equal to vol_obj_next_sn and vol_obj_next_sn gets 
+ *      incremented.  The entry's serial_num field is compared to the vol_obj_max_realloc_sn 
+ *      field below, and is only reallocable if the serial_num field is lesser.
+ *
+ *      For this iteration the assumption is made that vol_obj_next_sn will not be 
+ *      incremented enough to overflow, but eventually this must be taken into account.
+ *
+ * vol_obj_max_realloc_sn: Atomic uint64_t containing one plus the maximum serial number that
+ *      can be reallocated. When an entry's serial number is compared to this field, if
+ *      it is less than this field, then it can be reallocated. 
+ *
+ *      At present this field is not updated, which prevents H5VL_object_t reallocation.
+ *      Address this, or choose another reallocation heuristic before the release 
+ *      version.
+ *
+ * vol_objs_active: Count of the number of instance of H5VL_object_t that have been 
+ *      allocated and not yet released to the free list.  This count is maintained
+ *      so we can delay taking down the free list until all instances have been 
+ *      released to the free lists.  
+ *
+ *      Note that due to the delay between updating the free list and updating this
+ *      field, it value may be briefly incorrect when running multi-thread.  For 
+ *      now at least, this is a non-issue since we drop to a single thread during
+ *      library shutdown.
+ *
+ *
+ * Statistics:
+ *
+ * Object Free List Statistics:
+ *
+ * max_vol_obj_fl_len: Maximum number of entries that have resided on the vol object free
+ *      list at any point during the current run.  In the multi-thread case, this number
+ *      should be viewed as aproximate.
+ *
+ * num_vol_obj_structs_alloced_from_heap: Number of instances of H5VL_object_t
+ *      allocated from the heap.
+ *
+ * num_vol_obj_structs_alloced_from_fl:  Number of times an instance of H5VL_object_t
+ *      has been allocated from the vol object free list.
+ *
+ * num_vol_obj_structs_freed: Number of instances of H5VL_object_t that have been
+ *      freed -- that is returned to the heap.
+ *
+ * num_vol_obj_structs_added_to_fl: Number of times an instance of H5VL_object_t
+ *      has been added to the vol object free list.
+ *
+ * num_vol_obj_fl_head_update_cols: Number of vol object free list head update collisions.
+ *
+ * num_vol_obj_fl_tail_update_cols: Number of vol object free list tail update collisions.
+ *
+ * num_vol_obj_fl_append_cols: Number of collisions when appending an instance of
+ *     H5VL_object_t to the vol object free list.
+ *
+ * num_vol_obj_fl_head_sn_is_zero: Number of times that the instance of H5VL_object_t
+ *     at the head of the free list has serial number 0.  Note that thiw will trigger
+ *     an assertion failure in the debug build.
+ *
+ * num_vol_obj_sn_assigned: Number of times that a serial number is assigned
+ *     to an instance of H5VL_object_t.  This is done when an instance is added 
+ *     to the vol object free list.
+ *
+ * num_vol_obj_serial_num_resets:  Number of thimes that the serial number assinged
+ *      to an instance of H5VL_object_t is reset.  This is done when an instance 
+ *      is removed from the free list just prior to being either reallocated to 
+ *      released to the heap.
+ *
+ * num_vol_obj_fl_alloc_req_denied_due_to_empty:  Number of times an alloc request
+ *      for an instance of H5VL_object_t has had to be satisfied from the heap
+ *      instead of the free list because the vol object free list is empty.  Recall
+ *      that the vol object free list is logically empty when it contains only a single
+ *      entry.
+ *
+ * num_vol_obj_fl_alloc_req_denied_due_to_no_reallocable_entries:  Number of times an
+ *      alloc request for an instance of H5VL_object_t has had to be satisfied from
+ *      the heap because the entry at the head of the free list has a serial number
+ *      greater than or equal to object_max_realloc_sn.
+ *
+ * num_vol_obj_fl_frees_skipped_due_to_empty: Number of times that an instance of
+ *      H5VL_object_t on the vol object free list is not released to the heap because
+ *      the free list is empty.
+ *
+ * num_vol_obj_fl_frees_skipped_due_to_fl_too_small:  Number of times that an instance of
+ *      H5VL_object_t on the vol object free list is not released to the heap because
+ *      the free list length is less than max_desired_vol_obj_fl_len.
+ *
+ * num_object_fl_frees_skipped_due_to_no_reallocable_entries: Number of times that an
+ *      instance of H5VL_object_t on the vol object free list is not released to the heap
+ *      because the entry at the head of the free list has serial number greater than
+ *      or equal to id_max_realloc_sn.
+ *
+ * H5VL__alloc_vol_obj__num_calls: Number of times that H5VL__alloc_vol_obj() is called
+ *
+ * H5VL__clear_vol_obj_free_list__num_calls: Number of times that 
+ *      H5VL__clear_vol_obj_free_list() is called.
+ *
+ * H5VL__discard_vol_obj__num_calls: Number of times that H5VL__discard_vol_obj() is
+ *      called.
+ *
+ *
+ ****************************************************************************************/
+
+#define H5VL__MAX_DESIRED_OBJECT_FL_LEN   4ULL
+
+typedef struct H5VL_mt_t {
+
+    _Atomic H5VL_mt_vol_obj_sptr_t  vol_obj_fl_shead;
+    _Atomic H5VL_mt_vol_obj_sptr_t  vol_obj_fl_stail;
+    _Atomic uint64_t                vol_obj_fl_len;
+    _Atomic uint64_t                max_desired_vol_obj_fl_len;
+    _Atomic uint64_t                vol_obj_next_sn;
+    _Atomic uint64_t                vol_obj_max_realloc_sn;
+    _Atomic int64_t                 vol_objs_active;
+
+
+    /* Statistics: */
+
+    /* object free list stats */
+    _Atomic uint64_t                max_vol_obj_fl_len;
+    _Atomic uint64_t                num_vol_obj_structs_alloced_from_heap;
+    _Atomic uint64_t                num_vol_obj_structs_alloced_from_fl;
+    _Atomic uint64_t                num_vol_obj_structs_freed;
+    _Atomic uint64_t                num_vol_obj_structs_added_to_fl;
+    _Atomic uint64_t                num_vol_obj_fl_tail_update_cols;
+    _Atomic uint64_t                num_vol_obj_fl_head_update_cols;
+    _Atomic uint64_t                num_vol_obj_fl_append_cols;
+    _Atomic uint64_t                num_vol_obj_fl_alloc_req_denied_due_to_empty;
+    _Atomic uint64_t                num_vol_obj_fl_head_sn_is_zero;
+    _Atomic uint64_t                num_vol_obj_sn_assigned;
+    _Atomic uint64_t                num_vol_obj_serial_num_resets;
+    _Atomic uint64_t                num_vol_obj_fl_alloc_req_denied_due_to_no_reallocable_entries;
+    _Atomic uint64_t                num_vol_obj_fl_frees_skipped_due_to_empty;
+    _Atomic uint64_t                num_vol_obj_fl_frees_skipped_due_to_fl_too_small;
+    _Atomic uint64_t                num_vol_obj_fl_frees_skipped_due_to_no_reallocable_entries;
+    _Atomic uint64_t                H5VL__alloc_vol_obj__num_calls;
+    _Atomic uint64_t                H5VL__clear_vol_obj_free_list__num_calls;
+    _Atomic uint64_t                H5VL__discard_vol_obj__num_calls;
+
+} H5VL_mt_t;
+
+#endif /* H5_HAVE_MULTITHREAD */
+
 /*****************************/
 /* Package Private Variables */
 /*****************************/
+
+#ifdef H5_HAVE_MULTITHREAD 
+ 
+/* This structure contains global fields specific to the multi-thread H5VL build. */     
+H5_DLLVAR H5VL_mt_t H5VL_mt_g;
+ 
+#endif /* H5_HAVE_MULTITHREAD */
+
 
 /******************************/
 /* Package Private Prototypes */

--- a/src/H5VLprivate.h
+++ b/src/H5VLprivate.h
@@ -38,8 +38,89 @@ typedef struct H5VL_t {
     hid_t id; /* Identifier for the VOL connector                     */
 } H5VL_t;
 
+#ifdef H5_HAVE_MULTITHREAD
+
+/****************************************************************************************
+ *
+ * struct H5VL_mt_vol_obj_sptr_t
+ *
+ * H5VL_mt_object_sptr_t combines a pointer to H5I_mt_id_info_t with a serial number
+ * that must be incremented each time the value of the pointer is changed.
+ *
+ * When it appears in either H5I_mt_id_info_t or H5I_mt_t, it should do so
+ * as an atomic object.  Its purpose is to avoid ABA bugs.
+ *
+ * ptr: pointer to an instance of H5VL_object_t, or NULL if undefined.
+ *
+ * sn:  uint64_t that is initialized to 0, and must be incremented by 1 each time the
+ *      ptr field is modified.
+ *
+ ****************************************************************************************/
+
+typedef struct H5VL_object_t H5VL_object_t; /* forward declaration */
+
+typedef struct H5VL_mt_vol_obj_sptr_t {
+
+    H5VL_object_t * ptr;
+    uint64_t         sn;
+
+} H5VL_mt_vol_obj_sptr_t;
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+
+/****************************************************************************************
+ *
+ * struct H5VL_object_t 
+ *
+ * This header comment discusses only fields added to H5VL_object_t for multi-thread 
+ * operation.  
+ *
+ * tag: unsigned int 32 set to H5VL__VOL_BJ_TAG when allocated, and to 
+ *      H5VL__INVALID_OBJECT_TAG just before the instance of H5VL_object_t is deallocated.
+ *
+ * on_fl: Atomic boolean flag that is set to TRUE when the instance of H5VL_object_t
+ *      is placed on the object free list, and to FALSE on initial allocation from the
+ *      heap, or when the instance is allocated from the free list.
+ *
+ * fl_snext: Atomic instance of H5VL_mt_vol_obj_sptr_t used in the maintenance of the
+ *      object free list.  The structure contains both a pointer and a serial number,
+ *      which facilitates the avoidance of ABA bugs when managing the free list.
+ *  
+ * serial_num: unsigned int 64 that is always 0 when not on the vol ovject free list.
+ *      When added to the free list this value is set equal to H5I_mt_g's
+ *      vol_obj_next_sn field, and that field is then incremented. The value of serial_num
+ *      is used by the free list to determine if an entry can be reallocated.
+ *  
+ *      When a new instance of H5VL_object_t is needed, the free list is checked.
+ *      If the list contains more than one entry, and the serial_num field of the
+ *      entry at the head of the list is less than H5VL_mt_g.vol_obj_max_realloc_sn, 
+ *      the entry at the head of the free list may be removed from the free list and
+ *      reallocated.  
+ *  
+ *      The serial_num field is set to zero on removal from the free list,
+ *  
+ *      At present, there is no provision for the case in which H5VL_mt_g.vol_obj_next_sn
+ *      wraps around.  While it is unlikely that this will be a problem any time
+ *      soon, this issue must be addressed in the production version.
+ * 
+ ****************************************************************************************/
+
+#define H5VL__VOL_OBJ_TAG                0x3033
+#define H5VL__INVALID_VOL_OBJ_TAG        0x0300
+
 /* Internal vol object structure returned to the API */
 typedef struct H5VL_object_t {
+
+#ifdef H5_HAVE_MULTITHREAD
+
+    uint32_t                       tag;
+    _Atomic hbool_t                on_fl;
+    _Atomic H5VL_mt_vol_obj_sptr_t fl_snext;
+    _Atomic uint64_t               serial_num;
+
+#endif /* H5_HAVE_MULTITHREAD */
+
     void   *data;      /* Pointer to connector-managed data for this object    */
     H5VL_t *connector; /* Pointer to VOL connector struct                      */
     H5_ATOMIC(size_t) rc; /* Reference count                                      */


### PR DESCRIPTION
Repaired synchronization errors in H5I caused by inability to enforce
locking order as H5I was used in H5VL elsewhere in the HDF5 library. Removed code to wrap H5I calls in the global mutex inserted as a temporary fix.

Encountered an odd issue with the use of H5TS_thread_id().  As it appeared to be a wild pointer error somewhere in the API test code, coded around the issue for now by using the Pthreads thread ID call instead.  Retained the H5I_BYPASS_HDF5_TID #define in H5Ipkg.h to turn this work around on and off.  Interestingly, this problem seems to go away with CMake builds.

Also encountered very odd failures in the testmthdf5 test.  Note that this test is only built with CMake.  These issues seem to be related to known issues with static builds and attempted dynamic module loads. In any case, the issue goes away with CMake shared builds.  This issue has to be addressed -- but that will have to be another day.

Matt reported several other bugs in H5I, but I was unable to reproduce once the lock ordering issue was addressed, and shared builds were used.

Tested multi-thread debug and production, thread safe, and single thread with autotools build.  Tested multi-thread debug and production with CMake build.